### PR TITLE
Fix `loginFailure` event in redirect mode

### DIFF
--- a/src/services/auth0.service.js
+++ b/src/services/auth0.service.js
@@ -449,7 +449,7 @@
                         }
                     };
 
-                    var errorFn = !errorCallback ? null : function(err) {
+                    var errorFn = function(err) {
                         callHandler('loginFailure', { error: err });
                         if (errorCallback) {
                             errorCallback(err);
@@ -479,7 +479,7 @@
                       }
                     };
 
-                    var errorFn = !errorCallback ? null : function(err) {
+                    var errorFn = function(err) {
                       callHandler('loginFailure', { error: err });
                       if (errorCallback) {
                         errorCallback(err);


### PR DESCRIPTION
This fixes `loginFailure` event when using the redirect mode.

By the way, why checking for `errorCallback` twice!? o_0