### PR TITLE
[SDK-1847, SDK-1848] Add HttpInterceptor to attach access tokens to requests

### DIFF
--- a/projects/auth0-angular/src/lib/auth.config.ts
+++ b/projects/auth0-angular/src/lib/auth.config.ts
@@ -14,7 +14,8 @@ export interface HttpInterceptorRouteConfig extends GetTokenSilentlyOptions {
   /**
    * The URL to test, either by using a regex or by supplying the whole URL to match.
    * If `test` is a match for the current request URL from the HTTP client, then
-   * an access token is attached to the request in the "Authorization" header.
+   * an access token is attached to the request in the
+   *  ["Authorization" header](https://tools.ietf.org/html/draft-ietf-oauth-v2-bearer-20#section-2.1).
    *
    * If the test does not pass, the request proceeds without the access token attached.
    */

--- a/projects/auth0-angular/src/lib/auth.config.ts
+++ b/projects/auth0-angular/src/lib/auth.config.ts
@@ -1,11 +1,21 @@
-import { CacheLocation } from '@auth0/auth0-spa-js';
+import { CacheLocation, GetTokenSilentlyOptions } from '@auth0/auth0-spa-js';
 import { InjectionToken } from '@angular/core';
 
 export interface HttpInterceptorConfig {
   allowedList: HttpInterceptorRouteConfig[];
 }
 
-export interface HttpInterceptorRouteConfig {
+/**
+ * Configuration for a single interceptor route
+ */
+export interface HttpInterceptorRouteConfig extends GetTokenSilentlyOptions {
+  /**
+   * The URL to test, either by using a regex or by supplying the whole URL to match.
+   * If `test` is a match for the current request URL from the HTTP client, then
+   * an access token is attached to the request in the "Authorization" header.
+   *
+   * If the test does not pass, the request proceeds without the token attached.
+   */
   test: string | RegExp;
 }
 

--- a/projects/auth0-angular/src/lib/auth.config.ts
+++ b/projects/auth0-angular/src/lib/auth.config.ts
@@ -1,8 +1,28 @@
 import { CacheLocation, GetTokenSilentlyOptions } from '@auth0/auth0-spa-js';
 import { InjectionToken } from '@angular/core';
 
+/**
+ * Defines the type for a route config entry. Can either be:
+ *
+ * - an object of type HttpInterceptorConfig
+ * - a string
+ * - a regular expression
+ */
 export type ApiRouteDefinition = HttpInterceptorRouteConfig | string | RegExp;
 
+/**
+ * A custom type guard to help identify route definitions that are actually HttpInterceptorRouteConfig types.
+ * @param def The route definition type
+ */
+export function isHttpInterceptorRouteConfig(
+  def: ApiRouteDefinition
+): def is HttpInterceptorRouteConfig {
+  return (def as HttpInterceptorRouteConfig).uri !== undefined;
+}
+
+/**
+ * Configuration for the HttpInterceptor
+ */
 export interface HttpInterceptorConfig {
   allowedList: ApiRouteDefinition[];
 }

--- a/projects/auth0-angular/src/lib/auth.config.ts
+++ b/projects/auth0-angular/src/lib/auth.config.ts
@@ -30,7 +30,7 @@ export interface HttpInterceptorConfig {
 /**
  * Configuration for a single interceptor route
  */
-export interface HttpInterceptorRouteConfig extends GetTokenSilentlyOptions {
+export interface HttpInterceptorRouteConfig {
   /**
    * The URL to test, either by using a regex or by supplying the whole URL to match.
    * If `test` is a match for the current request URL from the HTTP client, then
@@ -40,6 +40,12 @@ export interface HttpInterceptorRouteConfig extends GetTokenSilentlyOptions {
    * If the test does not pass, the request proceeds without the access token attached.
    */
   uri: string | RegExp;
+
+  /**
+   * The options that are passed to the SDK when retrieving the
+   * access token to attach to the outgoing request.
+   */
+  tokenOptions?: GetTokenSilentlyOptions;
 }
 
 /**

--- a/projects/auth0-angular/src/lib/auth.config.ts
+++ b/projects/auth0-angular/src/lib/auth.config.ts
@@ -1,8 +1,10 @@
 import { CacheLocation, GetTokenSilentlyOptions } from '@auth0/auth0-spa-js';
 import { InjectionToken } from '@angular/core';
 
+export type ApiRouteDefinition = HttpInterceptorRouteConfig | string | RegExp;
+
 export interface HttpInterceptorConfig {
-  allowedList: HttpInterceptorRouteConfig[];
+  allowedList: ApiRouteDefinition[];
 }
 
 /**
@@ -16,7 +18,7 @@ export interface HttpInterceptorRouteConfig extends GetTokenSilentlyOptions {
    *
    * If the test does not pass, the request proceeds without the token attached.
    */
-  test: string | RegExp;
+  uri: string | RegExp;
 }
 
 /**

--- a/projects/auth0-angular/src/lib/auth.config.ts
+++ b/projects/auth0-angular/src/lib/auth.config.ts
@@ -1,6 +1,14 @@
 import { CacheLocation } from '@auth0/auth0-spa-js';
 import { InjectionToken } from '@angular/core';
 
+export interface HttpInterceptorConfig {
+  allowedList: HttpInterceptorRouteConfig[];
+}
+
+export interface HttpInterceptorRouteConfig {
+  test: string | RegExp;
+}
+
 /**
  * Configuration for the authentication service
  */
@@ -90,6 +98,12 @@ export interface AuthConfig {
    * The default audience to be used for requesting API access.
    */
   audience?: string;
+
+  /**
+   * Configuration for the built-in Http Interceptor, used for
+   * automatically attaching access tokens.
+   */
+  httpInterceptor?: HttpInterceptorConfig;
 
   /**
    * If you need to send custom parameters to the Authorization Server,

--- a/projects/auth0-angular/src/lib/auth.config.ts
+++ b/projects/auth0-angular/src/lib/auth.config.ts
@@ -16,7 +16,7 @@ export interface HttpInterceptorRouteConfig extends GetTokenSilentlyOptions {
    * If `test` is a match for the current request URL from the HTTP client, then
    * an access token is attached to the request in the "Authorization" header.
    *
-   * If the test does not pass, the request proceeds without the token attached.
+   * If the test does not pass, the request proceeds without the access token attached.
    */
   uri: string | RegExp;
 }

--- a/projects/auth0-angular/src/lib/auth.interceptor.spec.ts
+++ b/projects/auth0-angular/src/lib/auth.interceptor.spec.ts
@@ -1,9 +1,14 @@
 import { AuthHttpInterceptor } from './auth.interceptor';
 import { TestBed, fakeAsync, flush } from '@angular/core/testing';
-import { HttpClient, HTTP_INTERCEPTORS } from '@angular/common/http';
+import {
+  HttpClient,
+  HTTP_INTERCEPTORS,
+  HttpRequest,
+} from '@angular/common/http';
 import {
   HttpClientTestingModule,
   HttpTestingController,
+  TestRequest,
 } from '@angular/common/http/testing';
 import { Data } from '@angular/router';
 import { Auth0ClientService } from './auth.client';
@@ -13,6 +18,8 @@ describe('The Auth HTTP Interceptor', () => {
   let httpClient: HttpClient;
   let httpTestingController: HttpTestingController;
   let auth0Client: any;
+  let req: TestRequest;
+  const testData: Data = { message: 'Hello, world' };
 
   beforeEach(() => {
     auth0Client = jasmine.createSpyObj('Auth0Client', ['getTokenSilently']);
@@ -56,19 +63,17 @@ describe('The Auth HTTP Interceptor', () => {
 
   afterEach(() => {
     httpTestingController.verify();
+    req.flush(testData);
   });
 
   describe('Requests that do not require authentication', () => {
     it('pass through and do not have access tokens attached', () => {
-      const testData: Data = { message: 'Hello, world' };
-
       httpClient.get<Data>('/non-api').subscribe((result) => {
         expect(result).toEqual(testData);
         expect(req.request.headers.get('Authorization')).toBeFalsy();
       });
 
-      const req = httpTestingController.expectOne('/non-api');
-      req.flush(testData);
+      req = httpTestingController.expectOne('/non-api');
     });
   });
 
@@ -76,35 +81,27 @@ describe('The Auth HTTP Interceptor', () => {
     it('attach the access token when the configuration uri is a string', fakeAsync((
       done
     ) => {
-      const testData: Data = { message: 'Hello, world' };
-
       httpClient.get('/basic-api').subscribe(done);
       flush();
 
-      const req = httpTestingController.expectOne('/basic-api');
+      req = httpTestingController.expectOne('/basic-api');
 
       expect(req.request.headers.get('Authorization')).toBe(
         'Bearer access-token'
       );
-
-      req.flush(testData);
     }));
 
     it('attach the access token when the configuration uri is a regex', fakeAsync((
       done
     ) => {
-      const testData: Data = { message: 'Hello, world' };
-
       httpClient.get('/basic-api-regex?value=123').subscribe(done);
       flush();
 
-      const req = httpTestingController.expectOne('/basic-api-regex?value=123');
+      req = httpTestingController.expectOne('/basic-api-regex?value=123');
 
       expect(req.request.headers.get('Authorization')).toBe(
         'Bearer access-token'
       );
-
-      req.flush(testData);
     }));
   });
 
@@ -113,45 +110,36 @@ describe('The Auth HTTP Interceptor', () => {
       done
     ) => {
       // Async testing: https://github.com/angular/angular/issues/25733#issuecomment-636154553
-      const testData: Data = { message: 'Hello, world' };
-
       httpClient.get('/api').subscribe(done);
       flush();
 
-      const req = httpTestingController.expectOne('/api');
+      req = httpTestingController.expectOne('/api');
 
       expect(req.request.headers.get('Authorization')).toBe(
         'Bearer access-token'
       );
-
-      req.flush(testData);
     }));
 
     it('attach the access token when the uri is configured using a regex', fakeAsync((
       done
     ) => {
-      const testData: Data = { message: 'Hello, world' };
-
       httpClient.get('/regex-api?my-param=42').subscribe(done);
       flush();
 
-      const req = httpTestingController.expectOne('/regex-api?my-param=42');
+      req = httpTestingController.expectOne('/regex-api?my-param=42');
 
       expect(req.request.headers.get('Authorization')).toBe(
         'Bearer access-token'
       );
-
-      req.flush(testData);
     }));
 
     it('pass through the route options to getTokenSilently, without additional properties', fakeAsync((
       done
     ) => {
-      const testData: Data = { message: 'Hello, world' };
       httpClient.get('/api-with-options').subscribe(done);
       flush();
 
-      const req = httpTestingController.expectOne('/api-with-options');
+      req = httpTestingController.expectOne('/api-with-options');
 
       expect(req.request.headers.get('Authorization')).toBe(
         'Bearer access-token'
@@ -161,8 +149,6 @@ describe('The Auth HTTP Interceptor', () => {
         audience: 'audience',
         scope: 'scope',
       });
-
-      req.flush(testData);
     }));
   });
 });

--- a/projects/auth0-angular/src/lib/auth.interceptor.spec.ts
+++ b/projects/auth0-angular/src/lib/auth.interceptor.spec.ts
@@ -1,0 +1,97 @@
+import { AuthHttpInterceptor } from './auth.interceptor';
+import { TestBed, fakeAsync, flush } from '@angular/core/testing';
+import { HttpClient, HTTP_INTERCEPTORS } from '@angular/common/http';
+import {
+  HttpClientTestingModule,
+  HttpTestingController,
+} from '@angular/common/http/testing';
+import { Data } from '@angular/router';
+import { Auth0ClientService } from './auth.client';
+import { AuthConfigService, AuthConfig } from './auth.config';
+
+describe('The Auth HTTP Interceptor', () => {
+  let httpClient: HttpClient;
+  let httpTestingController: HttpTestingController;
+  let auth0Client: any;
+
+  beforeEach(() => {
+    auth0Client = jasmine.createSpyObj('Auth0Client', ['getTokenSilently']);
+    auth0Client.getTokenSilently.and.resolveTo('access-token');
+
+    const config: Partial<AuthConfig> = {
+      httpInterceptor: {
+        allowedList: [{ test: '/api' }, { test: /^\/regex-api/ }],
+      },
+    };
+
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule],
+      providers: [
+        {
+          provide: HTTP_INTERCEPTORS,
+          useClass: AuthHttpInterceptor,
+          multi: true,
+        },
+        { provide: Auth0ClientService, useValue: auth0Client },
+        {
+          provide: AuthConfigService,
+          useValue: config,
+        },
+      ],
+    });
+
+    httpClient = TestBed.inject(HttpClient);
+    httpTestingController = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => {
+    httpTestingController.verify();
+  });
+
+  it('passes through for a request that does not need an access token', () => {
+    const testData: Data = { message: 'Hello, world' };
+
+    httpClient.get<Data>('/non-api').subscribe((result) => {
+      expect(result).toEqual(testData);
+      expect(req.request.headers.get('Authorization')).toBeFalsy();
+    });
+
+    const req = httpTestingController.expectOne('/non-api');
+    req.flush(testData);
+  });
+
+  it('attaches the access token to the outgoing request destined for an API', fakeAsync((
+    done
+  ) => {
+    // Async testing: https://github.com/angular/angular/issues/25733#issuecomment-636154553
+    const testData: Data = { message: 'Hello, world' };
+
+    httpClient.get('/api').subscribe(done);
+    flush();
+
+    const req = httpTestingController.expectOne('/api');
+
+    expect(req.request.headers.get('Authorization')).toBe(
+      'Bearer access-token'
+    );
+
+    req.flush(testData);
+  }));
+
+  it('attaches the access token to the outgoing request destined for an API using a regex', fakeAsync((
+    done
+  ) => {
+    const testData: Data = { message: 'Hello, world' };
+
+    httpClient.get('/regex-api?my-param=42').subscribe(done);
+    flush();
+
+    const req = httpTestingController.expectOne('/regex-api?my-param=42');
+
+    expect(req.request.headers.get('Authorization')).toBe(
+      'Bearer access-token'
+    );
+
+    req.flush(testData);
+  }));
+});

--- a/projects/auth0-angular/src/lib/auth.interceptor.spec.ts
+++ b/projects/auth0-angular/src/lib/auth.interceptor.spec.ts
@@ -21,9 +21,15 @@ describe('The Auth HTTP Interceptor', () => {
     const config: Partial<AuthConfig> = {
       httpInterceptor: {
         allowedList: [
-          { test: '/api' },
-          { test: /^\/regex-api/ },
-          { test: '/api-with-options', audience: 'audience', scope: 'scope' },
+          '/basic-api',
+          /^\/basic-api-regex/,
+          { uri: '/api' },
+          { uri: /^\/regex-api/ },
+          {
+            uri: '/api-with-options',
+            audience: 'audience',
+            scope: 'scope',
+          },
         ],
       },
     };
@@ -82,7 +88,41 @@ describe('The Auth HTTP Interceptor', () => {
     req.flush(testData);
   }));
 
-  it('attaches the access token to the outgoing request destined for an API using a regex', fakeAsync((
+  it('attaches the access token to an API configured using a string', fakeAsync((
+    done
+  ) => {
+    const testData: Data = { message: 'Hello, world' };
+
+    httpClient.get('/basic-api').subscribe(done);
+    flush();
+
+    const req = httpTestingController.expectOne('/basic-api');
+
+    expect(req.request.headers.get('Authorization')).toBe(
+      'Bearer access-token'
+    );
+
+    req.flush(testData);
+  }));
+
+  it('attaches the access token to an API configured using a regex', fakeAsync((
+    done
+  ) => {
+    const testData: Data = { message: 'Hello, world' };
+
+    httpClient.get('/basic-api-regex?value=123').subscribe(done);
+    flush();
+
+    const req = httpTestingController.expectOne('/basic-api-regex?value=123');
+
+    expect(req.request.headers.get('Authorization')).toBe(
+      'Bearer access-token'
+    );
+
+    req.flush(testData);
+  }));
+
+  it('attaches the access token to the outgoing request destined for an API using an object with regex', fakeAsync((
     done
   ) => {
     const testData: Data = { message: 'Hello, world' };

--- a/projects/auth0-angular/src/lib/auth.interceptor.spec.ts
+++ b/projects/auth0-angular/src/lib/auth.interceptor.spec.ts
@@ -20,7 +20,11 @@ describe('The Auth HTTP Interceptor', () => {
 
     const config: Partial<AuthConfig> = {
       httpInterceptor: {
-        allowedList: [{ test: '/api' }, { test: /^\/regex-api/ }],
+        allowedList: [
+          { test: '/api' },
+          { test: /^\/regex-api/ },
+          { test: '/api-with-options', audience: 'audience', scope: 'scope' },
+        ],
       },
     };
 
@@ -91,6 +95,27 @@ describe('The Auth HTTP Interceptor', () => {
     expect(req.request.headers.get('Authorization')).toBe(
       'Bearer access-token'
     );
+
+    req.flush(testData);
+  }));
+
+  it('passes through the route options to getTokenSilently, without additional properties', fakeAsync((
+    done
+  ) => {
+    const testData: Data = { message: 'Hello, world' };
+    httpClient.get('/api-with-options').subscribe(done);
+    flush();
+
+    const req = httpTestingController.expectOne('/api-with-options');
+
+    expect(req.request.headers.get('Authorization')).toBe(
+      'Bearer access-token'
+    );
+
+    expect(auth0Client.getTokenSilently).toHaveBeenCalledWith({
+      audience: 'audience',
+      scope: 'scope',
+    });
 
     req.flush(testData);
   }));

--- a/projects/auth0-angular/src/lib/auth.interceptor.spec.ts
+++ b/projects/auth0-angular/src/lib/auth.interceptor.spec.ts
@@ -34,8 +34,10 @@ describe('The Auth HTTP Interceptor', () => {
           { uri: /^\/regex-api/ },
           {
             uri: '/api-with-options',
-            audience: 'audience',
-            scope: 'scope',
+            tokenOptions: {
+              audience: 'audience',
+              scope: 'scope',
+            },
           },
         ],
       },

--- a/projects/auth0-angular/src/lib/auth.interceptor.spec.ts
+++ b/projects/auth0-angular/src/lib/auth.interceptor.spec.ts
@@ -67,14 +67,16 @@ describe('The Auth HTTP Interceptor', () => {
   });
 
   describe('Requests that do not require authentication', () => {
-    it('pass through and do not have access tokens attached', () => {
+    it('pass through and do not have access tokens attached', fakeAsync(() => {
       httpClient.get<Data>('/non-api').subscribe((result) => {
         expect(result).toEqual(testData);
         expect(req.request.headers.get('Authorization')).toBeFalsy();
       });
 
+      flush();
+
       req = httpTestingController.expectOne('/non-api');
-    });
+    }));
   });
 
   describe('Requests that are configured using a primitive', () => {

--- a/projects/auth0-angular/src/lib/auth.interceptor.ts
+++ b/projects/auth0-angular/src/lib/auth.interceptor.ts
@@ -1,0 +1,59 @@
+import {
+  HttpInterceptor,
+  HttpRequest,
+  HttpHandler,
+  HttpEvent,
+} from '@angular/common/http';
+import { Observable, from, of } from 'rxjs';
+import { Injectable, Inject } from '@angular/core';
+import {
+  AuthConfig,
+  AuthConfigService,
+  HttpInterceptorRouteConfig,
+} from './auth.config';
+import { Auth0ClientService } from './auth.client';
+import { Auth0Client } from '@auth0/auth0-spa-js';
+import { concatMap, tap, map, switchMap } from 'rxjs/operators';
+
+@Injectable()
+export class AuthHttpInterceptor implements HttpInterceptor {
+  constructor(
+    @Inject(AuthConfigService) private config: AuthConfig,
+    @Inject(Auth0ClientService) private auth0Client: Auth0Client
+  ) {}
+
+  intercept(
+    req: HttpRequest<any>,
+    next: HttpHandler
+  ): Observable<HttpEvent<any>> {
+    if (this.config.httpInterceptor?.allowedList) {
+      let routeMatch: HttpInterceptorRouteConfig;
+
+      for (const match of this.config.httpInterceptor.allowedList) {
+        if (match.test instanceof RegExp) {
+          if (match.test.test(req.url)) {
+            routeMatch = match;
+            break;
+          }
+        } else if (match.test === req.url) {
+          routeMatch = match;
+          break;
+        }
+      }
+
+      if (routeMatch) {
+        return from(this.auth0Client.getTokenSilently()).pipe(
+          switchMap((token) => {
+            const clone = req.clone({
+              headers: req.headers.set('Authorization', `Bearer ${token}`),
+            });
+
+            return next.handle(clone);
+          })
+        );
+      }
+    }
+
+    return next.handle(req);
+  }
+}

--- a/projects/auth0-angular/src/lib/auth.interceptor.ts
+++ b/projects/auth0-angular/src/lib/auth.interceptor.ts
@@ -4,7 +4,7 @@ import {
   HttpHandler,
   HttpEvent,
 } from '@angular/common/http';
-import { Observable, from, of } from 'rxjs';
+import { Observable, from, of, combineLatest, iif } from 'rxjs';
 import { Injectable, Inject } from '@angular/core';
 import {
   AuthConfig,
@@ -13,7 +13,7 @@ import {
 } from './auth.config';
 import { Auth0ClientService } from './auth.client';
 import { Auth0Client } from '@auth0/auth0-spa-js';
-import { switchMap } from 'rxjs/operators';
+import { switchMap, map, first, concatMap } from 'rxjs/operators';
 
 @Injectable()
 export class AuthHttpInterceptor implements HttpInterceptor {
@@ -22,49 +22,62 @@ export class AuthHttpInterceptor implements HttpInterceptor {
     @Inject(Auth0ClientService) private auth0Client: Auth0Client
   ) {}
 
+  intercept(
+    req: HttpRequest<any>,
+    next: HttpHandler
+  ): Observable<HttpEvent<any>> {
+    if (!this.config.httpInterceptor?.allowedList) {
+      return next.handle(req);
+    }
+
+    return this.findMatchingRoute(req).pipe(
+      concatMap((route) =>
+        iif(
+          () => route !== false,
+          from(this.auth0Client.getTokenSilently()).pipe(
+            switchMap((token: string) => {
+              const clone = req.clone({
+                headers: req.headers.set('Authorization', `Bearer ${token}`),
+              });
+
+              return next.handle(clone);
+            })
+          ),
+          next.handle(req)
+        )
+      )
+    );
+  }
+
+  /**
+   * Determines whether the specified route can have an access token attached to it, based on matching the HTTP request against
+   * the interceptor route configuration.
+   * @param route The route to test
+   * @param request The HTTP request
+   */
+  private canAttachToken(
+    route: HttpInterceptorRouteConfig,
+    request: HttpRequest<any>
+  ): boolean {
+    if (route.test instanceof RegExp) {
+      if (route.test.test(request.url)) {
+        return true;
+      }
+    } else if (route.test === request.url) {
+      return true;
+    }
+  }
+
   /**
    * Tries to match a route from the SDK configuration to the HTTP request.
    * If a match is found, the route configuration is returned.
    * @param request The Http request
    */
-  private matchRequest(request: HttpRequest<any>): HttpInterceptorRouteConfig {
-    let routeMatch: HttpInterceptorRouteConfig;
-
-    for (const match of this.config.httpInterceptor.allowedList) {
-      if (match.test instanceof RegExp) {
-        if (match.test.test(request.url)) {
-          routeMatch = match;
-          break;
-        }
-      } else if (match.test === request.url) {
-        routeMatch = match;
-        break;
-      }
-    }
-
-    return routeMatch;
-  }
-
-  intercept(
-    req: HttpRequest<any>,
-    next: HttpHandler
-  ): Observable<HttpEvent<any>> {
-    if (this.config.httpInterceptor?.allowedList) {
-      const routeMatch = this.matchRequest(req);
-
-      if (routeMatch) {
-        return from(this.auth0Client.getTokenSilently()).pipe(
-          switchMap((token) => {
-            const clone = req.clone({
-              headers: req.headers.set('Authorization', `Bearer ${token}`),
-            });
-
-            return next.handle(clone);
-          })
-        );
-      }
-    }
-
-    return next.handle(req);
+  private findMatchingRoute(
+    request: HttpRequest<any>
+  ): Observable<HttpInterceptorRouteConfig | boolean> {
+    return from(this.config.httpInterceptor.allowedList).pipe(
+      first((route) => this.canAttachToken(route, request), false)
+    );
   }
 }

--- a/projects/auth0-angular/src/lib/auth.interceptor.ts
+++ b/projects/auth0-angular/src/lib/auth.interceptor.ts
@@ -72,11 +72,11 @@ export class AuthHttpInterceptor implements HttpInterceptor {
     request: HttpRequest<any>
   ): boolean {
     const testPrimitive = (value: string | RegExp) => {
-      if (value instanceof RegExp) {
-        if (value.test(request.url)) {
-          return true;
-        }
-      } else if (value === request.url) {
+      if (value === request.url) {
+        return true;
+      }
+
+      if (value instanceof RegExp && value.test(request.url)) {
         return true;
       }
     };

--- a/projects/auth0-angular/src/lib/auth.interceptor.ts
+++ b/projects/auth0-angular/src/lib/auth.interceptor.ts
@@ -43,7 +43,7 @@ export class AuthHttpInterceptor implements HttpInterceptor {
           // If we have a matching route, call getTokenSilently and attach the token to the
           // outgoing request
           of(route).pipe(
-            map(({ uri, ...options }) => options), // Extract the options that we don't want to send through to the token endpoint
+            pluck('tokenOptions'),
             concatMap((options) => this.auth0Client.getTokenSilently(options)),
             switchMap((token: string) => {
               // Clone the request and attach the bearer token

--- a/projects/auth0-angular/src/lib/auth.interceptor.ts
+++ b/projects/auth0-angular/src/lib/auth.interceptor.ts
@@ -13,6 +13,7 @@ import {
   AuthConfigService,
   HttpInterceptorRouteConfig,
   ApiRouteDefinition,
+  isHttpInterceptorRouteConfig,
 } from './auth.config';
 
 import { Auth0ClientService } from './auth.client';
@@ -81,9 +82,8 @@ export class AuthHttpInterceptor implements HttpInterceptor {
       }
     };
 
-    if ((route as HttpInterceptorRouteConfig).uri) {
-      const r = route as HttpInterceptorRouteConfig;
-      return testPrimitive(r.uri);
+    if (isHttpInterceptorRouteConfig(route)) {
+      return testPrimitive(route.uri);
     }
 
     return testPrimitive(route as string | RegExp);


### PR DESCRIPTION
### Description

This PR adds an Http Interceptor to automatically attach access tokens to outgoing requests that are using the built-in `HttpClient` type to make API calls.

Features:

- Configuration that allows the developer to dictate which API calls get which tokens
- Will accept strings, RegExp or an option that allows configuration for `getTokenSilently`
- Can specify `audience` and `scope` per-API definition
- Routes that are not matched by the `httpInterceptor` configuration will continue to work but will not have an access token attached

**Note:** While we can automatically register the Http Interceptor as part of the `AuthModule` setup, it may be better to allow the developer to specify this themselves. The interceptor is designed to be chainable and we can't guarantee we'd insert the interceptor into the right place. But, this could be configurable by adding an option that prevents automatic registration of the Http Interceptor if the developer chooses not to use it.

### Usage

Configure which routes should receive an access token:

```js
const AUTH0_CONFIG = {
    domain: 'your-domain.auth0.com',
    clientId: '<your client ID>',
    httpInterceptor: {
        allowedList: [
            '/api',      // use a simple string to match outgoing URL..
            /\/api-regex/,   // .. or a regex
            {
                uri: '/api'.   // or an object with a string
            },
            {
                uri: \/api-regex/    // or an object with regex
            },
            {
                // use an object with options for getTokenSilently
                uri: '/api',
                audience: 'http://localhost/',
                scope: 'read:data',
                ignoreCache: true
            }
        ]
    }
}
```

Register the Http Interceptor into the application module (this is as per [Provide the Module](https://angular.io/guide/http#provide-the-interceptor) docs):

```js
import { HttpClientModule, HTTP_INTERCEPTORS } from '@angular/common/http';

// Retrieve the interceptor currently using a relative path - in the future this will be straight from '@auth0/auth0-angular'
import { AuthHttpInterceptor } from 'projects/auth0-angular/src/lib/auth.interceptor';

@NgModule({
  declarations: [AppComponent],
  imports: [
    BrowserModule,
    HttpClientModule,
    AppRoutingModule,
    AuthModule.forRoot(AUTH0_CONFIG),
  ],
  providers: [
    { provide: HTTP_INTERCEPTORS, useClass: AuthHttpInterceptor, multi: true },
  ],
  bootstrap: [AppComponent],
})
```

Then, make the API call as normal:

```js
import { HttpClient } from '@angular/common/http';

http.get('/api').subscribe(result => console.log(result));
```

### Testing

- [X] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [X] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [X] All active GitHub checks for tests, formatting, and security are passing
- [X] The correct base branch is being used, if not `master`
