### PR TITLE
Add hide method

### DIFF
--- a/src/auth0-angular.js
+++ b/src/auth0-angular.js
@@ -497,6 +497,10 @@
         });
       };
 
+      auth.hide = function(callback) {
+        config.auth0lib.hide(callback);
+      }
+
       return auth;
     };
   });

--- a/src/auth0-angular.js
+++ b/src/auth0-angular.js
@@ -499,7 +499,7 @@
 
       auth.hide = function(callback) {
         config.auth0lib.hide(callback);
-      }
+      };
 
       return auth;
     };


### PR DESCRIPTION
If you render the Lock inside a container DOM element with
```js
auth.signin({container: "container"})
```
and then angular removes the DOM element, you won't be able to show the Lock again. Subsequent calls to `auth.signin` won't have any effect.

This happens because in order to to avoid being rendered twice, the Lock keeps track of whether or not it has been inserted into the DOM and assumes that it won't be removed by a third party.

By adding a `hide` method, users will be able to hide the Lock (or at least let them know it has been removed, for instance from a _route change_ event) and then show it again.

The issue was originally reported [here](https://ask.auth0.com/t/lock-widget-disappears-on-state-change-angularjs-ui-router-single-page-application/1361/2).