### PR TITLE
Ensure interceptor uses AuthClientConfig

### DIFF
--- a/projects/auth0-angular/src/lib/auth.interceptor.spec.ts
+++ b/projects/auth0-angular/src/lib/auth.interceptor.spec.ts
@@ -40,11 +40,13 @@ describe('The Auth HTTP Interceptor', () => {
     expect(req.request.headers.get('Authorization')).toBeFalsy();
   };
 
+  let config: Partial<AuthConfig>;
+
   beforeEach(() => {
     auth0Client = jasmine.createSpyObj('Auth0Client', ['getTokenSilently']);
     auth0Client.getTokenSilently.and.resolveTo('access-token');
 
-    const config: Partial<AuthConfig> = {
+    config = {
       httpInterceptor: {
         allowedList: [
           '',
@@ -93,6 +95,15 @@ describe('The Auth HTTP Interceptor', () => {
   afterEach(() => {
     httpTestingController.verify();
     req.flush(testData);
+  });
+
+  describe('When no config is configured', () => {
+    it('pass through and do not have access tokens attached', fakeAsync((
+      done
+    ) => {
+      config.httpInterceptor = null;
+      assertPassThruApiCallTo('/api/public', done);
+    }));
   });
 
   describe('Requests that do not require authentication', () => {

--- a/projects/auth0-angular/src/lib/auth.interceptor.spec.ts
+++ b/projects/auth0-angular/src/lib/auth.interceptor.spec.ts
@@ -8,7 +8,7 @@ import {
 } from '@angular/common/http/testing';
 import { Data } from '@angular/router';
 import { Auth0ClientService } from './auth.client';
-import { AuthConfigService, AuthConfig, HttpMethod } from './auth.config';
+import { AuthConfig, HttpMethod, AuthClientConfig } from './auth.config';
 
 // NOTE: Read Async testing: https://github.com/angular/angular/issues/25733#issuecomment-636154553
 
@@ -80,8 +80,8 @@ describe('The Auth HTTP Interceptor', () => {
         },
         { provide: Auth0ClientService, useValue: auth0Client },
         {
-          provide: AuthConfigService,
-          useValue: config,
+          provide: AuthClientConfig,
+          useValue: { get: () => config },
         },
       ],
     });


### PR DESCRIPTION
By submitting a PR to this repository, you agree to the terms within the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/auth0/.github/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo.

### Description

The interceptor was not configured to use Auth0ClientConfig, ignoring the Dynamic configuration that was introduced in 1.1.0.


### References

https://github.com/auth0/auth0-angular/issues/70

### Testing

- [x] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `master`
