### PR TITLE
Swap useFactory for useValue when providing AuthConfigService

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,7 @@ jobs:
             - ~/.npm
             - ~/.cache
       - run: npm run lint
-      - run: npm run build
+      - run: npm run build:prod
       - run: npm run test:ci
       - run: npm run e2e:ci
       - run:

--- a/projects/auth0-angular/src/lib/auth.module.ts
+++ b/projects/auth0-angular/src/lib/auth.module.ts
@@ -19,9 +19,7 @@ export class AuthModule {
         AuthGuard,
         {
           provide: AuthConfigService,
-          useFactory(): AuthConfig {
-            return config;
-          },
+          useValue: config,
         },
         {
           provide: Auth0ClientService,

--- a/projects/auth0-angular/src/lib/auth.module.ts
+++ b/projects/auth0-angular/src/lib/auth.module.ts
@@ -17,7 +17,12 @@ export class AuthModule {
       providers: [
         AuthService,
         AuthGuard,
-        { provide: AuthConfigService, useFactory: () => config },
+        {
+          provide: AuthConfigService,
+          useFactory(): AuthConfig {
+            return config;
+          },
+        },
         {
           provide: Auth0ClientService,
           useFactory: Auth0ClientFactory.createClient,


### PR DESCRIPTION
An error was being reported in a production build: 

```
Metadata collected contains an error that will be reported at runtime: Lambda not supported.
```

This PR changes the lambda in `auth.module.ts` to just use `useValue` instead (a factory is not needed here).

See https://github.com/angular/angular/issues/13614

This PR also changes the build script to use the production build over the normal `ng build` to try and catch this sort of thing.