### PR TITLE
Improve playground with options

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,7 @@ jobs:
       - node/with-cache:
           steps:
             - run: npm install
-            - run: npm run lint -- auth0-angular
+            - run: npm run lint
             - run: npm run build
             - run: npm run test-ci
             - run:

--- a/package-lock.json
+++ b/package-lock.json
@@ -318,6 +318,15 @@
         "tslib": "^2.0.0"
       }
     },
+    "@angular/forms": {
+      "version": "10.0.7",
+      "resolved": "https://registry.npmjs.org/@angular/forms/-/forms-10.0.7.tgz",
+      "integrity": "sha512-xSGPhidaUWLop3j9zPy4ZeO+/rwnusNWvwrDNey4W68lS068AExRXqf3yTuzobqBGdV2swDJaRabzgD7NS8yag==",
+      "dev": true,
+      "requires": {
+        "tslib": "^2.0.0"
+      }
+    },
     "@angular/platform-browser": {
       "version": "10.0.5",
       "resolved": "https://registry.npmjs.org/@angular/platform-browser/-/platform-browser-10.0.5.tgz",

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "@types/jasmine": "~3.5.0",
     "@types/jasminewd2": "~2.0.3",
     "@types/node": "^12.12.53",
+    "@angular/forms": "^10.0.5",
     "codecov": "^3.7.2",
     "codelyzer": "^6.0.0-next.1",
     "husky": "^4.2.5",

--- a/projects/playground/src/app/app.component.html
+++ b/projects/playground/src/app/app.component.html
@@ -53,6 +53,7 @@
           token.
         </p>
         <form [formGroup]="accessTokenOptionsForm">
+          <!-- add checkbox to Ignore cache -->
           <label>
             Silently
             <input type="radio" [value]="false" formControlName="usePopup" />

--- a/projects/playground/src/app/app.component.html
+++ b/projects/playground/src/app/app.component.html
@@ -79,7 +79,7 @@
         </form>
         <br />
         <textarea cols="50" rows="2" disabled="true">{{
-          accessToken$ | async
+          accessToken
         }}</textarea>
       </li>
     </ul>

--- a/projects/playground/src/app/app.component.html
+++ b/projects/playground/src/app/app.component.html
@@ -1,6 +1,6 @@
 <!-- Next Steps -->
 <h1>{{ 'Auth0 Angular Playground' | uppercase }}</h1>
-<p>SDK initialized = {{ !(isLoading$ | async) }}</p>
+<p class="status-indicator">SDK initialized = {{ !(isLoading$ | async) }}</p>
 
 <div class="actions" *ngIf="!(isLoading$ | async)">
   <h2>Authentication</h2>
@@ -41,16 +41,16 @@
   <div class="artifacts-wrapper" *ngIf="isAuthenticated$ | async">
     <h2>Artifacts</h2>
     <ul class="artifacts-list">
-      <li class="artifact-item">
-        <p>User Profile (Subset of the ID token claims)</p>
+      <li class="artifact">
+        <p>User Profile: Subset of the ID token claims</p>
         <textarea cols="50" rows="15" disabled="true">{{
           user$ | async | json
         }}</textarea>
       </li>
-      <li class="artifact-item">
-        <p>Access Token</p>
+      <li class="artifact">
         <p>
-          Select a mode and click the button to retrieve the access token.
+          Access Token: Select a mode and click the button to retrieve the
+          token.
         </p>
         <form [formGroup]="accessTokenOptionsForm">
           <label>

--- a/projects/playground/src/app/app.component.html
+++ b/projects/playground/src/app/app.component.html
@@ -1,54 +1,83 @@
 <!-- Next Steps -->
-<h1>{{ title | uppercase }}</h1>
+<h1>{{ 'Auth0 Angular Playground' | uppercase }}</h1>
 <p>SDK initialized = {{ !(isLoading$ | async) }}</p>
-<h2>Authentication</h2>
 
-<div class="actions">
-  <button
-    id="login-redirect"
-    (click)="loginWithRedirect()"
-    [disabled]="isAuthenticated$ | async"
-  >
-    Log in (redirect)
-  </button>
-  <button
-    id="login-popup"
-    (click)="loginWithPopup()"
-    [disabled]="isAuthenticated$ | async"
-  >
-    Log in (popup)
-  </button>
-  <button
-    id="logout"
-    (click)="logout()"
-    [disabled]="!(isAuthenticated$ | async)"
-  >
-    Log out
-  </button>
-  <button
-    id="logout-federated"
-    (click)="logout(true)"
-    [disabled]="!(isAuthenticated$ | async)"
-  >
-    Log out (federated)
-  </button>
-</div>
+<div class="actions" *ngIf="!(isLoading$ | async)">
+  <h2>Authentication</h2>
+  <div class="login-wrapper" *ngIf="!(isAuthenticated$ | async)">
+    <form [formGroup]="loginOptionsForm">
+      <label>
+        Use Redirect
+        <input type="radio" [value]="false" formControlName="usePopup" />
+      </label>
 
-<h2>Artifacts</h2>
-<div class="artifacts">
-  <ul>
-    <li>
-      <div>
-        <p>User Profile - Decoded ID token claims</p>
-        <textarea cols="30" rows="8" disabled="true">{{
+      <label>
+        Use Popup
+        <input type="radio" [value]="true" formControlName="usePopup" />
+      </label>
+      <button id="login" (click)="launchLogin()">
+        Log in
+      </button>
+    </form>
+  </div>
+
+  <div class="logout-wrapper" *ngIf="isAuthenticated$ | async">
+    <form [formGroup]="logoutOptionsForm">
+      <label>
+        Local Only
+        <input type="checkbox" formControlName="localOnly" />
+      </label>
+
+      <label>
+        Federated
+        <input type="checkbox" formControlName="federated" />
+      </label>
+      <button id="logout" (click)="launchLogout()">
+        Log out
+      </button>
+    </form>
+  </div>
+
+  <div class="artifacts-wrapper" *ngIf="isAuthenticated$ | async">
+    <h2>Artifacts</h2>
+    <ul class="artifacts-list">
+      <li class="artifact-item">
+        <p>User Profile (Subset of the ID token claims)</p>
+        <textarea cols="50" rows="15" disabled="true">{{
           user$ | async | json
         }}</textarea>
-      </div>
-    </li>
-  </ul>
-</div>
+      </li>
+      <li class="artifact-item">
+        <p>Access Token</p>
+        <p>
+          Select a mode and click the button to retrieve the access token.
+        </p>
+        <form [formGroup]="accessTokenOptionsForm">
+          <label>
+            Silently
+            <input type="radio" [value]="false" formControlName="usePopup" />
+          </label>
 
-<h2>Test Auth Guard</h2>
-<a routerLink="/protected">Protected Route</a> |
-<a routerLink="/">Unprotected Route</a>
-<router-outlet></router-outlet>
+          <label>
+            With Popup
+            <input type="radio" [value]="true" formControlName="usePopup" />
+          </label>
+          <button id="accessToken" (click)="updateAccessToken()">
+            Refresh
+          </button>
+        </form>
+        <br />
+        <textarea cols="50" rows="2" disabled="true">{{
+          accessToken$ | async
+        }}</textarea>
+      </li>
+    </ul>
+  </div>
+
+  <div class="guard-wrapper">
+    <h2>Test Auth Guard</h2>
+    <a routerLink="/protected">Protected Route</a> |
+    <a routerLink="/">Unprotected Route</a>
+    <router-outlet></router-outlet>
+  </div>
+</div>

--- a/projects/playground/src/app/app.component.html
+++ b/projects/playground/src/app/app.component.html
@@ -1,10 +1,12 @@
 <!-- Next Steps -->
 <h1>{{ 'Auth0 Angular Playground' | uppercase }}</h1>
-<p class="status-indicator">SDK initialized = {{ !(isLoading$ | async) }}</p>
+<p class="status-indicator">
+  SDK initialized = {{ (isLoading$ | async) === false }}
+</p>
 
-<div class="actions" *ngIf="!(isLoading$ | async)">
+<div class="actions" *ngIf="(isLoading$ | async) === false">
   <h2>Authentication</h2>
-  <div class="login-wrapper" *ngIf="!(isAuthenticated$ | async)">
+  <div class="login-wrapper" *ngIf="(isAuthenticated$ | async) === false">
     <form [formGroup]="loginOptionsForm">
       <label>
         Use Redirect

--- a/projects/playground/src/app/app.component.html
+++ b/projects/playground/src/app/app.component.html
@@ -53,7 +53,15 @@
           token.
         </p>
         <form [formGroup]="accessTokenOptionsForm">
-          <!-- add checkbox to Ignore cache -->
+          <label>
+            Ignore cache
+            <input
+              type="checkbox"
+              [value]="false"
+              formControlName="ignoreCache"
+            />
+          </label>
+
           <label>
             Silently
             <input type="radio" [value]="false" formControlName="usePopup" />

--- a/projects/playground/src/app/app.component.spec.ts
+++ b/projects/playground/src/app/app.component.spec.ts
@@ -2,6 +2,7 @@ import { TestBed, ComponentFixture } from '@angular/core/testing';
 import { RouterTestingModule } from '@angular/router/testing';
 import { AppComponent } from './app.component';
 import { AuthService } from 'projects/auth0-angular/src/lib/auth.service';
+import { WindowService } from 'projects/auth0-angular/src/lib/window';
 import { BehaviorSubject, of } from 'rxjs';
 import { ReactiveFormsModule } from '@angular/forms';
 
@@ -35,6 +36,14 @@ describe('AppComponent', () => {
         {
           provide: AuthService,
           useValue: authMock,
+        },
+        {
+          provide: WindowService,
+          useValue: {
+            location: {
+              origin: 'http://localhost:4200',
+            },
+          },
         },
       ],
     }).compileComponents();

--- a/projects/playground/src/app/app.component.spec.ts
+++ b/projects/playground/src/app/app.component.spec.ts
@@ -2,7 +2,7 @@ import { TestBed, ComponentFixture } from '@angular/core/testing';
 import { RouterTestingModule } from '@angular/router/testing';
 import { AppComponent } from './app.component';
 import { AuthService } from 'projects/auth0-angular/src/lib/auth.service';
-import { BehaviorSubject } from 'rxjs';
+import { BehaviorSubject, of } from 'rxjs';
 import { ReactiveFormsModule } from '@angular/forms';
 
 describe('AppComponent', () => {
@@ -106,34 +106,52 @@ describe('AppComponent', () => {
       expect(btnLogout).toBeTruthy();
     });
 
-    xit('should logout with default options', () => {
-      //TODO: uncheck all checkboxes
+    it('should logout with default options', () => {
+      const form = component.logoutOptionsForm.controls;
+      form.localOnly.setValue(false);
+      form.federated.setValue(false);
 
       const btnLogout = ne.querySelector('#logout');
       btnLogout.click();
       fixture.detectChanges();
 
-      //TODO: assert logout() was called without options
+      expect(authMock.logout).toHaveBeenCalledWith({
+        localOnly: false,
+        federated: false,
+        returnTo: 'http://localhost:4200',
+      });
     });
 
-    xit('should logout with federated', () => {
-      //TODO: check federated
+    it('should logout with federated', () => {
+      const form = component.logoutOptionsForm.controls;
+      form.localOnly.setValue(false);
+      form.federated.setValue(true);
 
       const btnLogout = ne.querySelector('#logout');
       btnLogout.click();
       fixture.detectChanges();
 
-      //TODO: assert logout() was called with federated=true
+      expect(authMock.logout).toHaveBeenCalledWith({
+        localOnly: false,
+        federated: true,
+        returnTo: 'http://localhost:4200',
+      });
     });
 
-    xit('should logout with localOnly', () => {
-      //TODO: check localOnly
+    it('should logout with localOnly', () => {
+      const form = component.logoutOptionsForm.controls;
+      form.localOnly.setValue(true);
+      form.federated.setValue(false);
 
       const btnLogout = ne.querySelector('#logout');
       btnLogout.click();
       fixture.detectChanges();
 
-      //TODO: assert logout() was called with localOnly=true
+      expect(authMock.logout).toHaveBeenCalledWith({
+        localOnly: true,
+        federated: false,
+        returnTo: 'http://localhost:4200',
+      });
     });
 
     it('should show user profile', () => {
@@ -147,7 +165,7 @@ describe('AppComponent', () => {
       expect(userValue).toEqual({ name: 'John', lastname: 'Doe' });
     });
 
-    it('should show empty access token', () => {
+    it('should show empty access token by default', () => {
       const divToken = ne.querySelectorAll('.artifacts-wrapper .artifact')[1];
       expect(divToken.querySelector('p').textContent).toContain(
         'Access Token: Select a mode and click the button to retrieve the token.'
@@ -156,38 +174,39 @@ describe('AppComponent', () => {
       expect(tokenContent).toEqual('');
     });
 
-    xit('should get access token silently', () => {
+    it('should get access token silently', () => {
       const divToken = ne.querySelectorAll('.artifacts-wrapper .artifact')[1];
       expect(divToken.querySelector('p').textContent).toContain('Access Token');
-
+      const form = component.accessTokenOptionsForm.controls;
+      form.usePopup.setValue(false);
       (authMock.getAccessTokenSilently as jasmine.Spy).and.returnValue(
-        'access token silently'
+        of('access token silently')
       );
-      //TODO: select "silently" radio button
 
       const btnRefresh = divToken.querySelector('button');
       btnRefresh.click();
       fixture.detectChanges();
-      //TODO: assert updateAccessToken() was called?
 
+      expect(authMock.getAccessTokenSilently).toHaveBeenCalledWith();
+      console.log(divToken.querySelector('textarea'));
       const tokenContent = divToken.querySelector('textarea').textContent;
       expect(tokenContent).toEqual('access token silently');
     });
 
-    xit('should get access token with popup', () => {
+    it('should get access token with popup', () => {
       const divToken = ne.querySelectorAll('.artifacts-wrapper .artifact')[1];
       expect(divToken.querySelector('p').textContent).toContain('Access Token');
-
+      const form = component.accessTokenOptionsForm.controls;
+      form.usePopup.setValue(true);
       (authMock.getAccessTokenWithPopup as jasmine.Spy).and.returnValue(
-        'access token popup'
+        of('access token popup')
       );
-      //TODO: select "popup" radio button
 
       const btnRefresh = divToken.querySelector('button');
       btnRefresh.click();
       fixture.detectChanges();
-      //TODO: assert updateAccessToken() was called?
 
+      expect(authMock.getAccessTokenWithPopup).toHaveBeenCalledWith();
       const tokenContent = divToken.querySelector('textarea').textContent;
       expect(tokenContent).toEqual('access token popup');
     });
@@ -218,26 +237,28 @@ describe('AppComponent', () => {
       expect(btnLogin).toBeTruthy();
     });
 
-    xit('should login with redirect', () => {
+    it('should login with redirect', () => {
       const wrapLogin = ne.querySelector('.login-wrapper');
-
-      //TODO: select "redirect" radio button
+      const form = component.loginOptionsForm.controls;
+      form.usePopup.setValue(false);
 
       const btnRefresh = wrapLogin.querySelector('button');
       btnRefresh.click();
       fixture.detectChanges();
-      //TODO: assert loginWithRedirect() was called?
+
+      expect(authMock.loginWithRedirect).toHaveBeenCalledWith();
     });
 
-    xit('should login with popup', () => {
+    it('should login with popup', () => {
       const wrapLogin = ne.querySelector('.login-wrapper');
-
-      //TODO: select "popup" radio button
+      const form = component.loginOptionsForm.controls;
+      form.usePopup.setValue(true);
 
       const btnRefresh = wrapLogin.querySelector('button');
       btnRefresh.click();
       fixture.detectChanges();
-      //TODO: assert loginWithPopup() was called?
+
+      expect(authMock.loginWithPopup).toHaveBeenCalledWith();
     });
   });
 });

--- a/projects/playground/src/app/app.component.spec.ts
+++ b/projects/playground/src/app/app.component.spec.ts
@@ -1,17 +1,25 @@
-import { TestBed, async } from '@angular/core/testing';
+import { TestBed, ComponentFixture } from '@angular/core/testing';
 import { RouterTestingModule } from '@angular/router/testing';
 import { AppComponent } from './app.component';
 import { AuthService } from 'projects/auth0-angular/src/lib/auth.service';
 import { BehaviorSubject } from 'rxjs';
+import { ReactiveFormsModule } from '@angular/forms';
 
 describe('AppComponent', () => {
   let authMock: AuthService;
+  let fixture: ComponentFixture<AppComponent>;
+  let component: AppComponent;
+  let ne;
 
-  beforeEach(async(() => {
+  beforeEach(() => {
     authMock = jasmine.createSpyObj(
       'AuthService',
       {
         loginWithRedirect: jasmine.createSpy().and.returnValue(null),
+        loginWithPopup: jasmine.createSpy().and.returnValue(null),
+        logout: jasmine.createSpy().and.returnValue(null),
+        getAccessTokenSilently: jasmine.createSpy().and.returnValue(null),
+        getAccessTokenWithPopup: jasmine.createSpy().and.returnValue(null),
       },
       {
         user$: new BehaviorSubject(null),
@@ -21,7 +29,7 @@ describe('AppComponent', () => {
     ) as any;
 
     TestBed.configureTestingModule({
-      imports: [RouterTestingModule],
+      imports: [RouterTestingModule, ReactiveFormsModule],
       declarations: [AppComponent],
       providers: [
         {
@@ -30,108 +38,206 @@ describe('AppComponent', () => {
         },
       ],
     }).compileComponents();
-  }));
 
-  describe('constructor', () => {
+    fixture = TestBed.createComponent(AppComponent);
+    component = fixture.componentInstance;
+    ne = fixture.nativeElement;
+    fixture.detectChanges();
+  });
+
+  describe('when initialized', () => {
     it('should create the app', () => {
-      const fixture = TestBed.createComponent(AppComponent);
-      const app = fixture.componentInstance;
-      expect(app).toBeTruthy();
-    });
-
-    it('should have as title `Auth0 Angular Playground`', () => {
-      const fixture = TestBed.createComponent(AppComponent);
-      const app = fixture.componentInstance;
-      expect(app.title).toEqual('Auth0 Angular Playground');
+      expect(component).toBeTruthy();
     });
 
     it('should render title', () => {
-      const fixture = TestBed.createComponent(AppComponent);
-      fixture.detectChanges();
-      const compiled = fixture.nativeElement;
-      expect(compiled.querySelector('h1').textContent).toContain(
-        'AUTH0 ANGULAR PLAYGROUND'
-      );
+      const h1 = ne.querySelector('h1');
+      expect(h1.textContent).toContain('AUTH0 ANGULAR PLAYGROUND');
     });
 
-    it('should render buttons', () => {
-      const fixture = TestBed.createComponent(AppComponent);
+    it('should render SDK loading status', () => {
+      const loadingIndicator = ne.querySelector('p.status-indicator');
+      expect(loadingIndicator.textContent).toContain('SDK initialized = false');
+
+      const loading = authMock.isLoading$ as BehaviorSubject<boolean>;
+      loading.next(false);
       fixture.detectChanges();
-      const compiled = fixture.nativeElement;
 
-      const butLoginRedirect = compiled.querySelector('#login-redirect');
-      expect(butLoginRedirect.textContent).toContain('Log in (redirect)');
+      expect(loadingIndicator.textContent).toContain('SDK initialized = true');
+    });
 
-      const butLoginPopup = compiled.querySelector('#login-popup');
-      expect(butLoginPopup.textContent).toContain('Log in (popup)');
+    it('should show controls when SDK finishes loading', () => {
+      let actions = ne.querySelector('.actions');
+      expect(actions).toBeNull();
 
-      const butLogout = compiled.querySelector('#logout');
-      expect(butLogout.textContent).toContain('Log out');
+      const loading = authMock.isLoading$ as BehaviorSubject<boolean>;
+      loading.next(false);
+      fixture.detectChanges();
 
-      const butLogoutFederated = compiled.querySelector('#logout-federated');
-      expect(butLogoutFederated.textContent).toContain('Log out (federated)');
+      actions = ne.querySelector('.actions');
+      expect(actions).toBeTruthy();
     });
   });
 
   describe('when user is authenticated', () => {
     beforeEach(() => {
-      let authenticated = authMock.isAuthenticated$ as BehaviorSubject<boolean>;
+      const loading = authMock.isLoading$ as BehaviorSubject<boolean>;
+      const authenticated = authMock.isAuthenticated$ as BehaviorSubject<
+        boolean
+      >;
+      const user = authMock.user$ as BehaviorSubject<any>;
+
+      loading.next(false);
       authenticated.next(true);
+      user.next({ name: 'John', lastname: 'Doe' });
+      fixture.detectChanges();
     });
 
-    it('should enable logout buttons', () => {
-      const fixture = TestBed.createComponent(AppComponent);
-      fixture.detectChanges();
-      const compiled = fixture.nativeElement;
-
-      const butLogout = compiled.querySelector('#logout');
-      expect(butLogout.disabled).toBeFalse();
-
-      const butFederated = compiled.querySelector('#logout-federated');
-      expect(butFederated.disabled).toBeFalse();
+    it('should hide login options', () => {
+      const wrapLogin = ne.querySelector('.login-wrapper');
+      expect(wrapLogin).toBeNull();
     });
 
-    it('should disable login buttons', () => {
-      const fixture = TestBed.createComponent(AppComponent);
+    it('should show logout options', () => {
+      const wrapLogout = ne.querySelector('.logout-wrapper');
+      expect(wrapLogout).toBeTruthy();
+
+      const btnLogout = ne.querySelector('#logout');
+      expect(btnLogout).toBeTruthy();
+    });
+
+    xit('should logout with default options', () => {
+      //TODO: uncheck all checkboxes
+
+      const btnLogout = ne.querySelector('#logout');
+      btnLogout.click();
       fixture.detectChanges();
-      const compiled = fixture.nativeElement;
 
-      const butLogout = compiled.querySelector('#login-popup');
-      expect(butLogout.disabled).toBeTrue();
+      //TODO: assert logout() was called without options
+    });
 
-      const butFederated = compiled.querySelector('#login-redirect');
-      expect(butFederated.disabled).toBeTrue();
+    xit('should logout with federated', () => {
+      //TODO: check federated
+
+      const btnLogout = ne.querySelector('#logout');
+      btnLogout.click();
+      fixture.detectChanges();
+
+      //TODO: assert logout() was called with federated=true
+    });
+
+    xit('should logout with localOnly', () => {
+      //TODO: check localOnly
+
+      const btnLogout = ne.querySelector('#logout');
+      btnLogout.click();
+      fixture.detectChanges();
+
+      //TODO: assert logout() was called with localOnly=true
+    });
+
+    it('should show user profile', () => {
+      const divProfile = ne.querySelectorAll('.artifacts-wrapper .artifact')[0];
+      expect(divProfile.querySelector('p').textContent).toContain(
+        'User Profile: Subset of the ID token claims'
+      );
+      const userValue = JSON.parse(
+        divProfile.querySelector('textarea').textContent
+      );
+      expect(userValue).toEqual({ name: 'John', lastname: 'Doe' });
+    });
+
+    it('should show empty access token', () => {
+      const divToken = ne.querySelectorAll('.artifacts-wrapper .artifact')[1];
+      expect(divToken.querySelector('p').textContent).toContain(
+        'Access Token: Select a mode and click the button to retrieve the token.'
+      );
+      const tokenContent = divToken.querySelector('textarea').textContent;
+      expect(tokenContent).toEqual('');
+    });
+
+    xit('should get access token silently', () => {
+      const divToken = ne.querySelectorAll('.artifacts-wrapper .artifact')[1];
+      expect(divToken.querySelector('p').textContent).toContain('Access Token');
+
+      (authMock.getAccessTokenSilently as jasmine.Spy).and.returnValue(
+        'access token silently'
+      );
+      //TODO: select "silently" radio button
+
+      const btnRefresh = divToken.querySelector('button');
+      btnRefresh.click();
+      fixture.detectChanges();
+      //TODO: assert updateAccessToken() was called?
+
+      const tokenContent = divToken.querySelector('textarea').textContent;
+      expect(tokenContent).toEqual('access token silently');
+    });
+
+    xit('should get access token with popup', () => {
+      const divToken = ne.querySelectorAll('.artifacts-wrapper .artifact')[1];
+      expect(divToken.querySelector('p').textContent).toContain('Access Token');
+
+      (authMock.getAccessTokenWithPopup as jasmine.Spy).and.returnValue(
+        'access token popup'
+      );
+      //TODO: select "popup" radio button
+
+      const btnRefresh = divToken.querySelector('button');
+      btnRefresh.click();
+      fixture.detectChanges();
+      //TODO: assert updateAccessToken() was called?
+
+      const tokenContent = divToken.querySelector('textarea').textContent;
+      expect(tokenContent).toEqual('access token popup');
     });
   });
 
   describe('when user is not authenticated', () => {
     beforeEach(() => {
-      let authenticated = authMock.isAuthenticated$ as BehaviorSubject<boolean>;
+      const loading = authMock.isLoading$ as BehaviorSubject<boolean>;
+      const authenticated = authMock.isAuthenticated$ as BehaviorSubject<
+        boolean
+      >;
+
+      loading.next(false);
       authenticated.next(false);
+      fixture.detectChanges();
     });
 
-    it('should disable logout buttons', () => {
-      const fixture = TestBed.createComponent(AppComponent);
-      fixture.detectChanges();
-      const compiled = fixture.nativeElement;
-
-      const butLogout = compiled.querySelector('#logout');
-      expect(butLogout.disabled).toBeTrue();
-
-      const butFederated = compiled.querySelector('#logout-federated');
-      expect(butFederated.disabled).toBeTrue();
+    it('should hide logout options', () => {
+      const wrapLogout = ne.querySelector('.logout-wrapper');
+      expect(wrapLogout).toBeNull();
     });
 
-    it('should enable login buttons', () => {
-      const fixture = TestBed.createComponent(AppComponent);
+    it('should show login options', () => {
+      const wrapLogin = ne.querySelector('.login-wrapper');
+      expect(wrapLogin).toBeTruthy();
+
+      const btnLogin = ne.querySelector('#login');
+      expect(btnLogin).toBeTruthy();
+    });
+
+    xit('should login with redirect', () => {
+      const wrapLogin = ne.querySelector('.login-wrapper');
+
+      //TODO: select "redirect" radio button
+
+      const btnRefresh = wrapLogin.querySelector('button');
+      btnRefresh.click();
       fixture.detectChanges();
-      const compiled = fixture.nativeElement;
+      //TODO: assert loginWithRedirect() was called?
+    });
 
-      const butLogout = compiled.querySelector('#login-popup');
-      expect(butLogout.disabled).toBeFalse();
+    xit('should login with popup', () => {
+      const wrapLogin = ne.querySelector('.login-wrapper');
 
-      const butFederated = compiled.querySelector('#login-redirect');
-      expect(butFederated.disabled).toBeFalse();
+      //TODO: select "popup" radio button
+
+      const btnRefresh = wrapLogin.querySelector('button');
+      btnRefresh.click();
+      fixture.detectChanges();
+      //TODO: assert loginWithPopup() was called?
     });
   });
 });

--- a/projects/playground/src/app/app.component.spec.ts
+++ b/projects/playground/src/app/app.component.spec.ts
@@ -187,7 +187,53 @@ describe('AppComponent', () => {
       btnRefresh.click();
       fixture.detectChanges();
 
-      expect(authMock.getAccessTokenSilently).toHaveBeenCalledWith();
+      expect(authMock.getAccessTokenSilently).toHaveBeenCalledWith({
+        ignoreCache: false,
+      });
+      console.log(divToken.querySelector('textarea'));
+      const tokenContent = divToken.querySelector('textarea').textContent;
+      expect(tokenContent).toEqual('access token silently');
+    });
+
+    it('should get access token silently', () => {
+      const divToken = ne.querySelectorAll('.artifacts-wrapper .artifact')[1];
+      expect(divToken.querySelector('p').textContent).toContain('Access Token');
+      const form = component.accessTokenOptionsForm.controls;
+      form.usePopup.setValue(false);
+      form.ignoreCache.setValue(false);
+      (authMock.getAccessTokenSilently as jasmine.Spy).and.returnValue(
+        of('access token silently')
+      );
+
+      const btnRefresh = divToken.querySelector('button');
+      btnRefresh.click();
+      fixture.detectChanges();
+
+      expect(authMock.getAccessTokenSilently).toHaveBeenCalledWith({
+        ignoreCache: false,
+      });
+      console.log(divToken.querySelector('textarea'));
+      const tokenContent = divToken.querySelector('textarea').textContent;
+      expect(tokenContent).toEqual('access token silently');
+    });
+
+    it('should get access token silently ignoring cache', () => {
+      const divToken = ne.querySelectorAll('.artifacts-wrapper .artifact')[1];
+      expect(divToken.querySelector('p').textContent).toContain('Access Token');
+      const form = component.accessTokenOptionsForm.controls;
+      form.usePopup.setValue(false);
+      form.ignoreCache.setValue(true);
+      (authMock.getAccessTokenSilently as jasmine.Spy).and.returnValue(
+        of('access token silently')
+      );
+
+      const btnRefresh = divToken.querySelector('button');
+      btnRefresh.click();
+      fixture.detectChanges();
+
+      expect(authMock.getAccessTokenSilently).toHaveBeenCalledWith({
+        ignoreCache: true,
+      });
       console.log(divToken.querySelector('textarea'));
       const tokenContent = divToken.querySelector('textarea').textContent;
       expect(tokenContent).toEqual('access token silently');

--- a/projects/playground/src/app/app.component.ts
+++ b/projects/playground/src/app/app.component.ts
@@ -27,6 +27,7 @@ export class AppComponent {
 
   accessTokenOptionsForm = new FormGroup({
     usePopup: new FormControl(false),
+    ignoreCache: new FormControl(false),
   });
 
   constructor(public auth: AuthService) {}
@@ -52,10 +53,11 @@ export class AppComponent {
 
   updateAccessToken(): void {
     const usePopup = this.accessTokenOptionsForm.value.usePopup === true;
+    const ignoreCache = this.accessTokenOptionsForm.value.ignoreCache === true;
     iif(
       () => usePopup,
       this.auth.getAccessTokenWithPopup(),
-      this.auth.getAccessTokenSilently()
+      this.auth.getAccessTokenSilently({ ignoreCache })
     )
       .pipe(first())
       .subscribe((token) => {

--- a/projects/playground/src/app/app.component.ts
+++ b/projects/playground/src/app/app.component.ts
@@ -1,8 +1,9 @@
-import { Component } from '@angular/core';
+import { Component, Inject } from '@angular/core';
 import { FormGroup, FormControl } from '@angular/forms';
 import { AuthService } from 'projects/auth0-angular/src/lib/auth.service';
-import { Observable, iif, BehaviorSubject, of } from 'rxjs';
-import { tap, first } from 'rxjs/operators';
+import { WindowService } from 'projects/auth0-angular/src/lib/window';
+import { iif, BehaviorSubject } from 'rxjs';
+import { first } from 'rxjs/operators';
 import { LogoutOptions } from '@auth0/auth0-spa-js';
 
 @Component({
@@ -30,7 +31,13 @@ export class AppComponent {
     ignoreCache: new FormControl(false),
   });
 
-  constructor(public auth: AuthService) {}
+  constructor(
+    public auth: AuthService,
+    @Inject(WindowService) private window: any
+  ) {
+    // https://github.com/angular/angular/issues/12631
+    this.window = window as Window;
+  }
 
   launchLogin(): void {
     const usePopup = this.loginOptionsForm.value.usePopup === true;
@@ -46,7 +53,7 @@ export class AppComponent {
     const options: LogoutOptions = {
       localOnly: formOptions.localOnly === true,
       federated: formOptions.federated === true,
-      returnTo: 'http://localhost:4200',
+      returnTo: this.window.location.origin,
     };
     this.auth.logout(options);
   }

--- a/projects/playground/src/app/app.component.ts
+++ b/projects/playground/src/app/app.component.ts
@@ -1,5 +1,9 @@
 import { Component } from '@angular/core';
+import { FormGroup, FormControl } from '@angular/forms';
 import { AuthService } from 'projects/auth0-angular/src/lib/auth.service';
+import { Observable, iif, BehaviorSubject, of } from 'rxjs';
+import { tap, first } from 'rxjs/operators';
+import { LogoutOptions } from '@auth0/auth0-spa-js';
 
 @Component({
   selector: 'app-root',
@@ -7,27 +11,55 @@ import { AuthService } from 'projects/auth0-angular/src/lib/auth.service';
   styleUrls: ['./app.component.css'],
 })
 export class AppComponent {
-  title = 'Auth0 Angular Playground';
-
   isAuthenticated$ = this.auth.isAuthenticated$;
   isLoading$ = this.auth.isLoading$;
   user$ = this.auth.user$;
+  accessToken$ = new BehaviorSubject(null);
+
+  loginOptionsForm = new FormGroup({
+    usePopup: new FormControl(false),
+  });
+
+  logoutOptionsForm = new FormGroup({
+    localOnly: new FormControl(false),
+    federated: new FormControl(false),
+  });
+
+  accessTokenOptionsForm = new FormGroup({
+    usePopup: new FormControl(false),
+  });
 
   constructor(public auth: AuthService) {}
 
-  loginWithRedirect() {
-    this.auth.loginWithRedirect();
+  launchLogin(): void {
+    const usePopup = this.loginOptionsForm.value.usePopup === true;
+    if (usePopup) {
+      this.auth.loginWithPopup();
+    } else {
+      this.auth.loginWithRedirect();
+    }
   }
 
-  loginWithPopup() {
-    this.auth.loginWithPopup();
-  }
-
-  logout(federated: boolean = false) {
-    const options = {
-      localOnly: true,
-      federated,
+  launchLogout(): void {
+    const formOptions = this.logoutOptionsForm.value;
+    const options: LogoutOptions = {
+      localOnly: formOptions.localOnly === true,
+      federated: formOptions.federated === true,
+      returnTo: 'http://localhost:4200',
     };
     this.auth.logout(options);
+  }
+
+  updateAccessToken(): void {
+    const usePopup = this.accessTokenOptionsForm.value.usePopup === true;
+    iif(
+      () => usePopup,
+      this.auth.getAccessTokenWithPopup(),
+      this.auth.getAccessTokenSilently()
+    )
+      .pipe(first())
+      .subscribe((token) => {
+        this.accessToken$.next(token);
+      });
   }
 }

--- a/projects/playground/src/app/app.component.ts
+++ b/projects/playground/src/app/app.component.ts
@@ -15,7 +15,7 @@ export class AppComponent {
   isAuthenticated$ = this.auth.isAuthenticated$;
   isLoading$ = this.auth.isLoading$;
   user$ = this.auth.user$;
-  accessToken: string = '';
+  accessToken = '';
 
   loginOptionsForm = new FormGroup({
     usePopup: new FormControl(false),

--- a/projects/playground/src/app/app.component.ts
+++ b/projects/playground/src/app/app.component.ts
@@ -15,7 +15,7 @@ export class AppComponent {
   isAuthenticated$ = this.auth.isAuthenticated$;
   isLoading$ = this.auth.isLoading$;
   user$ = this.auth.user$;
-  accessToken$ = new BehaviorSubject(null);
+  accessToken: string = '';
 
   loginOptionsForm = new FormGroup({
     usePopup: new FormControl(false),
@@ -68,7 +68,7 @@ export class AppComponent {
     )
       .pipe(first())
       .subscribe((token) => {
-        this.accessToken$.next(token);
+        this.accessToken = token;
       });
   }
 }

--- a/projects/playground/src/app/app.module.ts
+++ b/projects/playground/src/app/app.module.ts
@@ -1,6 +1,7 @@
 import { BrowserModule } from '@angular/platform-browser';
 import { NgModule } from '@angular/core';
 import { AuthModule } from 'projects/auth0-angular/src/lib/auth.module';
+import { ReactiveFormsModule } from '@angular/forms';
 
 import { AppRoutingModule } from './app-routing.module';
 import { AppComponent } from './app.component';
@@ -15,7 +16,12 @@ const AUTH0_CONFIG = {
 
 @NgModule({
   declarations: [AppComponent, ProtectedComponent, UnprotectedComponent],
-  imports: [BrowserModule, AppRoutingModule, AuthModule.forRoot(AUTH0_CONFIG)],
+  imports: [
+    BrowserModule,
+    AppRoutingModule,
+    ReactiveFormsModule,
+    AuthModule.forRoot(AUTH0_CONFIG),
+  ],
   providers: [],
   bootstrap: [AppComponent],
 })

--- a/projects/playground/src/app/app.module.ts
+++ b/projects/playground/src/app/app.module.ts
@@ -11,7 +11,7 @@ import { UnprotectedComponent } from './unprotected/unprotected.component';
 const AUTH0_CONFIG = {
   clientId: 'wLSIP47wM39wKdDmOj6Zb5eSEw3JVhVp',
   domain: 'brucke.auth0.com',
-  redirectUri: 'http://localhost:4200',
+  redirectUri: window.location.origin,
 };
 
 @NgModule({


### PR DESCRIPTION
### Description

- Adds forms to change the options on the go.
- Adds the ability to obtain the access token, and displays it.

### Testing

I've added unit tests for the components and some properties. There are some tests that are marked as ignored with `xit` until I find out how to modify the form on the template before calling the associated action. 

- [x] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `master`


## Screenshots
### Authenticated
![image](https://user-images.githubusercontent.com/3900123/89353079-08d28000-d68c-11ea-85f0-aa164632b46e.png)


### NOT Authenticated
![image](https://user-images.githubusercontent.com/3900123/89353085-0cfe9d80-d68c-11ea-81a6-ce93ae5f2a41.png)
