### PR TITLE
[SDK-2482] Add allowAnonymous option to HttpInterceptor config

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,6 +243,8 @@ If an HTTP call is made using `HttpClient` and there is no match in this configu
 
 **Note:** We do this to help prevent tokens being unintentionally attached to requests to the wrong recipient, which is a serious security issue. Those recipients could then use that token to call the API as if it were your application.
 
+In the event that requests should be made available for both anonymous and authenticated users, the `allowAnonymous` property can be set to `true`. When omitted, or set to `false`, requests that match the configuration, will not be executed when there is no access token available.
+
 Here are some examples:
 
 ```js
@@ -262,6 +264,12 @@ AuthModule.forRoot({
 
       // Attach access tokens to any calls that start with '/api/'
       '/api/*',
+
+      // Match anything starting with /api/products, but also allow for anonymous users.
+      {
+        uri: '/api/products/*',
+        allowAnonymous: true,
+      },
 
       // Match anything starting with /api/accounts, but also specify the audience and scope the attached
       // access token must have

--- a/projects/auth0-angular/src/lib/auth.config.ts
+++ b/projects/auth0-angular/src/lib/auth.config.ts
@@ -85,6 +85,13 @@ export interface HttpInterceptorRouteConfig {
    * The HTTP method name is case-sensitive.
    */
   httpMethod?: HttpMethod | string;
+
+  /**
+   * Allow the HTTP call to be executed anonymously, when no token is available.
+   *
+   * When omitted (or set to false), calls that match the configuration will fail when no token is available.
+   */
+  allowAnonymous?: boolean;
 }
 
 /**

--- a/projects/auth0-angular/src/lib/auth.interceptor.spec.ts
+++ b/projects/auth0-angular/src/lib/auth.interceptor.spec.ts
@@ -215,12 +215,14 @@ describe('The Auth HTTP Interceptor', () => {
       done: () => void
     ) => {
       (authService.getAccessTokenSilently as jasmine.Spy).and.returnValue(
-        throwError('ERROR')
+        throwError({ error: 'login_required' })
       );
 
       httpClient
         .request('get', '/api/calendar')
-        .subscribe({ error: (err) => expect(err).toBe('ERROR') });
+        .subscribe({
+          error: (err) => expect(err).toEqual({ error: 'login_required' }),
+        });
 
       httpTestingController.expectNone('/api/calendar');
       flush();
@@ -230,7 +232,7 @@ describe('The Auth HTTP Interceptor', () => {
       done: () => void
     ) => {
       (authService.getAccessTokenSilently as jasmine.Spy).and.returnValue(
-        throwError('ERROR')
+        throwError({ error: 'login_required' })
       );
 
       assertPassThruApiCallTo('/api/orders', done);

--- a/projects/auth0-angular/src/lib/auth.interceptor.ts
+++ b/projects/auth0-angular/src/lib/auth.interceptor.ts
@@ -156,11 +156,11 @@ export class AuthHttpInterceptor implements HttpInterceptor {
     );
   }
 
-  private allowAnonymous(route: ApiRouteDefinition | null, err: any) {
+  private allowAnonymous(route: ApiRouteDefinition | null, err: any): boolean {
     return (
-      route &&
+      !!route &&
       isHttpInterceptorRouteConfig(route) &&
-      route.allowAnonymous &&
+      !!route.allowAnonymous &&
       ['login_required', 'consent_required'].includes(err.error)
     );
   }

--- a/projects/auth0-angular/src/lib/auth.interceptor.ts
+++ b/projects/auth0-angular/src/lib/auth.interceptor.ts
@@ -47,11 +47,7 @@ export class AuthHttpInterceptor implements HttpInterceptor {
             concatMap<GetTokenSilentlyOptions, Observable<string>>((options) =>
               this.authService.getAccessTokenSilently(options).pipe(
                 catchError((err) => {
-                  if (
-                    route &&
-                    isHttpInterceptorRouteConfig(route) &&
-                    route.allowAnonymous
-                  ) {
+                  if (this.allowAnonymous(route, err)) {
                     return of('');
                   }
 
@@ -157,6 +153,15 @@ export class AuthHttpInterceptor implements HttpInterceptor {
   ): Observable<ApiRouteDefinition | null> {
     return from(config.allowedList).pipe(
       first((route) => this.canAttachToken(route, request), null)
+    );
+  }
+
+  private allowAnonymous(route: ApiRouteDefinition | null, err: any) {
+    return (
+      route &&
+      isHttpInterceptorRouteConfig(route) &&
+      route.allowAnonymous &&
+      ['login_required', 'consent_required'].includes(err.error)
     );
   }
 }


### PR DESCRIPTION
By submitting a PR to this repository, you agree to the terms within the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/auth0/.github/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo.

### Description

This PR adds the `allowAnonymous` property to the `HttpInterceptor` configuration. 

Before this PR, any request that matches any of the configuration, will not be executed in the event that there is no access token available (e.g. `getTokenSilently` throws).

After the PR, users can set the `allowAnonymous` property to true, allowing for matching requests to still be executed in the event that there is no access token available (e.g. `getTokenSilently` throws `login_required`).

### References
https://github.com/auth0/auth0-angular/issues/140

### Testing

- Add interceptor configuration for `/url`, without setting `allowAnonymous` 
- Make an Http call to `/url` when not authenicated, the request should **not show up** in the network tab
- Update the interceptor configuration for `url`, set `allowAnonymous` to `true`
- Make an Http call to `/url` when not authenicated, the request should **show up** in the network tab

- [x] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `master`
