### PR TITLE
Pass the returnTo state along to the loginState

### DIFF
--- a/src/auth0-angular.js
+++ b/src/auth0-angular.js
@@ -330,7 +330,7 @@
           if (to.data && to.data.requiresLogin) {
             if (!auth.isAuthenticated && !auth.refreshTokenPromise) {
               e.preventDefault();
-              $injector.get('$state').go(config.loginState);
+              $injector.get('$state').go(config.loginState, { returnTo: to });
             }
           }
         });


### PR DESCRIPTION
The current way that auth0-angular handles 'requiresLogin' prevents deep links as it does not handle returning to the state that required the login.

It would be nice if the actual state was passed along to the login state as done i this pull request.

The existing examples would continue to work - i.e. it is backwards compatible!

However implementations could now use the passed in state:

    auth.signin({ }, function (profile, idToken, accessToken, state, refreshToken) {
                // Success callback
                store.set('profile', profile);
                store.set('token', idToken);
                
               if ($state.params.returnTo) {
                  var returnTo = $state.params.returnTo;
                  $state.go(returnTo.name, returnTo.params );
               }
            }, function () {
            });


The login state can be given a default returnTo:

    state('login', {
        url: '/login'
        params: {
                returnTo: { name: 'root.index' } //default return state
         },
        tempalteUrl: 'login.html',
        controller: 'LoginCtrl'
      }); 