### PR TITLE
[SDK-1846] Add ability to get new access tokens

### DIFF
--- a/projects/auth0-angular/src/lib/auth.service.spec.ts
+++ b/projects/auth0-angular/src/lib/auth.service.spec.ts
@@ -37,6 +37,7 @@ describe('AuthService', () => {
     spyOn(auth0Client, 'isAuthenticated').and.resolveTo(false);
     spyOn(auth0Client, 'getUser').and.resolveTo(null);
     spyOn(auth0Client, 'logout');
+    spyOn(auth0Client, 'getTokenSilently').and.resolveTo('__access_token__');
 
     moduleSetup = {
       providers: [
@@ -274,5 +275,24 @@ describe('AuthService', () => {
     });
 
     service.logout(options);
+  });
+
+  describe('getAccessTokenSilently', () => {
+    it('should call the underlying SDK', (done) => {
+      service.getAccessTokenSilently().subscribe((token) => {
+        expect(auth0Client.getTokenSilently).toHaveBeenCalled();
+        done();
+      });
+    });
+
+    it('should call the underlying SDK and pass along the options', (done) => {
+      // Empty object here just to test the object reference
+      const options = {};
+
+      service.getAccessTokenSilently(options).subscribe((token) => {
+        expect(auth0Client.getTokenSilently).toHaveBeenCalledWith(options);
+        done();
+      });
+    });
   });
 });

--- a/projects/auth0-angular/src/lib/auth.service.spec.ts
+++ b/projects/auth0-angular/src/lib/auth.service.spec.ts
@@ -39,6 +39,10 @@ describe('AuthService', () => {
     spyOn(auth0Client, 'logout');
     spyOn(auth0Client, 'getTokenSilently').and.resolveTo('__access_token__');
 
+    spyOn(auth0Client, 'getTokenWithPopup').and.resolveTo(
+      '__access_token_from_popup__'
+    );
+
     moduleSetup = {
       providers: [
         AbstractNavigator,
@@ -291,6 +295,25 @@ describe('AuthService', () => {
 
       service.getAccessTokenSilently(options).subscribe((token) => {
         expect(auth0Client.getTokenSilently).toHaveBeenCalledWith(options);
+        done();
+      });
+    });
+  });
+
+  describe('getAccessTokenWithPopup', () => {
+    it('should call the underlying SDK', (done) => {
+      service.getAccessTokenWithPopup().subscribe((token) => {
+        expect(auth0Client.getTokenWithPopup).toHaveBeenCalled();
+        done();
+      });
+    });
+
+    it('should call the underlying SDK and pass along the options', (done) => {
+      // Empty object just to test reference
+      const options = {};
+
+      service.getAccessTokenWithPopup(options).subscribe((token) => {
+        expect(auth0Client.getTokenWithPopup).toHaveBeenCalledWith(options);
         done();
       });
     });

--- a/projects/auth0-angular/src/lib/auth.service.ts
+++ b/projects/auth0-angular/src/lib/auth.service.ts
@@ -186,9 +186,10 @@ export class AuthService implements OnDestroy {
    * back to using an iframe to make the token exchange.
    *
    * Note that in all cases, falling back to an iframe requires access to
-   * the `auth0` cookie.
+   * the `auth0` cookie, and thus will not work in browsers that block third-party
+   * cookies by default (Safari, Brave, etc).
    *
-   * @param options
+   * @param options The options for configuring the token fetch.
    */
   getAccessTokenSilently(
     options?: GetTokenSilentlyOptions

--- a/projects/auth0-angular/src/lib/auth.service.ts
+++ b/projects/auth0-angular/src/lib/auth.service.ts
@@ -6,6 +6,7 @@ import {
   PopupLoginOptions,
   PopupConfigOptions,
   LogoutOptions,
+  GetTokenSilentlyOptions,
 } from '@auth0/auth0-spa-js';
 
 import {
@@ -24,7 +25,6 @@ import {
   map,
   filter,
   takeUntil,
-  take,
   distinctUntilChanged,
 } from 'rxjs/operators';
 
@@ -155,6 +155,40 @@ export class AuthService implements OnDestroy {
     if (options?.localOnly) {
       this.isAuthenticatedSubject$.next(false);
     }
+  }
+
+  /**
+   * ```js
+   * getAccessTokenSilently(options);
+   * ```
+   *
+   * If there's a valid token stored, return it. Otherwise, opens an
+   * iframe with the `/authorize` URL using the parameters provided
+   * as arguments. Random and secure `state` and `nonce` parameters
+   * will be auto-generated. If the response is successful, results
+   * will be valid according to their expiration times.
+   *
+   * If refresh tokens are used, the token endpoint is called directly with the
+   * 'refresh_token' grant. If no refresh token is available to make this call,
+   * the SDK falls back to using an iframe to the '/authorize' URL.
+   *
+   * This method may use a web worker to perform the token call if the in-memory
+   * cache is used.
+   *
+   * If an `audience` value is given to this function, the SDK always falls
+   * back to using an iframe to make the token exchange.
+   *
+   * Note that in all cases, falling back to an iframe requires access to
+   * the `auth0` cookie.
+   *
+   * @param options
+   */
+  getAccessTokenSilently(
+    options?: GetTokenSilentlyOptions
+  ): Observable<string> {
+    return of(this.auth0Client).pipe(
+      concatMap((client) => client.getTokenSilently(options))
+    );
   }
 
   private shouldHandleCallback(): Observable<boolean> {

--- a/projects/auth0-angular/src/lib/auth.service.ts
+++ b/projects/auth0-angular/src/lib/auth.service.ts
@@ -1,4 +1,9 @@
-import { Injectable, Inject, OnDestroy } from '@angular/core';
+import {
+  Injectable,
+  Inject,
+  OnDestroy,
+  ɵCodegenComponentFactoryResolver,
+} from '@angular/core';
 
 import {
   Auth0Client,
@@ -7,6 +12,7 @@ import {
   PopupConfigOptions,
   LogoutOptions,
   GetTokenSilentlyOptions,
+  GetTokenWithPopupOptions,
 } from '@auth0/auth0-spa-js';
 
 import {
@@ -17,6 +23,7 @@ import {
   Observable,
   iif,
   defer,
+  concat,
 } from 'rxjs';
 
 import {
@@ -159,7 +166,7 @@ export class AuthService implements OnDestroy {
 
   /**
    * ```js
-   * getAccessTokenSilently(options);
+   * getAccessTokenSilently(options).subscribe(token => ...)
    * ```
    *
    * If there's a valid token stored, return it. Otherwise, opens an
@@ -188,6 +195,26 @@ export class AuthService implements OnDestroy {
   ): Observable<string> {
     return of(this.auth0Client).pipe(
       concatMap((client) => client.getTokenSilently(options))
+    );
+  }
+
+  /**
+   * ```js
+   * getTokenWithPopup(options).subscribe(token => ...)
+   * ```
+   *
+   * Get an access token interactively.
+   *
+   * Opens a popup with the `/authorize` URL using the parameters
+   * provided as arguments. Random and secure `state` and `nonce`
+   * parameters will be auto-generated. If the response is successful,
+   * results will be valid according to their expiration times.
+   */
+  getAccessTokenWithPopup(
+    options?: GetTokenWithPopupOptions
+  ): Observable<string> {
+    return of(this.auth0Client).pipe(
+      concatMap((client) => client.getTokenWithPopup(options))
     );
   }
 

--- a/projects/auth0-angular/src/lib/auth.service.ts
+++ b/projects/auth0-angular/src/lib/auth.service.ts
@@ -1,9 +1,4 @@
-import {
-  Injectable,
-  Inject,
-  OnDestroy,
-  ɵCodegenComponentFactoryResolver,
-} from '@angular/core';
+import { Injectable, Inject, OnDestroy } from '@angular/core';
 
 import {
   Auth0Client,


### PR DESCRIPTION
This PR adds wrapper methods for:

- getTokenSilently
- getTokenWithPopup

In this SDK, they are also renamed (respectively):

- getAccessTokenSilently
- getAccessTokenWithPopup

This is for consistency with `auth0-react`.
