### PR TITLE
Enable strict mode

### DIFF
--- a/projects/auth0-angular/src/lib/abstract-navigator.ts
+++ b/projects/auth0-angular/src/lib/abstract-navigator.ts
@@ -6,7 +6,7 @@ import { Location } from '@angular/common';
   providedIn: 'root',
 })
 export class AbstractNavigator {
-  private readonly router: Router;
+  private readonly router?: Router;
 
   constructor(private location: Location, injector: Injector) {
     try {

--- a/projects/auth0-angular/src/lib/auth.config.ts
+++ b/projects/auth0-angular/src/lib/auth.config.ts
@@ -246,7 +246,7 @@ export interface AuthConfig {
  */
 @Injectable({ providedIn: 'root' })
 export class AuthClientConfig {
-  private config: AuthConfig;
+  private config?: AuthConfig;
 
   constructor(@Optional() @Inject(AuthConfigService) config?: AuthConfig) {
     if (config) {
@@ -266,7 +266,7 @@ export class AuthClientConfig {
    * Gets the config that has been set by other consumers of the service
    */
   get(): AuthConfig {
-    return this.config;
+    return this.config as AuthConfig;
   }
 }
 

--- a/projects/auth0-angular/src/lib/auth.guard.ts
+++ b/projects/auth0-angular/src/lib/auth.guard.ts
@@ -42,7 +42,9 @@ export class AuthGuard implements CanActivate, CanLoad, CanActivateChild {
     return this.auth.isAuthenticated$.pipe(
       tap((loggedIn) => {
         if (!loggedIn) {
-          this.auth.loginWithRedirect({ appState: { target: state.url } });
+          return this.auth.loginWithRedirect({
+            appState: { target: state.url },
+          });
         } else {
           return of(true);
         }

--- a/projects/auth0-angular/src/lib/auth.interceptor.spec.ts
+++ b/projects/auth0-angular/src/lib/auth.interceptor.spec.ts
@@ -7,8 +7,12 @@ import {
   TestRequest,
 } from '@angular/common/http/testing';
 import { Data } from '@angular/router';
-import { Auth0ClientService } from './auth.client';
-import { AuthConfig, HttpMethod, AuthClientConfig } from './auth.config';
+import {
+  AuthConfig,
+  HttpMethod,
+  AuthClientConfig,
+  HttpInterceptorConfig,
+} from './auth.config';
 import { AuthService } from './auth.service';
 
 // NOTE: Read Async testing: https://github.com/angular/angular/issues/25733#issuecomment-636154553
@@ -25,7 +29,7 @@ describe('The Auth HTTP Interceptor', () => {
     done: () => void,
     method = 'get'
   ) => {
-    httpClient[method](url).subscribe(done);
+    httpClient.request(method, url).subscribe(done);
     flush();
     req = httpTestingController.expectOne(url);
 
@@ -102,18 +106,18 @@ describe('The Auth HTTP Interceptor', () => {
     req.flush(testData);
   });
 
-  describe('When no config is configured', () => {
+  describe('When no httpInterceptor is configured', () => {
     it('pass through and do not have access tokens attached', fakeAsync((
-      done
+      done: () => void
     ) => {
-      config.httpInterceptor = null;
+      config.httpInterceptor = (null as unknown) as HttpInterceptorConfig;
       assertPassThruApiCallTo('/api/public', done);
     }));
   });
 
   describe('Requests that do not require authentication', () => {
     it('pass through and do not have access tokens attached', fakeAsync((
-      done
+      done: () => void
     ) => {
       assertPassThruApiCallTo('/api/public', done);
     }));
@@ -121,43 +125,47 @@ describe('The Auth HTTP Interceptor', () => {
 
   describe('Requests that are configured using a primitive', () => {
     it('attach the access token when the configuration uri is a string', fakeAsync((
-      done
+      done: () => void
     ) => {
       // Testing /api/photos (exact match)
       assertAuthorizedApiCallTo('/api/photos', done);
     }));
 
     it('attach the access token when the configuration uri is a string with a wildcard', fakeAsync((
-      done
+      done: () => void
     ) => {
       // Testing /api/people* (wildcard match)
       assertAuthorizedApiCallTo('/api/people/profile', done);
     }));
 
-    it('matches a full url to an API', fakeAsync((done) => {
+    it('matches a full url to an API', fakeAsync((done: () => void) => {
       // Testing 'https://my-api.com/orders' (exact)
       assertAuthorizedApiCallTo('https://my-api.com/orders', done);
     }));
 
-    it('matches a URL that contains a query string', fakeAsync((done) => {
+    it('matches a URL that contains a query string', fakeAsync((
+      done: () => void
+    ) => {
       assertAuthorizedApiCallTo('/api/people?name=test', done);
     }));
 
-    it('matches a URL that contains a hash fragment', fakeAsync((done) => {
+    it('matches a URL that contains a hash fragment', fakeAsync((
+      done: () => void
+    ) => {
       assertAuthorizedApiCallTo('/api/people#hash-fragment', done);
     }));
   });
 
   describe('Requests that are configured using a complex object', () => {
     it('attach the access token when the uri is configured using a string', fakeAsync((
-      done
+      done: () => void
     ) => {
       // Testing { uri: /api/orders } (exact match)
       assertAuthorizedApiCallTo('/api/orders', done);
     }));
 
     it('pass through the route options to getTokenSilently, without additional properties', fakeAsync((
-      done
+      done: () => void
     ) => {
       // Testing { uri: /api/addresses } (exact match)
       assertAuthorizedApiCallTo('/api/addresses', done);
@@ -169,21 +177,21 @@ describe('The Auth HTTP Interceptor', () => {
     }));
 
     it('attach the access token when the configuration uri is a string with a wildcard', fakeAsync((
-      done
+      done: () => void
     ) => {
       // Testing { uri: /api/calendar* } (wildcard match)
       assertAuthorizedApiCallTo('/api/calendar/events', done);
     }));
 
     it('attaches the access token when the HTTP method matches', fakeAsync((
-      done
+      done: () => void
     ) => {
       // Testing { uri: /api/register } (wildcard match)
       assertAuthorizedApiCallTo('/api/register', done, 'post');
     }));
 
     it('does not attach the access token if the HTTP method does not match', fakeAsync((
-      done
+      done: () => void
     ) => {
       assertPassThruApiCallTo('/api/public', done);
     }));

--- a/projects/auth0-angular/src/lib/auth.service.spec.ts
+++ b/projects/auth0-angular/src/lib/auth.service.spec.ts
@@ -3,7 +3,7 @@ import { AuthService } from './auth.service';
 import { Auth0ClientService } from './auth.client';
 import { Auth0Client, IdToken } from '@auth0/auth0-spa-js';
 import { AbstractNavigator } from './abstract-navigator';
-import { bufferCount, filter } from 'rxjs/operators';
+import { bufferCount, bufferTime, filter } from 'rxjs/operators';
 import { Location } from '@angular/common';
 import { AuthConfig, AuthConfigService } from './auth.config';
 
@@ -92,6 +92,18 @@ describe('AuthService', () => {
           done();
         }
       });
+    });
+
+    it('should not set isLoading when service destroyed before checkSession finished', (done) => {
+      const localService = createService();
+
+      localService.isLoading$.pipe(bufferTime(500)).subscribe((loading) => {
+        expect(loading.length).toEqual(1);
+        expect(loading).toEqual([true]);
+        done();
+      });
+
+      localService.ngOnDestroy();
     });
   });
 

--- a/projects/auth0-angular/src/lib/auth.service.spec.ts
+++ b/projects/auth0-angular/src/lib/auth.service.spec.ts
@@ -38,8 +38,8 @@ describe('AuthService', () => {
     spyOn(auth0Client, 'loginWithPopup').and.resolveTo();
     spyOn(auth0Client, 'checkSession').and.resolveTo();
     spyOn(auth0Client, 'isAuthenticated').and.resolveTo(false);
-    spyOn(auth0Client, 'getUser').and.resolveTo(null);
-    spyOn(auth0Client, 'getIdTokenClaims').and.resolveTo(null);
+    spyOn(auth0Client, 'getUser').and.resolveTo(undefined);
+    spyOn(auth0Client, 'getIdTokenClaims').and.resolveTo(undefined);
     spyOn(auth0Client, 'logout');
     spyOn(auth0Client, 'getTokenSilently').and.resolveTo('__access_token__');
 
@@ -82,7 +82,7 @@ describe('AuthService', () => {
     });
 
     it('should set isLoading$ in the correct sequence', (done) => {
-      const values = [];
+      const values: boolean[] = [];
 
       service.isLoading$.subscribe((loading) => {
         values.push(loading);

--- a/projects/auth0-angular/src/lib/auth.service.ts
+++ b/projects/auth0-angular/src/lib/auth.service.ts
@@ -45,12 +45,12 @@ import { AuthClientConfig } from './auth.config';
   providedIn: 'root',
 })
 export class AuthService implements OnDestroy {
-  private isLoadingSubject$ = new BehaviorSubject(true);
+  private isLoadingSubject$ = new BehaviorSubject<boolean>(true);
   private errorSubject$ = new ReplaySubject<Error>(1);
-  private refreshState$ = new Subject();
+  private refreshState$ = new Subject<void>();
 
   // https://stackoverflow.com/a/41177163
-  private ngUnsubscribe$ = new Subject();
+  private ngUnsubscribe$ = new Subject<void>();
   /**
    * Emits boolean values indicating the loading state of the SDK.
    */

--- a/projects/playground/src/app/app.component.spec.ts
+++ b/projects/playground/src/app/app.component.spec.ts
@@ -9,7 +9,7 @@ describe('AppComponent', () => {
   let authMock: AuthService;
   let fixture: ComponentFixture<AppComponent>;
   let component: AppComponent;
-  let ne;
+  let ne: HTMLElement;
 
   beforeEach(() => {
     authMock = jasmine.createSpyObj(
@@ -52,18 +52,20 @@ describe('AppComponent', () => {
 
     it('should render title', () => {
       const h1 = ne.querySelector('h1');
-      expect(h1.textContent).toContain('AUTH0 ANGULAR PLAYGROUND');
+      expect(h1?.textContent).toContain('AUTH0 ANGULAR PLAYGROUND');
     });
 
     it('should render SDK loading status', () => {
       const loadingIndicator = ne.querySelector('p.status-indicator');
-      expect(loadingIndicator.textContent).toContain('SDK initialized = false');
+      expect(loadingIndicator?.textContent).toContain(
+        'SDK initialized = false'
+      );
 
       const loading = authMock.isLoading$ as BehaviorSubject<boolean>;
       loading.next(false);
       fixture.detectChanges();
 
-      expect(loadingIndicator.textContent).toContain('SDK initialized = true');
+      expect(loadingIndicator?.textContent).toContain('SDK initialized = true');
     });
 
     it('should show controls when SDK finishes loading', () => {
@@ -82,9 +84,7 @@ describe('AppComponent', () => {
   describe('when user is authenticated', () => {
     beforeEach(() => {
       const loading = authMock.isLoading$ as BehaviorSubject<boolean>;
-      const authenticated = authMock.isAuthenticated$ as BehaviorSubject<
-        boolean
-      >;
+      const authenticated = authMock.isAuthenticated$ as BehaviorSubject<boolean>;
       const user = authMock.user$ as BehaviorSubject<any>;
 
       loading.next(false);
@@ -111,7 +111,7 @@ describe('AppComponent', () => {
       form.localOnly.setValue(false);
       form.federated.setValue(false);
 
-      const btnLogout = ne.querySelector('#logout');
+      const btnLogout = ne.querySelector('#logout') as HTMLButtonElement;
       btnLogout.click();
       fixture.detectChanges();
 
@@ -127,7 +127,7 @@ describe('AppComponent', () => {
       form.localOnly.setValue(false);
       form.federated.setValue(true);
 
-      const btnLogout = ne.querySelector('#logout');
+      const btnLogout = ne.querySelector('#logout') as HTMLButtonElement;
       btnLogout.click();
       fixture.detectChanges();
 
@@ -143,7 +143,7 @@ describe('AppComponent', () => {
       form.localOnly.setValue(true);
       form.federated.setValue(false);
 
-      const btnLogout = ne.querySelector('#logout');
+      const btnLogout = ne.querySelector('#logout') as HTMLButtonElement;
       btnLogout.click();
       fixture.detectChanges();
 
@@ -156,27 +156,29 @@ describe('AppComponent', () => {
 
     it('should show user profile', () => {
       const divProfile = ne.querySelectorAll('.artifacts-wrapper .artifact')[0];
-      expect(divProfile.querySelector('p').textContent).toContain(
+      expect(divProfile.querySelector('p')?.textContent).toContain(
         'User Profile: Subset of the ID token claims'
       );
       const userValue = JSON.parse(
-        divProfile.querySelector('textarea').textContent
+        divProfile.querySelector('textarea')?.textContent ?? ''
       );
       expect(userValue).toEqual({ name: 'John', lastname: 'Doe' });
     });
 
     it('should show empty access token by default', () => {
       const divToken = ne.querySelectorAll('.artifacts-wrapper .artifact')[1];
-      expect(divToken.querySelector('p').textContent).toContain(
+      expect(divToken.querySelector('p')?.textContent).toContain(
         'Access Token: Select a mode and click the button to retrieve the token.'
       );
-      const tokenContent = divToken.querySelector('textarea').textContent;
+      const tokenContent = divToken.querySelector('textarea')?.textContent;
       expect(tokenContent).toEqual('');
     });
 
     it('should get access token silently', () => {
       const divToken = ne.querySelectorAll('.artifacts-wrapper .artifact')[1];
-      expect(divToken.querySelector('p').textContent).toContain('Access Token');
+      expect(divToken.querySelector('p')?.textContent).toContain(
+        'Access Token'
+      );
       const form = component.accessTokenOptionsForm.controls;
       form.usePopup.setValue(false);
       (authMock.getAccessTokenSilently as jasmine.Spy).and.returnValue(
@@ -184,20 +186,22 @@ describe('AppComponent', () => {
       );
 
       const btnRefresh = divToken.querySelector('button');
-      btnRefresh.click();
+      btnRefresh?.click();
       fixture.detectChanges();
 
       expect(authMock.getAccessTokenSilently).toHaveBeenCalledWith({
         ignoreCache: false,
       });
       console.log(divToken.querySelector('textarea'));
-      const tokenContent = divToken.querySelector('textarea').textContent;
+      const tokenContent = divToken.querySelector('textarea')?.textContent;
       expect(tokenContent).toEqual('access token silently');
     });
 
     it('should get access token silently', () => {
       const divToken = ne.querySelectorAll('.artifacts-wrapper .artifact')[1];
-      expect(divToken.querySelector('p').textContent).toContain('Access Token');
+      expect(divToken.querySelector('p')?.textContent).toContain(
+        'Access Token'
+      );
       const form = component.accessTokenOptionsForm.controls;
       form.usePopup.setValue(false);
       form.ignoreCache.setValue(false);
@@ -206,20 +210,22 @@ describe('AppComponent', () => {
       );
 
       const btnRefresh = divToken.querySelector('button');
-      btnRefresh.click();
+      btnRefresh?.click();
       fixture.detectChanges();
 
       expect(authMock.getAccessTokenSilently).toHaveBeenCalledWith({
         ignoreCache: false,
       });
       console.log(divToken.querySelector('textarea'));
-      const tokenContent = divToken.querySelector('textarea').textContent;
+      const tokenContent = divToken.querySelector('textarea')?.textContent;
       expect(tokenContent).toEqual('access token silently');
     });
 
     it('should get access token silently ignoring cache', () => {
       const divToken = ne.querySelectorAll('.artifacts-wrapper .artifact')[1];
-      expect(divToken.querySelector('p').textContent).toContain('Access Token');
+      expect(divToken.querySelector('p')?.textContent).toContain(
+        'Access Token'
+      );
       const form = component.accessTokenOptionsForm.controls;
       form.usePopup.setValue(false);
       form.ignoreCache.setValue(true);
@@ -228,20 +234,22 @@ describe('AppComponent', () => {
       );
 
       const btnRefresh = divToken.querySelector('button');
-      btnRefresh.click();
+      btnRefresh?.click();
       fixture.detectChanges();
 
       expect(authMock.getAccessTokenSilently).toHaveBeenCalledWith({
         ignoreCache: true,
       });
       console.log(divToken.querySelector('textarea'));
-      const tokenContent = divToken.querySelector('textarea').textContent;
+      const tokenContent = divToken.querySelector('textarea')?.textContent;
       expect(tokenContent).toEqual('access token silently');
     });
 
     it('should get access token with popup', () => {
       const divToken = ne.querySelectorAll('.artifacts-wrapper .artifact')[1];
-      expect(divToken.querySelector('p').textContent).toContain('Access Token');
+      expect(divToken.querySelector('p')?.textContent).toContain(
+        'Access Token'
+      );
       const form = component.accessTokenOptionsForm.controls;
       form.usePopup.setValue(true);
       (authMock.getAccessTokenWithPopup as jasmine.Spy).and.returnValue(
@@ -249,11 +257,11 @@ describe('AppComponent', () => {
       );
 
       const btnRefresh = divToken.querySelector('button');
-      btnRefresh.click();
+      btnRefresh?.click();
       fixture.detectChanges();
 
       expect(authMock.getAccessTokenWithPopup).toHaveBeenCalledWith();
-      const tokenContent = divToken.querySelector('textarea').textContent;
+      const tokenContent = divToken.querySelector('textarea')?.textContent;
       expect(tokenContent).toEqual('access token popup');
     });
   });
@@ -261,9 +269,7 @@ describe('AppComponent', () => {
   describe('when user is not authenticated', () => {
     beforeEach(() => {
       const loading = authMock.isLoading$ as BehaviorSubject<boolean>;
-      const authenticated = authMock.isAuthenticated$ as BehaviorSubject<
-        boolean
-      >;
+      const authenticated = authMock.isAuthenticated$ as BehaviorSubject<boolean>;
 
       loading.next(false);
       authenticated.next(false);
@@ -288,8 +294,8 @@ describe('AppComponent', () => {
       const form = component.loginOptionsForm.controls;
       form.usePopup.setValue(false);
 
-      const btnRefresh = wrapLogin.querySelector('button');
-      btnRefresh.click();
+      const btnRefresh = wrapLogin?.querySelector('button');
+      btnRefresh?.click();
       fixture.detectChanges();
 
       expect(authMock.loginWithRedirect).toHaveBeenCalledWith();
@@ -300,8 +306,8 @@ describe('AppComponent', () => {
       const form = component.loginOptionsForm.controls;
       form.usePopup.setValue(true);
 
-      const btnRefresh = wrapLogin.querySelector('button');
-      btnRefresh.click();
+      const btnRefresh = wrapLogin?.querySelector('button');
+      btnRefresh?.click();
       fixture.detectChanges();
 
       expect(authMock.loginWithPopup).toHaveBeenCalledWith();

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -3,6 +3,10 @@
   "compilerOptions": {
     "baseUrl": "./",
     "outDir": "./dist/out-tsc",
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
     "sourceMap": true,
     "declaration": false,
     "downlevelIteration": true,
@@ -12,7 +16,7 @@
     "target": "es2015",
     "module": "es2020",
     "lib": [
-      "es2018",
+      "es2018", 
       "dom"
     ],
     "paths": {

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -16,7 +16,7 @@
     "target": "es2015",
     "module": "es2020",
     "lib": [
-      "es2018", 
+      "es2018",
       "dom"
     ],
     "paths": {


### PR DESCRIPTION
### Description

Enable strict TS options.
Set them to the same values that Angular sets during creating a new project via `ng new`.
I fixed new type errors + add generics for better type checking

### References

https://blog.angular.io/angular-cli-strict-mode-c94ba5965f63
https://angular.io/guide/strict-mode

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `master`
