### PR TITLE
Get the auth0-angular script from the CDN

### DIFF
--- a/examples/ui-router/index.html
+++ b/examples/ui-router/index.html
@@ -10,7 +10,7 @@
   <script src="./scripts/myApp.js" type="text/javascript"> </script>
   <script src="http://angular-ui.github.io/ui-router/release/angular-ui-router.js"> </script>
 
-  <script src="./scripts/auth0-angular.js" type="text/javascript"> </script>
+  <script src="//cdn.auth0.com/w2/auth0-angular-4.js" type="text/javascript"> </script>
   <script src="./scripts/controllers.js" type="text/javascript"> </script>
 
   <title>Sample Angular App with Auth0</title>


### PR DESCRIPTION
Fixes the example by replacing the auth0-angular script url to the one
available in the CDN, instead of loading it locally.

Fixes https://github.com/auth0/auth0-angular/issues/241