### PR TITLE
Display alert in error message if server displays error

### DIFF
--- a/examples/widget-with-api/home/home.js
+++ b/examples/widget-with-api/home/home.js
@@ -12,8 +12,13 @@ angular.module( 'sample.home', [
       method: 'GET'
     }).then(function() {
       alert("We got the secured data successfully");
-    }, function() {
-      alert("Please download the API seed so that you can call it.");
+    }, function(response) {
+      if (response.status == 0) {
+        alert("Please download the API seed so that you can call it.");
+      }
+      else {
+        alert(response.data);
+      }
     });
   }
 


### PR DESCRIPTION
Doing this as this is used for seed project and the PHP seed fails
to validate the token if JWT using RS256 signature. Pull request
incoming for generating 500 Internal Server Error in PHP seed
project if signature fails

--
I setup my account to use RS256 signatures.  The seed project isn't configured currently to plug in the public key as the CLIENT_SECRET for any of the backend seeds (which is another bug).  But, if the server does generate an error back, the angular app shouldn't say the API seed should be downloaded.