### PR TITLE
Fix build by ensuring errors are handled

### DIFF
--- a/projects/auth0-angular/src/lib/auth.service.spec.ts
+++ b/projects/auth0-angular/src/lib/auth.service.spec.ts
@@ -418,7 +418,7 @@ describe('AuthService', () => {
   });
 
   it('should call `loginWithPopup`', (done) => {
-    loaded(service).subscribe(async () => {
+    loaded(service).subscribe(() => {
       (auth0Client.isAuthenticated as jasmine.Spy).calls.reset();
       (auth0Client.isAuthenticated as jasmine.Spy).and.resolveTo(true);
 
@@ -434,7 +434,7 @@ describe('AuthService', () => {
     });
   });
 
-  it('should call `loginWithPopup` with options', async (done) => {
+  it('should call `loginWithPopup` with options', (done) => {
     // These objects are empty, as we just want to check that the
     // same object reference was passed through than any specific options.
     const options = {};
@@ -503,7 +503,9 @@ describe('AuthService', () => {
 
       (auth0Client.getTokenSilently as jasmine.Spy).and.rejectWith(errorObj);
 
-      service.getAccessTokenSilently().subscribe();
+      service.getAccessTokenSilently().subscribe({
+        error: () => {},
+      });
 
       service.error$.subscribe((err: Error) => {
         expect(err).toBe(errorObj);
@@ -548,7 +550,9 @@ describe('AuthService', () => {
 
       (auth0Client.getTokenWithPopup as jasmine.Spy).and.rejectWith(errorObj);
 
-      service.getAccessTokenWithPopup().subscribe();
+      service.getAccessTokenWithPopup().subscribe({
+        error: () => {},
+      });
 
       service.error$.subscribe((err: Error) => {
         expect(err).toBe(errorObj);


### PR DESCRIPTION
Currently, our CI is failing randomly (but frequently) because of a problem with one of our tests.

It looks like one of our tests, that is preparing an error using `new Error(...)` is failing other tests, which seems like some kind of race condition or parallel execution problem.
However, as far as I can find, karma does not execute tests in parallel by default.

```javascript
it('should record errors in the error$ observable', (done) => {
  const errorObj = new Error('An error has occured');

  (auth0Client.getTokenSilently as jasmine.Spy).and.rejectWith(errorObj);

  service.getAccessTokenSilently().subscribe();

  service.error$.subscribe((err: Error) => {
    expect(err).toBe(errorObj);
    done();
  });
});
```

When the observables in two of our tests pass an error callback to the subscription method, those errors are prevented from bubbling to the test runner and avoiding the random test failure.

```javascript
service.getAccessTokenSilently().subscribe({
  error: () => {},
});
```

Even though we are not entirely sure why this solves it, for now, it seems acceptable to move forward with it.