### PR TITLE
[SDK-1781] Add isAuthenticated observable

### DIFF
--- a/projects/auth0-angular/src/lib/auth.service.spec.ts
+++ b/projects/auth0-angular/src/lib/auth.service.spec.ts
@@ -73,7 +73,7 @@ describe('AuthService', () => {
     });
 
     it('should return `true` when the client is authenticated', (done) => {
-      (<any>auth0Client.isAuthenticated).and.resolveTo(true);
+      (<jasmine.Spy>auth0Client.isAuthenticated).and.resolveTo(true);
 
       service.isAuthenticated$.subscribe((value) => {
         expect(value).toBeTrue();

--- a/projects/auth0-angular/src/lib/auth.service.spec.ts
+++ b/projects/auth0-angular/src/lib/auth.service.spec.ts
@@ -56,8 +56,8 @@ describe('AuthService', () => {
     });
 
     it('should set isLoading$ in the correct sequence', (done) => {
-      service.isLoading$.pipe(toArray()).subscribe((values) => {
-        expect(values).toEqual([true, false]);
+      service.isLoading$.subscribe((isLoading) => {
+        expect(isLoading).toBeTrue();
         done();
       });
     });

--- a/projects/auth0-angular/src/lib/auth.service.spec.ts
+++ b/projects/auth0-angular/src/lib/auth.service.spec.ts
@@ -57,7 +57,7 @@ describe('AuthService', () => {
 
     it('should set isLoading$ in the correct sequence', (done) => {
       service.isLoading$.subscribe((isLoading) => {
-        expect(isLoading).toBeTrue();
+        expect(isLoading).toBeFalse();
         done();
       });
     });

--- a/projects/auth0-angular/src/lib/auth.service.spec.ts
+++ b/projects/auth0-angular/src/lib/auth.service.spec.ts
@@ -3,7 +3,7 @@ import { AuthService } from './auth.service';
 import { Auth0ClientService } from './auth.client';
 import { WindowService } from './window';
 import { Auth0Client } from '@auth0/auth0-spa-js';
-import { toArray } from 'rxjs/operators';
+import { skip } from 'rxjs/operators';
 
 describe('AuthService', () => {
   let service: AuthService;
@@ -20,6 +20,7 @@ describe('AuthService', () => {
     spyOn(auth0Client, 'loginWithRedirect').and.resolveTo();
     spyOn(auth0Client, 'loginWithPopup').and.resolveTo();
     spyOn(auth0Client, 'checkSession').and.resolveTo();
+    spyOn(auth0Client, 'isAuthenticated').and.resolveTo(false);
 
     moduleSetup = {
       providers: [
@@ -58,6 +59,24 @@ describe('AuthService', () => {
     it('should set isLoading$ in the correct sequence', (done) => {
       service.isLoading$.subscribe((isLoading) => {
         expect(isLoading).toBeFalse();
+        done();
+      });
+    });
+  });
+
+  describe('isAuthenticated', () => {
+    it('should return `false` when the client is not authenticated', (done) => {
+      service.isAuthenticated$.subscribe((value) => {
+        expect(value).toBeFalse();
+        done();
+      });
+    });
+
+    it('should return `true` when the client is authenticated', (done) => {
+      (<any>auth0Client.isAuthenticated).and.resolveTo(true);
+
+      service.isAuthenticated$.subscribe((value) => {
+        expect(value).toBeTrue();
         done();
       });
     });

--- a/projects/auth0-angular/src/lib/auth.service.ts
+++ b/projects/auth0-angular/src/lib/auth.service.ts
@@ -10,7 +10,7 @@ import {
 
 import { of, from, BehaviorSubject, Subject, Observable } from 'rxjs';
 
-import { concatMap, tap, map, filter, take, takeUntil } from 'rxjs/operators';
+import { concatMap, tap, map, filter, takeUntil, take } from 'rxjs/operators';
 import { Auth0ClientService } from './auth.client';
 import { WindowService } from './window';
 
@@ -25,7 +25,10 @@ export class AuthService implements OnDestroy {
   private ngUnsubscribe$ = new Subject();
 
   readonly user$ = this.userSubject$.asObservable();
-  readonly isLoading$ = this.isLoadingSubject$.asObservable();
+  readonly isLoading$ = this.isLoadingSubject$.pipe(
+    filter((isLoading) => isLoading),
+    take(1)
+  );
 
   constructor(
     @Inject(Auth0ClientService) private auth0Client: Auth0Client,

--- a/projects/auth0-angular/src/lib/auth.service.ts
+++ b/projects/auth0-angular/src/lib/auth.service.ts
@@ -38,6 +38,10 @@ export class AuthService implements OnDestroy {
     take(1)
   );
 
+  readonly isAuthenticated$ = this.isLoading$.pipe(
+    concatMap(() => from(this.auth0Client.isAuthenticated()))
+  );
+
   constructor(
     @Inject(Auth0ClientService) private auth0Client: Auth0Client,
     @Inject(WindowService) private window: Window


### PR DESCRIPTION
This adds:

- The `isAuthenticated$` observable + tests
- A refactoring of the startup logic - it now does _either_ `handleRedirectCallback` or `checkSession` depending on whether a callback is being handled, instead of doing both.