### PR TITLE
Remove use of regex in API example snippets

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,23 +226,16 @@ AuthModule.forRoot({
   // The HttpInterceptor configuration
   httpInterceptor: {
     allowedList: [
-      // Use a string to match the URL exactly
+      // Attach access tokens to any calls to '/api' (exact match)
       '/api',
 
-      // Use a wildcard to match URLs that start with this value
+      // Attach access tokens to any calls that start with '/api/'
       '/api/*',
 
-      // Use a regex to match anything starting with /api
-      /^\/api/,
-
-      // The same as above, but with an object
+      // Match anything starting with /api/, but also specify the audience and scope the attached
+      // access token must have
       {
-        uri: /^\/api/, // can be a string or regex
-      },
-
-      // The same as above but also specifying the audience and scope the token must have
-      {
-        uri: /^\/api/,
+        uri: '/api/*',
         tokenOptions: {
           audience: 'http://my-api/',
           scope: 'read:accounts',


### PR DESCRIPTION
### Description

This updates the readme to remove Regex examples from the HttpInterceptor config, since we removed that ability in a previous update but forgot to update the readme.

### Testing

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `master`
