### PR TITLE
Make signin/up without showing Lock work

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ auth.signin({
   $location.path('/');
 }, function(error) {
   // Error
-})
+}, 'Auth0')
 ```
 
 **Redirect mode** will be used when not passing success or error callbacks.


### PR DESCRIPTION
I had to add 'Auth0' as the fourth parameter to "auth.signin" in order for it to work without showing the Lock popup