### PR TITLE
Adding support for Webpack

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,0 +1,2 @@
+require('./build/auth0-angular.js');
+module.exports = 'auth0';

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "homepage": "https://auth0.com",
   "author": "Martin Gontovnikas",
   "version": "4.1.0",
-  "main": "./build/auth0-angular.js",
+  "main": "index.js",
   "devDependencies": {
     "bower": "^1.3.3",
     "chai": "^1.9.1",


### PR DESCRIPTION
Adding `auth0` to module.exports in index.js at top-level for added support for webpack via NPM install.  This allows for the angular module dependency like:

```
import auth0 from 'auth0-angular';
angular.module('app', ['auth0']);
```

Referred to [auth0/angular-storage#28](https://github.com/auth0/angular-storage/pull/28) for similar change.