### PR TITLE
adds missing ; in ng sso example + code formating

### DIFF
--- a/examples/sso/scripts/myApp.js
+++ b/examples/sso/scripts/myApp.js
@@ -2,8 +2,6 @@ var myApp = angular.module('myApp', [
   'ngCookies', 'auth0', 'ngRoute', 'angular-jwt', 'angular-storage'
 ]);
 
-
-
 myApp.config(function ($routeProvider, authProvider, $httpProvider, jwtInterceptorProvider) {
   $routeProvider
   .when('/logout',  {
@@ -39,15 +37,12 @@ myApp.config(function ($routeProvider, authProvider, $httpProvider, jwtIntercept
   // Add a simple interceptor that will fetch all requests and add the jwt token to its authorization header.
   // NOTE: in case you are calling APIs which expect a token signed with a different secret, you might
   // want to check the delegation-token example
-
   jwtInterceptorProvider.tokenGetter = function(store) {
     return store.get('token');
-  }
+  };
 
-  // Add a simple interceptor that will fetch all requests and add the jwt token to its authorization header.
-  // NOTE: in case you are calling APIs which expect a token signed with a different secret, you might
-  // want to check the delegation-token example
   $httpProvider.interceptors.push('jwtInterceptor');
+
 }).run(function($rootScope, auth, store, jwtHelper, $location) {
   $rootScope.$on('$locationChangeStart', function() {
     if (!auth.isAuthenticated) {
@@ -60,6 +55,6 @@ myApp.config(function ($routeProvider, authProvider, $httpProvider, jwtIntercept
         }
       }
     }
-
   });
+
 });


### PR DESCRIPTION
Noticed a missing semicolon in the sso example. Added and fixed a few formatting inconsistencies.