### PR TITLE
[SDK-1780] Add user$ observable

### DIFF
--- a/projects/auth0-angular/src/lib/auth.service.spec.ts
+++ b/projects/auth0-angular/src/lib/auth.service.spec.ts
@@ -21,6 +21,7 @@ describe('AuthService', () => {
     spyOn(auth0Client, 'loginWithPopup').and.resolveTo();
     spyOn(auth0Client, 'checkSession').and.resolveTo();
     spyOn(auth0Client, 'isAuthenticated').and.resolveTo(false);
+    spyOn(auth0Client, 'getUser').and.resolveTo(null);
 
     moduleSetup = {
       providers: [
@@ -65,7 +66,7 @@ describe('AuthService', () => {
     });
   });
 
-  describe('isAuthenticated', () => {
+  describe('The isAuthenticated observable', () => {
     it('should return `false` when the client is not authenticated', (done) => {
       service.isAuthenticated$.subscribe((value) => {
         expect(value).toBeFalse();
@@ -78,6 +79,31 @@ describe('AuthService', () => {
 
       service.isAuthenticated$.subscribe((value) => {
         expect(value).toBeTrue();
+        done();
+      });
+    });
+  });
+
+  describe('The user observable', () => {
+    it('should get the user if authenticated', (done) => {
+      const user = {
+        name: 'Test User',
+      };
+
+      (<jasmine.Spy>auth0Client.isAuthenticated).and.resolveTo(true);
+      (<jasmine.Spy>auth0Client.getUser).and.resolveTo(user);
+
+      service.user$.subscribe((value) => {
+        expect(value).toBe(user);
+        done();
+      });
+    });
+
+    it('should get the user if not authenticated', (done) => {
+      (<jasmine.Spy>auth0Client.isAuthenticated).and.resolveTo(true);
+
+      service.user$.subscribe((value) => {
+        expect(value).toBeFalsy();
         done();
       });
     });

--- a/projects/auth0-angular/src/lib/auth.service.spec.ts
+++ b/projects/auth0-angular/src/lib/auth.service.spec.ts
@@ -66,7 +66,7 @@ describe('AuthService', () => {
     });
   });
 
-  describe('The isAuthenticated observable', () => {
+  describe('The `isAuthenticated` observable', () => {
     it('should return `false` when the client is not authenticated', (done) => {
       service.isAuthenticated$.subscribe((value) => {
         expect(value).toBeFalse();

--- a/projects/auth0-angular/src/lib/auth.service.spec.ts
+++ b/projects/auth0-angular/src/lib/auth.service.spec.ts
@@ -84,7 +84,7 @@ describe('AuthService', () => {
     });
   });
 
-  describe('The user observable', () => {
+  describe('The `user` observable', () => {
     it('should get the user if authenticated', (done) => {
       const user = {
         name: 'Test User',

--- a/projects/auth0-angular/src/lib/auth.service.ts
+++ b/projects/auth0-angular/src/lib/auth.service.ts
@@ -5,7 +5,6 @@ import {
   RedirectLoginOptions,
   PopupLoginOptions,
   PopupConfigOptions,
-  RedirectLoginResult,
 } from '@auth0/auth0-spa-js';
 
 import {
@@ -18,15 +17,7 @@ import {
   defer,
 } from 'rxjs';
 
-import {
-  concatMap,
-  tap,
-  map,
-  filter,
-  takeUntil,
-  take,
-  takeWhile,
-} from 'rxjs/operators';
+import { concatMap, tap, map, filter, takeUntil, take } from 'rxjs/operators';
 
 import { Auth0ClientService } from './auth.client';
 import { WindowService } from './window';
@@ -36,13 +27,11 @@ import { AbstractNavigator } from './abstract-navigator';
   providedIn: 'root',
 })
 export class AuthService implements OnDestroy {
-  private userSubject$ = new BehaviorSubject<any>(null);
   private isLoadingSubject$ = new BehaviorSubject(true);
 
   // https://stackoverflow.com/a/41177163
   private ngUnsubscribe$ = new Subject();
 
-  readonly user$ = this.userSubject$.asObservable();
   readonly isLoading$ = this.isLoadingSubject$.pipe(
     filter((isLoading) => !isLoading),
     take(1)
@@ -50,6 +39,10 @@ export class AuthService implements OnDestroy {
 
   readonly isAuthenticated$ = this.isLoading$.pipe(
     concatMap(() => from(this.auth0Client.isAuthenticated()))
+  );
+
+  readonly user$ = this.isAuthenticated$.pipe(
+    concatMap(() => from(this.auth0Client.getUser()))
   );
 
   constructor(


### PR DESCRIPTION
This PR adds the `user$` observable, which allows consumers to retrieve user
profile information after the user has logged in.

Usage:

```js
<ul *ngIf="auth.user$ | async as user">
  <li>{{ user.name }}</li>
  <li>{{ user.email }}</li>
</ul>
```