### PR TITLE
[SDK-1776] Add logout

### DIFF
--- a/projects/auth0-angular/src/lib/auth.service.spec.ts
+++ b/projects/auth0-angular/src/lib/auth.service.spec.ts
@@ -21,6 +21,7 @@ describe('AuthService', () => {
     spyOn(auth0Client, 'loginWithPopup').and.resolveTo();
     spyOn(auth0Client, 'checkSession').and.resolveTo();
     spyOn(auth0Client, 'isAuthenticated').and.resolveTo(false);
+    spyOn(auth0Client, 'logout');
 
     moduleSetup = {
       providers: [
@@ -174,5 +175,27 @@ describe('AuthService', () => {
 
     await service.loginWithPopup(options, config).toPromise();
     expect(auth0Client.loginWithPopup).toHaveBeenCalledWith(options, config);
+  });
+
+  it('should call `logout`', () => {
+    service.logout();
+    expect(auth0Client.logout).toHaveBeenCalled();
+  });
+
+  it('should call `logout` with options', () => {
+    const options = { returnTo: 'http://localhost' };
+    service.logout(options);
+    expect(auth0Client.logout).toHaveBeenCalledWith(options);
+  });
+
+  it('should reset the authentication state when passing `localOnly` to logout', (done) => {
+    const options = { localOnly: true };
+
+    service.isAuthenticated$.subscribe((authenticated) => {
+      expect(authenticated).toBeFalse();
+      done();
+    });
+
+    service.logout(options);
   });
 });


### PR DESCRIPTION
This PR adds the ability to log out of an application by adding the `logout`
method.

Additionally:

- Changes `isAuthenticated$` to be backed by a `BehaviorSubject<boolean>`
  instead of using `auth0Client.isAuthenticated`
- Authentication state is now manually configurable and reset on startup after
  `handleLoginRedirect` or `checkSession` by calling the SDK method
- This allows us to reset authentication state after logging out when
  `localOnly`
- This will in the future allow us to correctly set authentication state when
  using `loginWithPopup` (separate PR incoming)
