### PR TITLE
Update bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -3,8 +3,8 @@
   "main": "build/auth0-angular.js",
   "dependencies": {
     "angular": "*",
-    "auth0-lock": ">= 6.3.0",
-    "auth0.js": ">= 5.2.2"
+    "auth0-lock": "9.2.2",
+    "auth0.js": "7.0.3"
   },
   "devDependencies": {
     "angular-mocks": "~1.5.5",


### PR DESCRIPTION
locking down auth0-lock and auth0.js dependencies. auth0-lock v10 broke angular-auth0.