### PR TITLE
Only emit user$ and idTokenClaims$ when login, logout or token changed

### DIFF
--- a/projects/auth0-angular/src/lib/auth.service.ts
+++ b/projects/auth0-angular/src/lib/auth.service.ts
@@ -34,6 +34,7 @@ import {
   catchError,
   switchMap,
   mergeMap,
+  scan,
 } from 'rxjs/operators';
 
 import { Auth0ClientService } from './auth.client';
@@ -48,6 +49,7 @@ export class AuthService implements OnDestroy {
   private isLoadingSubject$ = new BehaviorSubject<boolean>(true);
   private errorSubject$ = new ReplaySubject<Error>(1);
   private refreshState$ = new Subject<void>();
+  private accessToken$ = new ReplaySubject<string>(1);
 
   // https://stackoverflow.com/a/41177163
   private ngUnsubscribe$ = new Subject<void>();
@@ -58,21 +60,39 @@ export class AuthService implements OnDestroy {
 
   /**
    * Trigger used to pull User information from the Auth0Client.
+   * Triggers when the access token has changed.
+   */
+  private accessTokenTrigger$ = this.accessToken$.pipe(
+    scan(
+      (
+        acc: { current: string | null; previous: string | null },
+        current: string | null
+      ) => {
+        return {
+          previous: acc.current,
+          current,
+        };
+      },
+      { current: null, previous: null }
+    ),
+    filter(({ previous, current }) => previous !== current)
+  );
+
+  /**
+   * Trigger used to pull User information from the Auth0Client.
    * Triggers when an event occurs that needs to retrigger the User Profile information.
-   * Such as: Initially, getAccessTokenSilently, getAccessTokenWithPopup and Logout
+   * Events: Access Token change and Logout
    */
   private isAuthenticatedTrigger$ = this.isLoading$.pipe(
     filter((loading) => !loading),
     distinctUntilChanged(),
     switchMap(() =>
       // To track the value of isAuthenticated over time, we need to merge:
-      //  - the current value
+      //  - the value whenever the access token changes. (this should always be true of there is an access token
+      //    but it is safer to pass this through this.auth0Client.isAuthenticated() nevertheless)
       //  - the value whenever refreshState$ emits
-      merge(
-        defer(() => this.auth0Client.isAuthenticated()),
-        this.refreshState$.pipe(
-          mergeMap(() => this.auth0Client.isAuthenticated())
-        )
+      merge(this.accessTokenTrigger$, this.refreshState$).pipe(
+        mergeMap(() => this.auth0Client.isAuthenticated())
       )
     )
   );
@@ -118,7 +138,9 @@ export class AuthService implements OnDestroy {
       iif(
         () => isCallback,
         this.handleRedirectCallback(),
-        defer(() => this.auth0Client.checkSession())
+        defer(() => this.auth0Client.checkSession()).pipe(
+          mergeMap(() => this.getAccessTokenSilently(/* { cacheOnly: true } */))
+        )
       );
 
     this.shouldHandleCallback()
@@ -186,10 +208,9 @@ export class AuthService implements OnDestroy {
     options?: PopupLoginOptions,
     config?: PopupConfigOptions
   ): Observable<void> {
-    return from(
-      this.auth0Client.loginWithPopup(options, config).then(() => {
-        this.refreshState$.next();
-      })
+    return from(this.auth0Client.loginWithPopup(options, config)).pipe(
+      mergeMap(() => this.getAccessTokenSilently(/* { cacheOnly: true } */)),
+      mergeMap(() => of<void>())
     );
   }
 
@@ -248,7 +269,7 @@ export class AuthService implements OnDestroy {
   ): Observable<string> {
     return of(this.auth0Client).pipe(
       concatMap((client) => client.getTokenSilently(options)),
-      tap(() => this.refreshState$.next()),
+      tap((token) => this.accessToken$.next(token)),
       catchError((error) => {
         this.errorSubject$.next(error);
         return throwError(error);
@@ -273,7 +294,7 @@ export class AuthService implements OnDestroy {
   ): Observable<string> {
     return of(this.auth0Client).pipe(
       concatMap((client) => client.getTokenWithPopup(options)),
-      tap(() => this.refreshState$.next()),
+      tap((token) => this.accessToken$.next(token)),
       catchError((error) => {
         this.errorSubject$.next(error);
         return throwError(error);


### PR DESCRIPTION
Instead of always retriggering `user$` and `idTokenClaims$` whenever the user calls `getTokenSilently` or `getTokenWithPopup`, this PR ensures we only re-emit the user and claims when the token is changed. 

Even tho the code is using the Access Token and the information is pulled freon the ID Token, ads long as the Access Token hasn't changed, neither should the ID Token.

This isn't a perfect solution yet, but I think it's as close as we can get for now to avoid excessive emits on the observables.

Closes #105

This PR also solves an infinite loop that is explained here: https://community.auth0.com/t/infinite-requests-when-piping-auth-user-in-angular-auth-o/57136/2