### PR TITLE
Update Readme regarding dynamic configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -339,7 +339,9 @@ ngOnInit() {
 
 ### Dynamic Configuration
 
-Instead of using `AuthModule.forRoot` to specify auth configuration, you can provide a factory function using `APP_INITIALIZER` to load your config from an external source before the auth module is loaded, and provide your configuration using `AuthClientConfig.set`:
+Instead of using `AuthModule.forRoot` to specify auth configuration, you can provide a factory function using `APP_INITIALIZER` to load your config from an external source before the auth module is loaded, and provide your configuration using `AuthClientConfig.set`.
+
+The configuration will only be used initially when the SDK is instantiated. Any changes made to the configuration at a later moment in time will have no effect on the default options used when calling the SDK's methods. This is also the reason why the dynamic configuration should be set using an `APP_INITIALIZER`, because doing so ensures the configuration is available prior to instantiating the SDK.
 
 > :information_source: Any request made through an instance of `HttpClient` that got instantiated by Angular, will use all of the configured interceptors, including our `AuthHttpInterceptor`. Because the `AuthHttpInterceptor` requires the existence of configuration settings, the request for retrieving those dynamic configuration settings should ensure it's not using any of those interceptors. In Angular, this can be done by manually instantiating `HttpClient` using an injected `HttpBackend` instance.
 


### PR DESCRIPTION
As being reported in https://github.com/auth0/auth0-angular/issues/117, the API for setting the dynamic configuration can be a bit confusing as users might think it supports runtime changes to the config, which isn't the case.

This PR adds a small section to the readme about this.