### PR TITLE
Update State when error occurs while getting token

### DIFF
--- a/projects/auth0-angular/src/lib/auth.service.ts
+++ b/projects/auth0-angular/src/lib/auth.service.ts
@@ -251,6 +251,7 @@ export class AuthService implements OnDestroy {
       tap(() => this.refreshState$.next()),
       catchError((error) => {
         this.errorSubject$.next(error);
+        this.refreshState$.next();
         return throwError(error);
       })
     );
@@ -276,6 +277,7 @@ export class AuthService implements OnDestroy {
       tap(() => this.refreshState$.next()),
       catchError((error) => {
         this.errorSubject$.next(error);
+        this.refreshState$.next();
         return throwError(error);
       })
     );


### PR DESCRIPTION
In the situation where getting an access token fails because the refresh token is expired and/or the session with Auth0 is also expired, the SDK throws a login required message but the state still reflects as if the user is authenticated.

This PR ensures that on every error, the Angular SDK retrieves the state (isAuthenticated, user and idTokenClaims) from the SPA JS SDK to guarantee the observables (`isAuthenticated$`, `user$`, `idTokenClaims$`) reflect the correct state.

You can test this in our playground as follows:

- Ensure both refresh tokens and auth0 login session expires after 3 minutes
- Login
- Wait 3 minutes
- Try to get a new token

Before this PR, the UI would still look as if the user is authenticated because the isAuthenticated$ observable still shows true.
After this PR the UI will look as if the user is not authenticated.