### PR TITLE
[SDK-1860] SDK Useragent

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,12 +4,14 @@
   "scripts": {
     "ng": "ng",
     "start": "ng serve",
-    "build": "ng build",
+    "build": "npm run update-useragent && ng build",
     "test": "ng test",
     "test-ci": "ng test --no-watch --no-progress --browsers=ChromeHeadlessCI --codeCoverage=true",
     "lint": "ng lint",
     "e2e": "ng e2e",
-    "pretty-quick": "pretty-quick"
+    "pretty-quick": "pretty-quick",
+    "update-useragent": "node projects/auth0-angular/scripts/update-useragent.js",
+    "prestart": "npm run update-useragent"
   },
   "private": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -10,8 +10,7 @@
     "lint": "ng lint",
     "e2e": "ng e2e",
     "pretty-quick": "pretty-quick",
-    "update-useragent": "node projects/auth0-angular/scripts/update-useragent.js",
-    "prestart": "npm run update-useragent"
+    "update-useragent": "node projects/auth0-angular/scripts/update-useragent.js"
   },
   "private": true,
   "dependencies": {

--- a/projects/auth0-angular/package.json
+++ b/projects/auth0-angular/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "auth0-angular",
+  "name": "@auth0/auth0-angular",
   "version": "0.0.1",
   "peerDependencies": {
     "@angular/common": "^10.0.2",

--- a/projects/auth0-angular/scripts/update-useragent.js
+++ b/projects/auth0-angular/scripts/update-useragent.js
@@ -1,0 +1,8 @@
+const fs = require('fs');
+const pkg = require('../package.json');
+
+fs.writeFileSync(
+  'projects/auth0-angular/src/useragent.ts',
+  `export default { name: '${pkg.name}', version: '${pkg.version}' };
+`
+);

--- a/projects/auth0-angular/src/lib/auth.client.ts
+++ b/projects/auth0-angular/src/lib/auth.client.ts
@@ -1,6 +1,7 @@
 import { InjectionToken } from '@angular/core';
 import { Auth0Client } from '@auth0/auth0-spa-js';
 import { AuthConfig } from './auth.config';
+import useragent from '../useragent';
 
 export class Auth0ClientFactory {
   static createClient(config: AuthConfig): Auth0Client {
@@ -11,6 +12,10 @@ export class Auth0ClientFactory {
       client_id: clientId,
       max_age: maxAge,
       ...rest,
+      auth0Client: {
+        name: useragent.name,
+        version: useragent.version,
+      },
     });
   }
 }

--- a/projects/auth0-angular/src/useragent.ts
+++ b/projects/auth0-angular/src/useragent.ts
@@ -1,0 +1,1 @@
+export default { name: '@auth0/auth0-angular', version: '0.0.1' };

--- a/projects/auth0-angular/tsconfig.lib.json
+++ b/projects/auth0-angular/tsconfig.lib.json
@@ -7,18 +7,13 @@
     "declaration": true,
     "inlineSources": true,
     "types": [],
-    "lib": [
-      "dom",
-      "es2018"
-    ]
+    "lib": ["dom", "es2018"],
+    "resolveJsonModule": true
   },
   "angularCompilerOptions": {
     "skipTemplateCodegen": true,
     "strictMetadataEmit": true,
     "enableResourceInlining": true
   },
-  "exclude": [
-    "src/test.ts",
-    "**/*.spec.ts"
-  ]
+  "exclude": ["src/test.ts", "**/*.spec.ts"]
 }


### PR DESCRIPTION
This PR configures the useragent string for the SPA SDK so that the correct
useragent is reported when making requests.

- It generates a useragent.ts file on start and build, which is read by the
  runtime
- The version and package name are automatically extracted
- When publishing, the SDK should be built using `npm run build` instead of `ng
  build` (this will be captured in some releasing notes
