### PR TITLE
fix server URL in widget-redirect README.md

### DIFF
--- a/examples/widget-redirect/README.md
+++ b/examples/widget-redirect/README.md
@@ -12,4 +12,4 @@ In order to run the example you need to just start a server. What we suggest is 
 1. run npm install -g serve
 1. run serve in the directory of this project.
 
-Go to [http://localhost:3000](http://localhost:3000) and you'll see the app running :).
+Go to [http://localhost:8000](http://localhost:8000) and you'll see the app running :).


### PR DESCRIPTION
this seems to default to port `8000` instead of port `3000`