### PR TITLE
Add uriMatcher to HttpInterceptorRouteConfig

### DIFF
--- a/README.md
+++ b/README.md
@@ -291,8 +291,22 @@ AuthModule.forRoot({
           scope: 'read:users',
         },
       },
+    ],
+  },
+});
+```
 
-      // Using an URI matcher
+> Under the hood, `tokenOptions` is passed as-is to [the `getTokenSilently` method](https://auth0.github.io/auth0-spa-js/classes/auth0client.html#gettokensilently) on the underlying SDK, so all the same options apply here.
+
+**Uri Matching**
+
+If you need more fine-grained control over the URI matching, you can provide a callback function to the `uriMatcher` property that takes a single `uri` argument (being [`HttpRequest.url`](https://angular.io/api/common/http/HttpRequest#url)) and returns a boolean. If this function returns true, then an access token is attached to the request in the ["Authorization" header](https://tools.ietf.org/html/draft-ietf-oauth-v2-bearer-20#section-2.1). If it returns false, the request proceeds without the access token attached.
+
+```
+AuthModule.forRoot({
+  ...
+  httpInterceptor: {
+    allowedList: [
       {
         uriMatcher: (uri) => uri.indexOf('/api/orders') > -1,
         httpMethod: HttpMethod.Post,
@@ -306,7 +320,7 @@ AuthModule.forRoot({
 });
 ```
 
-> Under the hood, `tokenOptions` is passed as-is to [the `getTokenSilently` method](https://auth0.github.io/auth0-spa-js/classes/auth0client.html#gettokensilently) on the underlying SDK, so all the same options apply here.
+You might want to do this in scenarios where you need the token on multiple endpoints, but want to exclude it from only a few other endpoints. Instead of explicitly listing all endpoints that do need a token, a uriMatcher can be used to include all but the few endpoints that do not need a token attached to its requests.
 
 #### Use HttpClient to make an API call
 

--- a/README.md
+++ b/README.md
@@ -291,6 +291,16 @@ AuthModule.forRoot({
           scope: 'read:users',
         },
       },
+
+      // Using an URI matcher
+      {
+        uriMatcher: (uri) => uri.indexOf('/api/orders') > -1,
+        httpMethod: HttpMethod.Post,
+        tokenOptions: {
+          audience: 'http://my-api/',
+          scope: 'write:orders',
+        },
+      },
     ],
   },
 });

--- a/projects/auth0-angular/src/lib/auth.config.ts
+++ b/projects/auth0-angular/src/lib/auth.config.ts
@@ -70,7 +70,7 @@ export interface HttpInterceptorRouteConfig {
    * an access token is attached to the request in the
    *  ["Authorization" header](https://tools.ietf.org/html/draft-ietf-oauth-v2-bearer-20#section-2.1).
    *
-   * If the test does not pass, the request proceeds without the access token attached.
+   * If it returns false, the request proceeds without the access token attached.
    */
   uriMatcher?: (uri: string) => boolean;
 

--- a/projects/auth0-angular/src/lib/auth.config.ts
+++ b/projects/auth0-angular/src/lib/auth.config.ts
@@ -16,7 +16,7 @@ export const enum HttpMethod {
 /**
  * Defines the type for a route config entry. Can either be:
  *
- * - an object of type HttpInterceptorConfig
+ * - an object of type HttpInterceptorRouteConfig
  * - a string
  */
 export type ApiRouteDefinition = HttpInterceptorRouteConfig | string;
@@ -28,7 +28,10 @@ export type ApiRouteDefinition = HttpInterceptorRouteConfig | string;
 export function isHttpInterceptorRouteConfig(
   def: ApiRouteDefinition
 ): def is HttpInterceptorRouteConfig {
-  return (def as HttpInterceptorRouteConfig).uri !== undefined;
+  return (
+    (def as HttpInterceptorRouteConfig).uri !== undefined ||
+    (def as HttpInterceptorRouteConfig).uriMatcher !== undefined
+  );
 }
 
 /**
@@ -57,7 +60,19 @@ export interface HttpInterceptorRouteConfig {
    * '/api' - exactly match the route /api
    * '/api/*' - match any route that starts with /api/
    */
-  uri: string;
+  uri?: string;
+
+  /**
+   * A function that will be called with the HttpRequest.url value, allowing you to do
+   * any kind of flexible matching.
+   *
+   * If this function returns true, then
+   * an access token is attached to the request in the
+   *  ["Authorization" header](https://tools.ietf.org/html/draft-ietf-oauth-v2-bearer-20#section-2.1).
+   *
+   * If the test does not pass, the request proceeds without the access token attached.
+   */
+  uriMatcher?: (uri: string) => boolean;
 
   /**
    * The options that are passed to the SDK when retrieving the

--- a/projects/auth0-angular/src/lib/auth.config.ts
+++ b/projects/auth0-angular/src/lib/auth.config.ts
@@ -28,10 +28,7 @@ export type ApiRouteDefinition = HttpInterceptorRouteConfig | string;
 export function isHttpInterceptorRouteConfig(
   def: ApiRouteDefinition
 ): def is HttpInterceptorRouteConfig {
-  return (
-    (def as HttpInterceptorRouteConfig).uri !== undefined ||
-    (def as HttpInterceptorRouteConfig).uriMatcher !== undefined
-  );
+  return typeof def !== 'string';
 }
 
 /**

--- a/projects/auth0-angular/src/lib/auth.interceptor.spec.ts
+++ b/projects/auth0-angular/src/lib/auth.interceptor.spec.ts
@@ -207,14 +207,14 @@ describe('The Auth HTTP Interceptor', () => {
 
   describe('Requests that are configured using an uri matcher', () => {
     it('attach the access token when the matcher returns true', fakeAsync((
-      done
+      done: () => void
     ) => {
       // Testing { uriMatcher: (uri) => uri.indexOf('/api/contact') !== -1 }
       assertAuthorizedApiCallTo('/api/contact', done, 'post');
     }));
 
     it('pass through the route options to getTokenSilently, without additional properties', fakeAsync((
-      done
+      done: () => void
     ) => {
       // Testing { uriMatcher: (uri) => uri.indexOf('/api/contact') !== -1 }
       assertAuthorizedApiCallTo('/api/contact', done, 'post');
@@ -226,7 +226,7 @@ describe('The Auth HTTP Interceptor', () => {
     }));
 
     it('does not attach the access token when the HTTP method does not match', fakeAsync((
-      done
+      done: () => void
     ) => {
       // Testing { uriMatcher: (uri) => uri.indexOf('/api/contact') !== -1 }
       assertAuthorizedApiCallTo('/api/contact', done, 'post');

--- a/projects/auth0-angular/src/lib/auth.interceptor.spec.ts
+++ b/projects/auth0-angular/src/lib/auth.interceptor.spec.ts
@@ -197,18 +197,18 @@ describe('The Auth HTTP Interceptor', () => {
     }));
   });
 
-  describe('Requests that are configured using a matcher', () => {
+  describe('Requests that are configured using an uri matcher', () => {
     it('attach the access token when the matcher returns true', fakeAsync((
       done
     ) => {
-      // Testing { requestMatcher: (request) => request.url.indexOf('/api/contact') !== -1 }
+      // Testing { uriMatcher: (uri) => uri.indexOf('/api/contact') !== -1 }
       assertAuthorizedApiCallTo('/api/contact', done, 'post');
     }));
 
     it('pass through the route options to getTokenSilently, without additional properties', fakeAsync((
       done
     ) => {
-      // Testing { requestMatcher: (request) => request.url.indexOf('/api/contact') !== -1 }
+      // Testing { uriMatcher: (uri) => uri.indexOf('/api/contact') !== -1 }
       assertAuthorizedApiCallTo('/api/contact', done, 'post');
 
       expect(authService.getAccessTokenSilently).toHaveBeenCalledWith({
@@ -220,7 +220,7 @@ describe('The Auth HTTP Interceptor', () => {
     it('does not attaches the access token when the HTTP method does not match', fakeAsync((
       done
     ) => {
-      // Testing { requestMatcher: (request) => request.method === HttpMethod.Post && request.url.indexOf('/api/about') !== -1 }
+      // Testing { uriMatcher: (uri) => uri.indexOf('/api/contact') !== -1 }
       assertAuthorizedApiCallTo('/api/contact', done, 'post');
       assertPassThruApiCallTo('/api/contact', done);
     }));

--- a/projects/auth0-angular/src/lib/auth.interceptor.spec.ts
+++ b/projects/auth0-angular/src/lib/auth.interceptor.spec.ts
@@ -73,6 +73,14 @@ describe('The Auth HTTP Interceptor', () => {
             uri: '/api/register',
             httpMethod: HttpMethod.Post,
           },
+          {
+            uriMatcher: (uri) => uri.indexOf('/api/contact') !== -1,
+            httpMethod: HttpMethod.Post,
+            tokenOptions: {
+              audience: 'audience',
+              scope: 'scope',
+            },
+          },
         ],
       },
     };
@@ -186,6 +194,35 @@ describe('The Auth HTTP Interceptor', () => {
       done
     ) => {
       assertPassThruApiCallTo('/api/public', done);
+    }));
+  });
+
+  describe('Requests that are configured using a matcher', () => {
+    it('attach the access token when the matcher returns true', fakeAsync((
+      done
+    ) => {
+      // Testing { requestMatcher: (request) => request.url.indexOf('/api/contact') !== -1 }
+      assertAuthorizedApiCallTo('/api/contact', done, 'post');
+    }));
+
+    it('pass through the route options to getTokenSilently, without additional properties', fakeAsync((
+      done
+    ) => {
+      // Testing { requestMatcher: (request) => request.url.indexOf('/api/contact') !== -1 }
+      assertAuthorizedApiCallTo('/api/contact', done, 'post');
+
+      expect(authService.getAccessTokenSilently).toHaveBeenCalledWith({
+        audience: 'audience',
+        scope: 'scope',
+      });
+    }));
+
+    it('does not attaches the access token when the HTTP method does not match', fakeAsync((
+      done
+    ) => {
+      // Testing { requestMatcher: (request) => request.method === HttpMethod.Post && request.url.indexOf('/api/about') !== -1 }
+      assertAuthorizedApiCallTo('/api/contact', done, 'post');
+      assertPassThruApiCallTo('/api/contact', done);
     }));
   });
 });

--- a/projects/auth0-angular/src/lib/auth.interceptor.spec.ts
+++ b/projects/auth0-angular/src/lib/auth.interceptor.spec.ts
@@ -217,7 +217,7 @@ describe('The Auth HTTP Interceptor', () => {
       });
     }));
 
-    it('does not attaches the access token when the HTTP method does not match', fakeAsync((
+    it('does not attach the access token when the HTTP method does not match', fakeAsync((
       done
     ) => {
       // Testing { uriMatcher: (uri) => uri.indexOf('/api/contact') !== -1 }

--- a/projects/auth0-angular/src/lib/auth.interceptor.ts
+++ b/projects/auth0-angular/src/lib/auth.interceptor.ts
@@ -113,6 +113,7 @@ export class AuthHttpInterceptor implements HttpInterceptor {
         return false;
       }
 
+      /* istanbul ignore if */
       if (!route.uri && !route.uriMatcher) {
         console.warn(
           'Either a uri or uriMatcher is required when configuring the HTTP interceptor.'

--- a/projects/auth0-angular/src/lib/auth.interceptor.ts
+++ b/projects/auth0-angular/src/lib/auth.interceptor.ts
@@ -90,7 +90,7 @@ export class AuthHttpInterceptor implements HttpInterceptor {
     route: ApiRouteDefinition,
     request: HttpRequest<any>
   ): boolean {
-    const testPrimitive = (value: string): boolean => {
+    const testPrimitive = (value: string | undefined): boolean => {
       if (!value) {
         return false;
       }

--- a/projects/auth0-angular/src/lib/auth.interceptor.ts
+++ b/projects/auth0-angular/src/lib/auth.interceptor.ts
@@ -91,10 +91,6 @@ export class AuthHttpInterceptor implements HttpInterceptor {
     request: HttpRequest<any>
   ): boolean {
     const testPrimitive = (value: string) => {
-      if (value) {
-        value.trim();
-      }
-
       if (!value) {
         return false;
       }
@@ -119,7 +115,9 @@ export class AuthHttpInterceptor implements HttpInterceptor {
         return false;
       }
 
-      return testPrimitive(route.uri);
+      return route.uriMatcher
+        ? route.uriMatcher(request.url)
+        : testPrimitive(route.uri);
     }
 
     return testPrimitive(route);

--- a/projects/auth0-angular/src/lib/auth.interceptor.ts
+++ b/projects/auth0-angular/src/lib/auth.interceptor.ts
@@ -115,6 +115,12 @@ export class AuthHttpInterceptor implements HttpInterceptor {
         return false;
       }
 
+      if (!route.uri && !route.uriMatcher) {
+        console.warn(
+          'Either a uri or uriMatcher is required when configuring the HTTP interceptor.'
+        );
+      }
+
       return route.uriMatcher
         ? route.uriMatcher(request.url)
         : testPrimitive(route.uri);


### PR DESCRIPTION
Several times users have requested the ability to exclude URLs from having tokens added to them instead of explicitly include all that need a token.

See: https://github.com/auth0/auth0-angular/issues/120 and https://github.com/auth0/auth0-angular/issues/74

Instead of doing that, this PR adds support for an URI Matcher that allows the user to implement anything they want themselves. This ensures the user gets 100% flexibility,m without pulling in extra complexity.

Apart from being able to use

```
{
  uri: '/api/orders')',
  httpMethod: HttpMethod.Post,
}
```

Users can now also use

```
{
  uriMatcher: (uri) => uri.indexOf('/api/orders') > -1,
  httpMethod: HttpMethod.Post,
}
```