### PR TITLE
Disable `authUtils.errorHandler` 

### DIFF
--- a/src/services/auth0.utils.js
+++ b/src/services/auth0.utils.js
@@ -159,14 +159,17 @@
                  * */
                 
                 authUtils.errorHandler = function(fn) {
-                  return function () {
-                    var args = Array.prototype.slice.call(arguments);
-                    if (args[0] !== null) {
-                      authUtils.safeApply(function () {
-                        fn.apply(null, args);
-                      });
+                    if (window.Auth0Lock || window.Auth0LockPasswordless) {
+                        return;
                     }
-                  };
+                    return function () {
+                        var args = Array.prototype.slice.call(arguments);
+                        if (args[0] !== null) {
+                            authUtils.safeApply(function () {
+                                fn.apply(null, args);
+                            });
+                        }
+                    };
                 };
                 
 


### PR DESCRIPTION
Disable `authUtils.errorHandler` when `Auth0Lock` or `Auth0LockPasswordless` are used