### PR TITLE
Fix incompatible with new version of libraries

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -3,8 +3,8 @@
   "main": "build/auth0-angular.js",
   "dependencies": {
     "angular": "*",
-    "auth0-lock": ">= 6.3.0",
-    "auth0.js": ">= 5.2.2"
+    "auth0-lock": ">= 6.3.0 && < 10.0.0",
+    "auth0.js": ">= 5.2.2 && < 8.0.0"
   },
   "devDependencies": {
     "angular-mocks": "~1.5.5",


### PR DESCRIPTION
Fix incompatible with new version of:
- auth0.js
- auth0-lock