### PR TITLE
[SDK-2161] Allow to skip the redirect callback

### DIFF
--- a/README.md
+++ b/README.md
@@ -353,8 +353,7 @@ providers: [
 ### Using multiple OAuth providers
 
 If your application is making use of multiple OAuth providers, you might need to use multiple callback paths as well, one for each OAuth provider.
-To ensure the SDK does not process the callback for any provider other than Auth0,
-you should configure the AuthModule by setting `skipRedirectCallback`.
+To ensure the SDK does not process the callback for any provider other than Auth0, you should configure the AuthModule by setting `skipRedirectCallback`.
 
 ```js
 AuthModule.forRoot({

--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ ng add @auth0/auth0-angular
 - [Protect a route](#protect-a-route)
 - [Call an API](#call-an-api)
 - [Dynamic configuration](#dynamic-configuration)
+- [Using multiple OAuth providers](#using-multiple-oauth-providers)
 
 ### Register the authentication module
 
@@ -311,7 +312,7 @@ export class MyComponent {
 }
 ```
 
-## Dynamic Configuration
+### Dynamic Configuration
 
 Instead of using `AuthModule.forRoot` to specify auth configuration, you can provide a factory function using `APP_INITIALIZER` to load your config from an external source before the auth module is loaded, and provide your configuration using `AuthClientConfig.set`:
 
@@ -348,6 +349,20 @@ providers: [
   },
 ],
 ```
+
+### Using multiple OAuth providers
+
+If your application is making use of multiple OAuth providers, you might need to use multiple callback paths as well, one for each OAuth provider.
+To ensure the SDK does not process the callback for any provider other than Auth0,
+you should configure the AuthModule by setting `skipRedirectCallback`.
+
+```js
+AuthModule.forRoot({
+  skipRedirectCallback: window.location.pathname === '/other-callback',
+});
+```
+
+**Note**: In the above example, `/other-callback` is an existing route that will be called by any other OAuth provider with a `code` (or `error` in case something went wrong) and `state`.
 
 ## Angular Universal
 

--- a/README.md
+++ b/README.md
@@ -353,7 +353,7 @@ providers: [
 ### Using multiple OAuth providers
 
 If your application uses multiple OAuth providers, you may need to use multiple callback paths as well, one for each OAuth provider.
-To ensure the SDK does not process the callback for any provider other than Auth0, you should configure the AuthModule by setting `skipRedirectCallback`.
+To ensure the SDK does not process the callback for any provider other than Auth0, configure the AuthModule by setting the `skipRedirectCallback` property as follows:
 
 ```js
 AuthModule.forRoot({

--- a/README.md
+++ b/README.md
@@ -352,7 +352,7 @@ providers: [
 
 ### Using multiple OAuth providers
 
-If your application is making use of multiple OAuth providers, you might need to use multiple callback paths as well, one for each OAuth provider.
+If your application uses multiple OAuth providers, you may need to use multiple callback paths as well, one for each OAuth provider.
 To ensure the SDK does not process the callback for any provider other than Auth0, you should configure the AuthModule by setting `skipRedirectCallback`.
 
 ```js

--- a/projects/auth0-angular/src/lib/auth.config.ts
+++ b/projects/auth0-angular/src/lib/auth.config.ts
@@ -106,8 +106,9 @@ export interface AuthConfig {
   redirectUri?: string;
 
   /**
-   * By default, if the page URL has code and state parameters, the SDK will assume they are for an Auth0 application and attempt to exchange the
-   * code for a token. In some cases the code might be for something else (e.g. another OAuth SDK). In these
+   * By default, if the page URL has code and state parameters, the SDK will assume they are for
+   * an Auth0 application and attempt to exchange the code for a token.
+   * In some cases the code might be for something else (e.g. another OAuth SDK). In these
    * instances you can instruct the client to ignore them by setting `skipRedirectCallback`.
    *
    * ```js

--- a/projects/auth0-angular/src/lib/auth.config.ts
+++ b/projects/auth0-angular/src/lib/auth.config.ts
@@ -106,6 +106,13 @@ export interface AuthConfig {
   redirectUri?: string;
 
   /**
+   * By default, if the page url has code/state params, the SDK will treat them as Auth0's and attempt to exchange the
+   * code for a token. In some cases the code might be for something else (another OAuth SDK perhaps). In these
+   * instances you can instruct the client to ignore them.
+   */
+  skipRedirectCallback?: boolean;
+
+  /**
    * The value in seconds used to account for clock skew in JWT expirations.
    * Typically, this value is no more than a minute or two at maximum.
    * Defaults to 60s.

--- a/projects/auth0-angular/src/lib/auth.config.ts
+++ b/projects/auth0-angular/src/lib/auth.config.ts
@@ -108,7 +108,17 @@ export interface AuthConfig {
   /**
    * By default, if the page url has code/state params, the SDK will treat them as Auth0's and attempt to exchange the
    * code for a token. In some cases the code might be for something else (another OAuth SDK perhaps). In these
-   * instances you can instruct the client to ignore them.
+   * instances you can instruct the client to ignore them by setting the skipRedirectCallback.
+   *
+   * ```js
+   * AuthModule.forRoot({
+   *   skipRedirectCallback: window.location.pathname === '/other-callback'
+   * })
+   * ```
+   *
+   * **Note**: In the above example, `/other-callback` is an existing route that will be called
+   * by any other OAuth provider with a `code` (or `error` in case when something went wrong) and `state`.
+   *
    */
   skipRedirectCallback?: boolean;
 

--- a/projects/auth0-angular/src/lib/auth.config.ts
+++ b/projects/auth0-angular/src/lib/auth.config.ts
@@ -106,9 +106,9 @@ export interface AuthConfig {
   redirectUri?: string;
 
   /**
-   * By default, if the page url has code/state params, the SDK will treat them as Auth0's and attempt to exchange the
-   * code for a token. In some cases the code might be for something else (another OAuth SDK perhaps). In these
-   * instances you can instruct the client to ignore them by setting the skipRedirectCallback.
+   * By default, if the page URL has code and state parameters, the SDK will assume they are for an Auth0 application and attempt to exchange the
+   * code for a token. In some cases the code might be for something else (e.g. another OAuth SDK). In these
+   * instances you can instruct the client to ignore them by setting `skipRedirectCallback`.
    *
    * ```js
    * AuthModule.forRoot({

--- a/projects/auth0-angular/src/lib/auth.service.spec.ts
+++ b/projects/auth0-angular/src/lib/auth.service.spec.ts
@@ -5,7 +5,7 @@ import { Auth0Client, IdToken } from '@auth0/auth0-spa-js';
 import { AbstractNavigator } from './abstract-navigator';
 import { filter } from 'rxjs/operators';
 import { Location } from '@angular/common';
-import { AuthClientConfig } from './auth.config';
+import { AuthConfig, AuthConfigService } from './auth.config';
 
 /**
  * Wraps service.isLoading$ so that assertions can be made
@@ -20,13 +20,14 @@ describe('AuthService', () => {
   let moduleSetup: any;
   let service: AuthService;
   let locationSpy: jasmine.SpyObj<Location>;
-  let authClientConfigSpy: jasmine.SpyObj<AuthClientConfig>;
+  let authConfig: Partial<AuthConfig>;
 
   const createService = () => {
     return TestBed.inject(AuthService);
   };
 
   beforeEach(() => {
+    authConfig = {};
     auth0Client = new Auth0Client({
       domain: '',
       client_id: '',
@@ -48,8 +49,6 @@ describe('AuthService', () => {
 
     locationSpy = jasmine.createSpyObj('Location', ['path']);
     locationSpy.path.and.returnValue('');
-
-    authClientConfigSpy = jasmine.createSpyObj(['get']);
 
     moduleSetup = {
       providers: [
@@ -177,8 +176,8 @@ describe('AuthService', () => {
             useValue: locationSpy,
           },
           {
-            provide: AuthClientConfig,
-            useValue: authClientConfigSpy,
+            provide: AuthConfigService,
+            useValue: authConfig,
           },
         ],
       });
@@ -196,9 +195,7 @@ describe('AuthService', () => {
     });
 
     it('should not handle the callback when skipRedirectCallback is true', (done) => {
-      authClientConfigSpy.get.and.returnValue({
-        skipRedirectCallback: true,
-      } as any);
+      authConfig.skipRedirectCallback = true;
 
       const localService = createService();
 

--- a/projects/auth0-angular/src/lib/auth.service.spec.ts
+++ b/projects/auth0-angular/src/lib/auth.service.spec.ts
@@ -200,7 +200,7 @@ describe('AuthService', () => {
       const localService = createService();
 
       loaded(localService).subscribe(() => {
-        expect(auth0Client.handleRedirectCallback).not.toHaveBeenCalledTimes(1);
+        expect(auth0Client.handleRedirectCallback).not.toHaveBeenCalled();
         done();
       });
     });

--- a/projects/auth0-angular/src/lib/auth.service.spec.ts
+++ b/projects/auth0-angular/src/lib/auth.service.spec.ts
@@ -5,6 +5,7 @@ import { Auth0Client, IdToken } from '@auth0/auth0-spa-js';
 import { AbstractNavigator } from './abstract-navigator';
 import { filter } from 'rxjs/operators';
 import { Location } from '@angular/common';
+import { AuthClientConfig } from './auth.config';
 
 /**
  * Wraps service.isLoading$ so that assertions can be made
@@ -19,6 +20,7 @@ describe('AuthService', () => {
   let moduleSetup: any;
   let service: AuthService;
   let locationSpy: jasmine.SpyObj<Location>;
+  let authClientConfigSpy: jasmine.SpyObj<AuthClientConfig>;
 
   const createService = () => {
     return TestBed.inject(AuthService);
@@ -46,6 +48,8 @@ describe('AuthService', () => {
 
     locationSpy = jasmine.createSpyObj('Location', ['path']);
     locationSpy.path.and.returnValue('');
+
+    authClientConfigSpy = jasmine.createSpyObj(['get']);
 
     moduleSetup = {
       providers: [
@@ -172,6 +176,10 @@ describe('AuthService', () => {
             provide: Location,
             useValue: locationSpy,
           },
+          {
+            provide: AuthClientConfig,
+            useValue: authClientConfigSpy,
+          },
         ],
       });
 
@@ -183,6 +191,19 @@ describe('AuthService', () => {
 
       loaded(localService).subscribe(() => {
         expect(auth0Client.handleRedirectCallback).toHaveBeenCalledTimes(1);
+        done();
+      });
+    });
+
+    it('should not handle the callback when skipRedirectCallback is true', (done) => {
+      authClientConfigSpy.get.and.returnValue({
+        skipRedirectCallback: true,
+      } as any);
+
+      const localService = createService();
+
+      loaded(localService).subscribe(() => {
+        expect(auth0Client.handleRedirectCallback).not.toHaveBeenCalledTimes(1);
         done();
       });
     });

--- a/projects/auth0-angular/src/lib/auth.service.ts
+++ b/projects/auth0-angular/src/lib/auth.service.ts
@@ -259,7 +259,7 @@ export class AuthService implements OnDestroy {
         return (
           (search.includes('code=') || search.includes('error=')) &&
           search.includes('state=') &&
-          !this.configFactory.get()?.skipRedirectCallback
+          !this.configFactory.get().skipRedirectCallback
         );
       })
     );

--- a/projects/auth0-angular/src/lib/auth.service.ts
+++ b/projects/auth0-angular/src/lib/auth.service.ts
@@ -36,6 +36,7 @@ import {
 import { Auth0ClientService } from './auth.client';
 import { AbstractNavigator } from './abstract-navigator';
 import { Location } from '@angular/common';
+import { AuthClientConfig } from './auth.config';
 
 @Injectable({
   providedIn: 'root',
@@ -88,6 +89,7 @@ export class AuthService implements OnDestroy {
 
   constructor(
     @Inject(Auth0ClientService) private auth0Client: Auth0Client,
+    private configFactory: AuthClientConfig,
     private location: Location,
     private navigator: AbstractNavigator
   ) {
@@ -253,11 +255,13 @@ export class AuthService implements OnDestroy {
 
   private shouldHandleCallback(): Observable<boolean> {
     return of(this.location.path()).pipe(
-      map(
-        (search) =>
+      map((search) => {
+        return (
           (search.includes('code=') || search.includes('error=')) &&
-          search.includes('state=')
-      )
+          search.includes('state=') &&
+          !this.configFactory.get()?.skipRedirectCallback
+        );
+      })
     );
   }
 

--- a/projects/playground/src/app/app.module.ts
+++ b/projects/playground/src/app/app.module.ts
@@ -17,7 +17,6 @@ import {
 const authConfig: AuthConfig = {
   clientId: 'wLSIP47wM39wKdDmOj6Zb5eSEw3JVhVp',
   domain: 'brucke.auth0.com',
-  skipRedirectCallback: window.location.pathname === '/other-callback',
 };
 
 /**

--- a/projects/playground/src/app/app.module.ts
+++ b/projects/playground/src/app/app.module.ts
@@ -17,6 +17,7 @@ import {
 const authConfig: AuthConfig = {
   clientId: 'wLSIP47wM39wKdDmOj6Zb5eSEw3JVhVp',
   domain: 'brucke.auth0.com',
+  skipRedirectCallback: window.location.pathname === '/other-callback',
 };
 
 /**


### PR DESCRIPTION
When using multiple OAuth providers on the same page, it happens that another provider redirects back to a certain URL, including state and code parameters.

Currently, our SDK processed this and tries to retrieve a token. However, it should ignore these as they do not belong to Auth0.