### PR TITLE
Fix popup auth to correctly set authenticated state after login

### DIFF
--- a/projects/auth0-angular/src/lib/auth.service.spec.ts
+++ b/projects/auth0-angular/src/lib/auth.service.spec.ts
@@ -208,6 +208,8 @@ describe('AuthService', () => {
   });
 
   it('should call `loginWithPopup` with options', async (done) => {
+    // These objects are empty, as we just want to check that the
+    // same object reference was passed through than any specific options.
     const options = {};
     const config = {};
 

--- a/projects/auth0-angular/src/lib/auth.service.spec.ts
+++ b/projects/auth0-angular/src/lib/auth.service.spec.ts
@@ -24,7 +24,6 @@ describe('AuthService', () => {
     spyOn(auth0Client, 'getUser').and.resolveTo(null);
     spyOn(auth0Client, 'logout');
 
-
     moduleSetup = {
       providers: [
         AbstractNavigator,
@@ -191,17 +190,43 @@ describe('AuthService', () => {
     expect(auth0Client.loginWithRedirect).toHaveBeenCalledWith(options);
   });
 
-  it('should call `loginWithPopup`', async () => {
-    await service.loginWithPopup();
-    expect(auth0Client.loginWithPopup).toHaveBeenCalled();
+  it('should call `loginWithPopup`', (done) => {
+    service.isLoading$.subscribe(async () => {
+      (<jasmine.Spy>auth0Client.isAuthenticated).calls.reset();
+      (<jasmine.Spy>auth0Client.isAuthenticated).and.resolveTo(true);
+
+      service.loginWithPopup();
+
+      service.isAuthenticated$.subscribe((authenticated) => {
+        if (authenticated) {
+          expect(auth0Client.loginWithPopup).toHaveBeenCalled();
+          expect(auth0Client.isAuthenticated).toHaveBeenCalled();
+          done();
+        }
+      });
+    });
   });
 
-  it('should call `loginWithPopup` with options', async () => {
+  it('should call `loginWithPopup` with options', async (done) => {
     const options = {};
     const config = {};
 
-    await service.loginWithPopup(options, config).toPromise();
-    expect(auth0Client.loginWithPopup).toHaveBeenCalledWith(options, config);
+    service.isLoading$.subscribe(() => {
+      (<jasmine.Spy>auth0Client.isAuthenticated).calls.reset();
+      (<jasmine.Spy>auth0Client.isAuthenticated).and.resolveTo(true);
+
+      service.loginWithPopup(options, config);
+
+      service.isAuthenticated$.subscribe((authenticated) => {
+        if (authenticated) {
+          expect(auth0Client.loginWithPopup).toHaveBeenCalledWith(
+            options,
+            config
+          );
+          done();
+        }
+      });
+    });
   });
 
   it('should call `logout`', () => {

--- a/projects/auth0-angular/src/lib/auth.service.ts
+++ b/projects/auth0-angular/src/lib/auth.service.ts
@@ -5,8 +5,7 @@ import {
   RedirectLoginOptions,
   PopupLoginOptions,
   PopupConfigOptions,
-  RedirectLoginResult,
-  LogoutOptions
+  LogoutOptions,
 } from '@auth0/auth0-spa-js';
 
 import {
@@ -34,7 +33,7 @@ export class AuthService implements OnDestroy {
 
   // https://stackoverflow.com/a/41177163
   private ngUnsubscribe$ = new Subject();
-  
+
   readonly isLoading$ = this.isLoadingSubject$.pipe(
     filter((isLoading) => !isLoading),
     take(1)
@@ -118,7 +117,13 @@ export class AuthService implements OnDestroy {
     options?: PopupLoginOptions,
     config?: PopupConfigOptions
   ): Observable<void> {
-    return from(this.auth0Client.loginWithPopup(options, config));
+    return from(
+      this.auth0Client.loginWithPopup(options, config).then(async () => {
+        this.isAuthenticatedSubject$.next(
+          await this.auth0Client.isAuthenticated()
+        );
+      })
+    );
   }
 
   /**


### PR DESCRIPTION
### Description

This PR changes `loginWithPopup` so that it sets the correct authenticated state after login.

### Testing

- [X] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [X] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [X] All active GitHub checks for tests, formatting, and security are passing
- [X] The correct base branch is being used, if not `master`
