### PR TITLE
Remove unnecessary returns from tap

### DIFF
--- a/projects/auth0-angular/src/lib/auth.guard.ts
+++ b/projects/auth0-angular/src/lib/auth.guard.ts
@@ -8,7 +8,7 @@ import {
   UrlSegment,
   CanActivateChild,
 } from '@angular/router';
-import { Observable, of } from 'rxjs';
+import { Observable } from 'rxjs';
 import { tap, take } from 'rxjs/operators';
 import { AuthService } from './auth.service';
 
@@ -42,11 +42,9 @@ export class AuthGuard implements CanActivate, CanLoad, CanActivateChild {
     return this.auth.isAuthenticated$.pipe(
       tap((loggedIn) => {
         if (!loggedIn) {
-          return this.auth.loginWithRedirect({
+          this.auth.loginWithRedirect({
             appState: { target: state.url },
           });
-        } else {
-          return of(true);
         }
       })
     );


### PR DESCRIPTION
### Description

Removing unused code.

Correct me if I'm wrong, but there is no point returning anything from `tap` in rxjs as the returned observable is always going to be the identical to the source observable anyway.

So I thought this bit of code returning `of(true)`, although not harmful, was just confusing.

### References

https://rxjs-dev.firebaseapp.com/api/operators/tap

### Testing

No tests have been added because this change doesn't add any functionality or even fix any bug. The change should have no effect other than make the library a tiny bit smaller and easier to understand.

This change can be tested by making sure the auth guards continue to work as expected.

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `master`
