### PR TITLE
Get auth0-angular from CDN

### DIFF
--- a/examples/sso/README.md
+++ b/examples/sso/README.md
@@ -46,10 +46,11 @@ For that, open `/etc/hosts` and edits as follows:
 ::1             localhost
 # ...
 127.0.0.1 app1.com
+127.0.0.1 app2.com
 ````
 
 Once that's done, just start this project twice in different ports. For that, we recommend using `serve` which is installed with `npm`by doing `npm i -g serve`.
-
+Then just run these commands on separate terminals.
 ````
 serve --port 3001
 serve --port 3000

--- a/examples/sso/index.html
+++ b/examples/sso/index.html
@@ -8,9 +8,9 @@
   <script src="//cdn.rawgit.com/auth0/angular-jwt/master/dist/angular-jwt.js" type="text/javascript"> </script>
   <script src="//code.angularjs.org/1.2.16/angular-route.min.js" type="text/javascript"> </script>
   <script src="//code.angularjs.org/1.2.16/angular-cookies.min.js" type="text/javascript"> </script>
-  <script src="./scripts/myApp.js" type="text/javascript"> </script>
+  <script src="//cdn.auth0.com/w2/auth0-angular-4.js"> </script>
 
-  <script src="./scripts/auth0-angular.js"> </script>
+  <script src="./scripts/myApp.js" type="text/javascript"> </script>
   <script src="./scripts/controllers.js" type="text/javascript"> </script>
 
   <title>Sample Angular App with Auth0</title>


### PR DESCRIPTION
Gets the auth0-angular dependency from the CDN instead of a local copy.
Also fixes the README file to make it consistent on how to properly run
the example.

Fixes https://github.com/auth0/auth0-angular/issues/238