### PR TITLE
Record getToken errors in the errors$ observable

### DIFF
--- a/README.md
+++ b/README.md
@@ -312,6 +312,31 @@ export class MyComponent {
 }
 ```
 
+#### Handling errors
+
+Whenever the SDK fails to retrieve a token, either as part of the above interceptor or when manually calling `AuthService.getAccessTokenSilently` and `AuthService.getAccessTokenWithPopup`, it will emit the corresponding error in the `AuthService.error$` observable.
+
+If you want to interact to these errors, subscribe to the `error$` observable and act accordingly.
+
+```
+ngOnInit() {
+  this.authService.error$.subscribe(error => {
+    // Handle Error here
+  });
+}
+```
+
+A common reason you might want to handle the above errors, emitted by the error$ observable, is to re-login the user when the SDK throws a `login_required` error.
+
+```
+ngOnInit() {
+  this.authService.error$.pipe(
+    filter(e => e.error === 'login_required'),
+    mergeMap(() => this.authService.loginWithRedirect())
+  ).subscribe();
+}
+```
+
 ### Dynamic Configuration
 
 Instead of using `AuthModule.forRoot` to specify auth configuration, you can provide a factory function using `APP_INITIALIZER` to load your config from an external source before the auth module is loaded, and provide your configuration using `AuthClientConfig.set`:

--- a/README.md
+++ b/README.md
@@ -314,7 +314,7 @@ export class MyComponent {
 
 #### Handling errors
 
-Whenever the SDK fails to retrieve a token, either as part of the above interceptor or when manually calling `AuthService.getAccessTokenSilently` and `AuthService.getAccessTokenWithPopup`, it will emit the corresponding error in the `AuthService.error$` observable.
+Whenever the SDK fails to retrieve an Access Token, either as part of the above interceptor or when manually calling `AuthService.getAccessTokenSilently` and `AuthService.getAccessTokenWithPopup`, it will emit the corresponding error in the `AuthService.error$` observable.
 
 If you want to interact to these errors, subscribe to the `error$` observable and act accordingly.
 
@@ -326,7 +326,7 @@ ngOnInit() {
 }
 ```
 
-A common reason you might want to handle the above errors, emitted by the error$ observable, is to re-login the user when the SDK throws a `login_required` error.
+A common reason you might want to handle the above errors, emitted by the `error$` observable, is to re-login the user when the SDK throws a `login_required` error.
 
 ```
 ngOnInit() {

--- a/projects/auth0-angular/src/lib/auth.interceptor.spec.ts
+++ b/projects/auth0-angular/src/lib/auth.interceptor.spec.ts
@@ -9,13 +9,14 @@ import {
 import { Data } from '@angular/router';
 import { Auth0ClientService } from './auth.client';
 import { AuthConfig, HttpMethod, AuthClientConfig } from './auth.config';
+import { AuthService } from './auth.service';
 
 // NOTE: Read Async testing: https://github.com/angular/angular/issues/25733#issuecomment-636154553
 
 describe('The Auth HTTP Interceptor', () => {
   let httpClient: HttpClient;
   let httpTestingController: HttpTestingController;
-  let auth0Client: any;
+  let authService: Partial<AuthService>;
   let req: TestRequest;
   const testData: Data = { message: 'Hello, world' };
 
@@ -43,8 +44,12 @@ describe('The Auth HTTP Interceptor', () => {
   let config: Partial<AuthConfig>;
 
   beforeEach(() => {
-    auth0Client = jasmine.createSpyObj('Auth0Client', ['getTokenSilently']);
-    auth0Client.getTokenSilently.and.resolveTo('access-token');
+    authService = jasmine.createSpyObj('AuthService', [
+      'getAccessTokenSilently',
+    ]);
+    (authService.getAccessTokenSilently as jasmine.Spy).and.resolveTo(
+      'access-token'
+    );
 
     config = {
       httpInterceptor: {
@@ -80,7 +85,7 @@ describe('The Auth HTTP Interceptor', () => {
           useClass: AuthHttpInterceptor,
           multi: true,
         },
-        { provide: Auth0ClientService, useValue: auth0Client },
+        { provide: AuthService, useValue: authService },
         {
           provide: AuthClientConfig,
           useValue: { get: () => config },
@@ -157,7 +162,7 @@ describe('The Auth HTTP Interceptor', () => {
       // Testing { uri: /api/addresses } (exact match)
       assertAuthorizedApiCallTo('/api/addresses', done);
 
-      expect(auth0Client.getTokenSilently).toHaveBeenCalledWith({
+      expect(authService.getAccessTokenSilently).toHaveBeenCalledWith({
         audience: 'audience',
         scope: 'scope',
       });

--- a/projects/auth0-angular/src/lib/auth.interceptor.ts
+++ b/projects/auth0-angular/src/lib/auth.interceptor.ts
@@ -16,15 +16,14 @@ import {
   AuthConfig,
 } from './auth.config';
 
-import { Auth0ClientService } from './auth.client';
-import { Auth0Client } from '@auth0/auth0-spa-js';
 import { switchMap, first, concatMap, pluck } from 'rxjs/operators';
+import { AuthService } from './auth.service';
 
 @Injectable()
 export class AuthHttpInterceptor implements HttpInterceptor {
   constructor(
     private configFactory: AuthClientConfig,
-    @Inject(Auth0ClientService) private auth0Client: Auth0Client
+    private authService: AuthService
   ) {}
 
   intercept(
@@ -45,7 +44,9 @@ export class AuthHttpInterceptor implements HttpInterceptor {
           // outgoing request
           of(route).pipe(
             pluck('tokenOptions'),
-            concatMap((options) => this.auth0Client.getTokenSilently(options)),
+            concatMap((options) =>
+              this.authService.getAccessTokenSilently(options)
+            ),
             switchMap((token: string) => {
               // Clone the request and attach the bearer token
               const clone = req.clone({

--- a/projects/auth0-angular/src/lib/auth.service.spec.ts
+++ b/projects/auth0-angular/src/lib/auth.service.spec.ts
@@ -497,6 +497,32 @@ describe('AuthService', () => {
         done();
       });
     });
+
+    it('should record errors in the error$ observable', (done) => {
+      const errorObj = new Error('An error has occured');
+
+      (auth0Client.getTokenSilently as jasmine.Spy).and.rejectWith(errorObj);
+
+      service.getAccessTokenSilently().subscribe();
+
+      service.error$.subscribe((err: Error) => {
+        expect(err).toBe(errorObj);
+        done();
+      });
+    });
+
+    it('should bubble errors', (done) => {
+      const errorObj = new Error('An error has occured');
+
+      (auth0Client.getTokenSilently as jasmine.Spy).and.rejectWith(errorObj);
+
+      service.getAccessTokenSilently().subscribe({
+        error: (err: Error) => {
+          expect(err).toBe(errorObj);
+          done();
+        },
+      });
+    });
   });
 
   describe('getAccessTokenWithPopup', () => {
@@ -514,6 +540,32 @@ describe('AuthService', () => {
       service.getAccessTokenWithPopup(options).subscribe((token) => {
         expect(auth0Client.getTokenWithPopup).toHaveBeenCalledWith(options);
         done();
+      });
+    });
+
+    it('should record errors in the error$ observable', (done) => {
+      const errorObj = new Error('An error has occured');
+
+      (auth0Client.getTokenWithPopup as jasmine.Spy).and.rejectWith(errorObj);
+
+      service.getAccessTokenWithPopup().subscribe();
+
+      service.error$.subscribe((err: Error) => {
+        expect(err).toBe(errorObj);
+        done();
+      });
+    });
+
+    it('should bubble errors', (done) => {
+      const errorObj = new Error('An error has occured');
+
+      (auth0Client.getTokenWithPopup as jasmine.Spy).and.rejectWith(errorObj);
+
+      service.getAccessTokenWithPopup().subscribe({
+        error: (err: Error) => {
+          expect(err).toBe(errorObj);
+          done();
+        },
       });
     });
   });

--- a/projects/auth0-angular/src/lib/auth.service.ts
+++ b/projects/auth0-angular/src/lib/auth.service.ts
@@ -21,6 +21,7 @@ import {
   defer,
   ReplaySubject,
   merge,
+  throwError,
 } from 'rxjs';
 
 import {
@@ -250,7 +251,11 @@ export class AuthService implements OnDestroy {
   ): Observable<string> {
     return of(this.auth0Client).pipe(
       concatMap((client) => client.getTokenSilently(options)),
-      tap(() => this.refreshState$.next())
+      tap(() => this.refreshState$.next()),
+      catchError((error) => {
+        this.errorSubject$.next(error);
+        return throwError(error);
+      })
     );
   }
 
@@ -271,7 +276,11 @@ export class AuthService implements OnDestroy {
   ): Observable<string> {
     return of(this.auth0Client).pipe(
       concatMap((client) => client.getTokenWithPopup(options)),
-      tap(() => this.refreshState$.next())
+      tap(() => this.refreshState$.next()),
+      catchError((error) => {
+        this.errorSubject$.next(error);
+        return throwError(error);
+      })
     );
   }
 


### PR DESCRIPTION
By submitting a PR to this repository, you agree to the terms within the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/auth0/.github/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo.

### Description

Whenever `Auth0Client.getTokenSilently` or `Auth0Client.getTokenWithPopup` throw an error, the `AuthService`'s `error$` observable will not record those errors.

This PR ensures it does.

Apart from that, this PR also reworks the`AuthHttpInterceptor` to use the AuthService instead of the Auth0Client directly, to ensure errors are also recorded as part of the `error$` observable when using the interceptor.


### References

#103 

### Testing

When errors are thrown as part of either `Auth0Client.getTokenSilently`or `Auth0Client.getTokenWithPopup` when calling `AuthService.getAccessTokenSilently` or `AuthService.getAccessTokenWithPopup`, the `error$` observable should record those errors.

- [x] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `master`
