### PR TITLE
[SDK-2140] Emit null for user and idTokenClaims when logged out

### DIFF
--- a/projects/auth0-angular/src/lib/auth.service.spec.ts
+++ b/projects/auth0-angular/src/lib/auth.service.spec.ts
@@ -3,7 +3,7 @@ import { AuthService } from './auth.service';
 import { Auth0ClientService } from './auth.client';
 import { Auth0Client, IdToken } from '@auth0/auth0-spa-js';
 import { AbstractNavigator } from './abstract-navigator';
-import { filter } from 'rxjs/operators';
+import { bufferCount, filter } from 'rxjs/operators';
 import { Location } from '@angular/common';
 
 /**
@@ -126,6 +126,27 @@ describe('AuthService', () => {
         done();
       });
     });
+
+    it('should return null when logged out', (done) => {
+      const user = {
+        name: 'Test User',
+      };
+
+      (auth0Client.isAuthenticated as jasmine.Spy).and.resolveTo(true);
+      (auth0Client.getUser as jasmine.Spy).and.resolveTo(user);
+
+      service.user$.pipe(bufferCount(2)).subscribe((values) => {
+        expect(values[0]).toBe(user);
+        expect(values[1]).toBe(null);
+        done();
+      });
+
+      service.isAuthenticated$.pipe(filter(Boolean)).subscribe(() => {
+        service.logout({
+          localOnly: true,
+        });
+      });
+    });
   });
 
   describe('The `idTokenClaims` observable', () => {
@@ -143,6 +164,30 @@ describe('AuthService', () => {
       service.idTokenClaims$.subscribe((value) => {
         expect(value).toBe(claims);
         done();
+      });
+    });
+
+    it('should return null when logged out', (done) => {
+      const claims: IdToken = {
+        __raw: 'idToken',
+        exp: 1602887231,
+        iat: 1602883631,
+        iss: 'https://example.eu.auth0.com/',
+      };
+
+      (auth0Client.isAuthenticated as jasmine.Spy).and.resolveTo(true);
+      (auth0Client.getIdTokenClaims as jasmine.Spy).and.resolveTo(claims);
+
+      service.idTokenClaims$.pipe(bufferCount(2)).subscribe((values) => {
+        expect(values[0]).toBe(claims);
+        expect(values[1]).toBe(null);
+        done();
+      });
+
+      service.isAuthenticated$.pipe(filter(Boolean)).subscribe(() => {
+        service.logout({
+          localOnly: true,
+        });
       });
     });
   });

--- a/projects/auth0-angular/src/lib/auth.service.ts
+++ b/projects/auth0-angular/src/lib/auth.service.ts
@@ -67,18 +67,20 @@ export class AuthService implements OnDestroy {
    * Emits details about the authenticated user when `isAuthenticated$` is `true`.
    */
   readonly user$ = this.isAuthenticated$.pipe(
-    filter((authenticated) => authenticated),
     distinctUntilChanged(),
-    concatMap(() => this.auth0Client.getUser())
+    concatMap((authenticated) =>
+      authenticated ? this.auth0Client.getUser() : of(null)
+    )
   );
 
   /**
    * Emits ID token claims when `isAuthenticated$` is `true`.
    */
   readonly idTokenClaims$ = this.isAuthenticated$.pipe(
-    filter((authenticated) => authenticated),
     distinctUntilChanged(),
-    concatMap(() => this.auth0Client.getIdTokenClaims())
+    concatMap((authenticated) =>
+      authenticated ? this.auth0Client.getIdTokenClaims() : of(null)
+    )
   );
 
   /**


### PR DESCRIPTION
When logging out, both user and idTokenClaims will not emit null. This might end up in unexpected behavior.

This PR ensures the user and idTokenClaims emit null when logging out.