### PR TITLE
Ensure isAuthenticated always pulls live value from SPA JS SDK

### DIFF
--- a/projects/auth0-angular/src/lib/auth.service.ts
+++ b/projects/auth0-angular/src/lib/auth.service.ts
@@ -34,7 +34,6 @@ import {
   catchError,
   switchMap,
   mergeMap,
-  shareReplay,
 } from 'rxjs/operators';
 
 import { Auth0ClientService } from './auth.client';
@@ -75,9 +74,7 @@ export class AuthService implements OnDestroy {
           mergeMap(() => this.auth0Client.isAuthenticated())
         )
       )
-    ),
-    // Ensure every future subscriber receives the last known value
-    shareReplay(1)
+    )
   );
 
   /**


### PR DESCRIPTION
The Angular SDK "caches" the isAuthenticated value by using `shareReplay(1)`. This has the consequence that it does not reflect logging false when the idToken is expired, even tho SPA JS' `isAuthenticated()` does return false.