### PR TITLE
Fix incorrect usage of Promise to Observable conversion

### DIFF
--- a/projects/auth0-angular/src/lib/auth.guard.spec.ts
+++ b/projects/auth0-angular/src/lib/auth.guard.spec.ts
@@ -22,7 +22,9 @@ describe('AuthGuard', () => {
     it('should redirect a logged out user', () => {
       const authServiceMock: any = {
         isAuthenticated$: of(false),
-        loginWithRedirect: jasmine.createSpy('loginWithRedirect'),
+        loginWithRedirect: jasmine
+          .createSpy('loginWithRedirect')
+          .and.returnValue(of()),
       };
       guard = new AuthGuard(authServiceMock);
       guard.canActivate(routeMock, routeStateMock).subscribe();
@@ -48,7 +50,9 @@ describe('AuthGuard', () => {
     it('should redirect a logged out user', () => {
       const authServiceMock: any = {
         isAuthenticated$: of(false),
-        loginWithRedirect: jasmine.createSpy('loginWithRedirect'),
+        loginWithRedirect: jasmine
+          .createSpy('loginWithRedirect')
+          .and.returnValue(of()),
       };
       guard = new AuthGuard(authServiceMock);
       guard.canActivateChild(routeMock, routeStateMock).subscribe();

--- a/projects/auth0-angular/src/lib/auth.guard.ts
+++ b/projects/auth0-angular/src/lib/auth.guard.ts
@@ -9,7 +9,7 @@ import {
   CanActivateChild,
 } from '@angular/router';
 import { Observable, of } from 'rxjs';
-import { tap, take } from 'rxjs/operators';
+import { take, mergeMap, mapTo } from 'rxjs/operators';
 import { AuthService } from './auth.service';
 
 @Injectable({
@@ -40,9 +40,11 @@ export class AuthGuard implements CanActivate, CanLoad, CanActivateChild {
     state: RouterStateSnapshot
   ): Observable<boolean> {
     return this.auth.isAuthenticated$.pipe(
-      tap((loggedIn) => {
+      mergeMap((loggedIn) => {
         if (!loggedIn) {
-          this.auth.loginWithRedirect({ appState: { target: state.url } });
+          return this.auth
+            .loginWithRedirect({ appState: { target: state.url } })
+            .pipe(mapTo(false));
         } else {
           return of(true);
         }

--- a/projects/auth0-angular/src/lib/auth.service.spec.ts
+++ b/projects/auth0-angular/src/lib/auth.service.spec.ts
@@ -95,21 +95,15 @@ describe('AuthService', () => {
     });
 
     it('should not set isLoading when service destroyed before checkSession finished', (done) => {
-      (auth0Client.checkSession as jasmine.Spy).and.callFake(() => {
-        return new Promise((resolve) => setTimeout(resolve, 20));
-      });
-
       const localService = createService();
 
-      localService.ngOnDestroy();
-
-      localService.isLoading$.pipe(bufferTime(25)).subscribe((loading) => {
+      localService.isLoading$.pipe(bufferTime(500)).subscribe((loading) => {
         expect(loading.length).toEqual(1);
         expect(loading).toEqual([true]);
         done();
-
-        (auth0Client.checkSession as jasmine.Spy).and.resolveTo();
       });
+
+      localService.ngOnDestroy();
     });
   });
 

--- a/projects/auth0-angular/src/lib/auth.service.spec.ts
+++ b/projects/auth0-angular/src/lib/auth.service.spec.ts
@@ -422,7 +422,7 @@ describe('AuthService', () => {
       (auth0Client.isAuthenticated as jasmine.Spy).calls.reset();
       (auth0Client.isAuthenticated as jasmine.Spy).and.resolveTo(true);
 
-      service.loginWithPopup();
+      service.loginWithPopup().subscribe();
 
       service.isAuthenticated$.subscribe((authenticated) => {
         if (authenticated) {
@@ -444,7 +444,7 @@ describe('AuthService', () => {
       (auth0Client.isAuthenticated as jasmine.Spy).calls.reset();
       (auth0Client.isAuthenticated as jasmine.Spy).and.resolveTo(true);
 
-      service.loginWithPopup(options, config);
+      service.loginWithPopup(options, config).subscribe();
 
       service.isAuthenticated$.subscribe((authenticated) => {
         if (authenticated) {

--- a/projects/playground/src/app/app.component.spec.ts
+++ b/projects/playground/src/app/app.component.spec.ts
@@ -15,11 +15,11 @@ describe('AppComponent', () => {
     authMock = jasmine.createSpyObj(
       'AuthService',
       {
-        loginWithRedirect: jasmine.createSpy().and.returnValue(null),
-        loginWithPopup: jasmine.createSpy().and.returnValue(null),
+        loginWithRedirect: jasmine.createSpy(),
+        loginWithPopup: jasmine.createSpy(),
         logout: jasmine.createSpy().and.returnValue(null),
-        getAccessTokenSilently: jasmine.createSpy().and.returnValue(null),
-        getAccessTokenWithPopup: jasmine.createSpy().and.returnValue(null),
+        getAccessTokenSilently: jasmine.createSpy(),
+        getAccessTokenWithPopup: jasmine.createSpy(),
       },
       {
         user$: new BehaviorSubject(null),
@@ -27,6 +27,11 @@ describe('AppComponent', () => {
         isAuthenticated$: new BehaviorSubject(false),
       }
     ) as any;
+
+    (authMock.loginWithRedirect as jasmine.Spy).and.returnValue(of(null));
+    (authMock.loginWithPopup as jasmine.Spy).and.returnValue(of(null));
+    (authMock.getAccessTokenSilently as jasmine.Spy).and.returnValue(of(null));
+    (authMock.getAccessTokenWithPopup as jasmine.Spy).and.returnValue(of(null));
 
     TestBed.configureTestingModule({
       imports: [RouterTestingModule, ReactiveFormsModule],
@@ -82,9 +87,7 @@ describe('AppComponent', () => {
   describe('when user is authenticated', () => {
     beforeEach(() => {
       const loading = authMock.isLoading$ as BehaviorSubject<boolean>;
-      const authenticated = authMock.isAuthenticated$ as BehaviorSubject<
-        boolean
-      >;
+      const authenticated = authMock.isAuthenticated$ as BehaviorSubject<boolean>;
       const user = authMock.user$ as BehaviorSubject<any>;
 
       loading.next(false);
@@ -261,9 +264,7 @@ describe('AppComponent', () => {
   describe('when user is not authenticated', () => {
     beforeEach(() => {
       const loading = authMock.isLoading$ as BehaviorSubject<boolean>;
-      const authenticated = authMock.isAuthenticated$ as BehaviorSubject<
-        boolean
-      >;
+      const authenticated = authMock.isAuthenticated$ as BehaviorSubject<boolean>;
 
       loading.next(false);
       authenticated.next(false);

--- a/projects/playground/src/app/app.component.ts
+++ b/projects/playground/src/app/app.component.ts
@@ -41,9 +41,9 @@ export class AppComponent {
   launchLogin(): void {
     const usePopup = this.loginOptionsForm.value.usePopup === true;
     if (usePopup) {
-      this.auth.loginWithPopup();
+      this.auth.loginWithPopup().subscribe();
     } else {
-      this.auth.loginWithRedirect();
+      this.auth.loginWithRedirect().subscribe();
     }
   }
 


### PR DESCRIPTION
It looks like our Angular SDK has unexpected behavior when using Promises and converting them to Observables.

There is an interesting blog post on dev.to about this subject: https://dev.to/frederikprijck/converting-a-promise-into-an-observable-dag.

In general, the following code (see https://stackblitz.com/edit/rxjs-zhr6vz):

```
someFunctionReturningPromise(): Promise<any> {
  return new Promise((resolve, reject) => {
    console.log('Promise resolved')
    resolve();
  });
}
someFunction(): Observable<any> {
  return from(someFunctionReturningPromise());
}

someFunction(); // logs 'Promise resolved'
```

As you can see in the stackblitz, you can see the promise is resolved before a subscription is added to the observable. That's unexpected when working with Observables, an observable isn't supposed to trigger anything if no one subscribes.

This is where the defer comes into play, the following code will not resolve the promise (see https://stackblitz.com/edit/rxjs-yh63ce):

```
someFunctionReturningPromise(): Promise<any> {
  return new Promise((resolve, reject) => {
    console.log('Promise resolved')
    resolve();
  });
}
someFunction(): Observable<any> {
  return defer(() => from(someFunctionReturningPromise()));
}

someFunction(); // does not log 'Promise resolved'
```
As soon as we now replace `someFunction()` with `someFunction().subscribe()`, the promise will be resolved.

**Note**: This could be considered a breaking change, as people could have been relying on the fact that using `this.authService.loginWithRedirect()` works without subscribing. Therefor I want to open this PR as a matter of discussion first, we can see how we proceed with this.

@stevehobbsdev and @lbalmaceda , I would love to get your input on this.