### PR TITLE
Do not send httpInterceptor to Auth0Client constructor

### DIFF
--- a/projects/auth0-angular/src/lib/auth.client.ts
+++ b/projects/auth0-angular/src/lib/auth.client.ts
@@ -13,7 +13,7 @@ export class Auth0ClientFactory {
       );
     }
 
-    const { redirectUri, clientId, maxAge, ...rest } = config;
+    const { redirectUri, clientId, maxAge, httpInterceptor, ...rest } = config;
 
     return new Auth0Client({
       redirect_uri: redirectUri || window.location.origin,


### PR DESCRIPTION
httpInterceptor is currently being passed to the Auth0Client constructor, resulting in the fact that it gets sent as a query string argument to the /authorize endpoint which is unexpected:

![image](https://user-images.githubusercontent.com/2146903/100100739-91ef0c00-2e61-11eb-800c-203ab1291a3f.png)

This PR strips the httpInterceptor setting from the config, ensuring it doesn't get sent to the constructor.