### PR TITLE
[SDK-2542] Expose methods from Auth0 SPA SDK

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3619,6 +3619,16 @@
       "integrity": "sha512-1Yj8h9Q+QDF5FzhMs/c9+6UntbD5MkRfRwac8DoEm9ZfUBZ7tZ55YcGVAzEe4bXsdQHEk+s9S5wsOKVdZrw0tQ==",
       "dev": true
     },
+    "bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
     "blob": {
       "version": "0.0.5",
       "resolved": "https://registry.npmjs.org/blob/-/blob-0.0.5.tgz",
@@ -6611,6 +6621,13 @@
           }
         }
       }
+    },
+    "file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "dev": true,
+      "optional": true
     },
     "fill-range": {
       "version": "7.0.1",
@@ -9768,6 +9785,13 @@
       "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
       "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==",
       "dev": true
+    },
+    "nan": {
+      "version": "2.14.2",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.2.tgz",
+      "integrity": "sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ==",
+      "dev": true,
+      "optional": true
     },
     "nanomatch": {
       "version": "1.2.13",
@@ -15205,7 +15229,11 @@
           "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
           "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "bindings": "^1.5.0",
+            "nan": "^2.12.1"
+          }
         },
         "glob-parent": {
           "version": "3.1.0",
@@ -15878,7 +15906,11 @@
           "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
           "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "bindings": "^1.5.0",
+            "nan": "^2.12.1"
+          }
         },
         "glob-parent": {
           "version": "3.1.0",

--- a/projects/auth0-angular/src/lib/auth.service.spec.ts
+++ b/projects/auth0-angular/src/lib/auth.service.spec.ts
@@ -4,6 +4,7 @@ import { Auth0ClientService } from './auth.client';
 import {
   Auth0Client,
   IdToken,
+  LogoutUrlOptions,
   RedirectLoginOptions,
 } from '@auth0/auth0-spa-js';
 import { AbstractNavigator } from './abstract-navigator';
@@ -47,6 +48,7 @@ describe('AuthService', () => {
     spyOn(auth0Client, 'logout');
     spyOn(auth0Client, 'getTokenSilently').and.resolveTo('__access_token__');
     spyOn(auth0Client, 'buildAuthorizeUrl').and.resolveTo('/authorize');
+    spyOn(auth0Client, 'buildLogoutUrl').and.returnValue('/v2/logout');
 
     spyOn(auth0Client, 'getTokenWithPopup').and.resolveTo(
       '__access_token_from_popup__'
@@ -702,6 +704,18 @@ describe('AuthService', () => {
       service.buildAuthorizeUrl(options).subscribe((url) => {
         expect(url).toBeTruthy();
         expect(auth0Client.buildAuthorizeUrl).toHaveBeenCalledWith(options);
+        done();
+      });
+    });
+  });
+
+  describe('buildLogoutUrl', () => {
+    it('should call the underlying SDK', (done) => {
+      const options: LogoutUrlOptions = {};
+
+      service.buildLogoutUrl(options).subscribe((url) => {
+        expect(url).toBeTruthy();
+        expect(auth0Client.buildLogoutUrl).toHaveBeenCalledWith(options);
         done();
       });
     });

--- a/projects/auth0-angular/src/lib/auth.service.spec.ts
+++ b/projects/auth0-angular/src/lib/auth.service.spec.ts
@@ -47,7 +47,7 @@ describe('AuthService', () => {
       '__access_token_from_popup__'
     );
 
-    locationSpy = jasmine.createSpyObj('Location', ['path', 'replaceState']);
+    locationSpy = jasmine.createSpyObj('Location', ['path']);
     locationSpy.path.and.returnValue('');
 
     moduleSetup = {

--- a/projects/auth0-angular/src/lib/auth.service.spec.ts
+++ b/projects/auth0-angular/src/lib/auth.service.spec.ts
@@ -651,7 +651,7 @@ describe('AuthService', () => {
     it('should call the underlying SDK', (done) => {
       const localService = createService();
 
-      localService.handleRedirectCallback().subscribe((result) => {
+      localService.handleRedirectCallback().subscribe(() => {
         expect(auth0Client.handleRedirectCallback).toHaveBeenCalled();
         done();
       });
@@ -661,30 +661,30 @@ describe('AuthService', () => {
       const url = 'http://localhost';
       const localService = createService();
 
-      localService.handleRedirectCallback(url).subscribe((result) => {
+      localService.handleRedirectCallback(url).subscribe(() => {
         expect(auth0Client.handleRedirectCallback).toHaveBeenCalledWith(url);
         done();
       });
     });
 
-    fit('should refresh the internal state', (done) => {
+    it('should refresh the internal state', (done) => {
       const localService = createService();
 
-      localService.isLoading$.subscribe((loading) =>
-        console.log('loading observable', loading)
-      );
+      localService.isLoading$.subscribe((loading) => {
+        if (!loading) {
+          localService.isAuthenticated$
+            .pipe(bufferCount(2))
+            .subscribe((authenticatedStates) => {
+              expect(authenticatedStates).toEqual([false, true]);
+              expect(auth0Client.isAuthenticated).toHaveBeenCalled();
+              done();
+            });
 
-      // (auth0Client.isAuthenticated as jasmine.Spy).and.resolveTo(true);
+          (auth0Client.isAuthenticated as jasmine.Spy).and.resolveTo(true);
 
-      localService.isAuthenticated$.pipe(bufferCount(1)).subscribe((result) => {
-        console.log(result);
-        expect(auth0Client.isAuthenticated).toHaveBeenCalled();
-        done();
+          localService.handleRedirectCallback().subscribe();
+        }
       });
-
-      // localService.handleRedirectCallback().subscribe((result) => {
-      //   console.log('result', result);
-      // });
     });
   });
 });

--- a/projects/auth0-angular/src/lib/auth.service.spec.ts
+++ b/projects/auth0-angular/src/lib/auth.service.spec.ts
@@ -1,7 +1,11 @@
 import { TestBed } from '@angular/core/testing';
 import { AuthService } from './auth.service';
 import { Auth0ClientService } from './auth.client';
-import { Auth0Client, IdToken } from '@auth0/auth0-spa-js';
+import {
+  Auth0Client,
+  IdToken,
+  RedirectLoginOptions,
+} from '@auth0/auth0-spa-js';
 import { AbstractNavigator } from './abstract-navigator';
 import { bufferCount, bufferTime, filter, mergeMap, tap } from 'rxjs/operators';
 import { Location } from '@angular/common';
@@ -42,6 +46,7 @@ describe('AuthService', () => {
     spyOn(auth0Client, 'getIdTokenClaims').and.resolveTo(undefined);
     spyOn(auth0Client, 'logout');
     spyOn(auth0Client, 'getTokenSilently').and.resolveTo('__access_token__');
+    spyOn(auth0Client, 'buildAuthorizeUrl').and.resolveTo('/authorize');
 
     spyOn(auth0Client, 'getTokenWithPopup').and.resolveTo(
       '__access_token_from_popup__'
@@ -687,6 +692,18 @@ describe('AuthService', () => {
           mergeMap(() => localService.handleRedirectCallback())
         )
         .subscribe();
+    });
+  });
+
+  describe('buildAuthorizeUrl', () => {
+    it('should call the underlying SDK', (done) => {
+      const options: RedirectLoginOptions = {};
+
+      service.buildAuthorizeUrl(options).subscribe((url) => {
+        expect(url).toBeTruthy();
+        expect(auth0Client.buildAuthorizeUrl).toHaveBeenCalledWith(options);
+        done();
+      });
     });
   });
 });

--- a/projects/auth0-angular/src/lib/auth.service.ts
+++ b/projects/auth0-angular/src/lib/auth.service.ts
@@ -355,6 +355,19 @@ export class AuthService implements OnDestroy {
     return defer(() => this.auth0Client.buildAuthorizeUrl(options));
   }
 
+  /**
+   * ```js
+   * buildLogoutUrl().subscribe(url => ...)
+   * ```
+   * Builds a URL to the logout endpoint.
+   *
+   * @param options The options used to configure the parameters that appear in the logout endpoint URL.
+   * @returns a URL to the logout endpoint using the parameters provided as arguments.
+   */
+  buildLogoutUrl(options?: LogoutUrlOptions): Observable<string> {
+    return of(this.auth0Client.buildLogoutUrl(options));
+  }
+
   private shouldHandleCallback(): Observable<boolean> {
     return of(this.location.path()).pipe(
       map((search) => {

--- a/projects/auth0-angular/src/lib/auth.service.ts
+++ b/projects/auth0-angular/src/lib/auth.service.ts
@@ -327,7 +327,6 @@ export class AuthService implements OnDestroy {
     return defer(() => this.auth0Client.handleRedirectCallback(url)).pipe(
       withLatestFrom(this.isLoadingSubject$),
       tap(([result, isLoading]) => {
-        console.log('isLoading', isLoading);
         if (!isLoading) {
           this.refreshState$.next();
         }

--- a/projects/auth0-angular/src/lib/auth.service.ts
+++ b/projects/auth0-angular/src/lib/auth.service.ts
@@ -327,6 +327,7 @@ export class AuthService implements OnDestroy {
     return defer(() => this.auth0Client.handleRedirectCallback(url)).pipe(
       withLatestFrom(this.isLoadingSubject$),
       tap(([result, isLoading]) => {
+        console.log('isLoading', isLoading);
         if (!isLoading) {
           this.refreshState$.next();
         }

--- a/projects/auth0-angular/src/lib/auth.service.ts
+++ b/projects/auth0-angular/src/lib/auth.service.ts
@@ -9,6 +9,7 @@ import {
   GetTokenSilentlyOptions,
   GetTokenWithPopupOptions,
   RedirectLoginResult,
+  LogoutUrlOptions,
 } from '@auth0/auth0-spa-js';
 
 import {
@@ -337,6 +338,21 @@ export class AuthService implements OnDestroy {
       }),
       map(([result]) => result)
     );
+  }
+
+  /**
+   * ```js
+   * buildAuthorizeUrl().subscribe(url => ...)
+   * ```
+   *
+   * Builds an `/authorize` URL for loginWithRedirect using the parameters
+   * provided as arguments. Random and secure `state` and `nonce`
+   * parameters will be auto-generated.
+   * @param options The options
+   * @returns A URL to the authorize endpoint
+   */
+  buildAuthorizeUrl(options?: RedirectLoginOptions): Observable<string> {
+    return defer(() => this.auth0Client.buildAuthorizeUrl(options));
   }
 
   private shouldHandleCallback(): Observable<boolean> {

--- a/projects/auth0-angular/src/lib/auth.service.ts
+++ b/projects/auth0-angular/src/lib/auth.service.ts
@@ -311,20 +311,20 @@ export class AuthService implements OnDestroy {
     );
   }
 
-  private shouldHandleCallback(): Observable<boolean> {
-    return of(this.location.path()).pipe(
-      map((search) => {
-        return (
-          (search.includes('code=') || search.includes('error=')) &&
-          search.includes('state=') &&
-          !this.configFactory.get().skipRedirectCallback
-        );
-      })
-    );
-  }
-
-  handleRedirectCallback(): Observable<RedirectLoginResult> {
-    return defer(() => this.auth0Client.handleRedirectCallback()).pipe(
+  /**
+   * ```js
+   * handleRedirectCallback(url).subscribe(result => ...)
+   * ```
+   *
+   * After the browser redirects back to the callback page,
+   * call `handleRedirectCallback` to handle success and error
+   * responses from Auth0. If the response is successful, results
+   * will be valid according to their expiration times.
+   *
+   * @param url The URL to that should be used to retrieve the `state` and `code` values. Defaults to `window.location.href` if not given.
+   */
+  handleRedirectCallback(url?: string): Observable<RedirectLoginResult> {
+    return defer(() => this.auth0Client.handleRedirectCallback(url)).pipe(
       withLatestFrom(this.isLoadingSubject$),
       tap(([result, isLoading]) => {
         if (!isLoading) {
@@ -334,6 +334,18 @@ export class AuthService implements OnDestroy {
         this.navigator.navigateByUrl(target);
       }),
       map(([result]) => result)
+    );
+  }
+
+  private shouldHandleCallback(): Observable<boolean> {
+    return of(this.location.path()).pipe(
+      map((search) => {
+        return (
+          (search.includes('code=') || search.includes('error=')) &&
+          search.includes('state=') &&
+          !this.configFactory.get().skipRedirectCallback
+        );
+      })
     );
   }
 }

--- a/projects/auth0-angular/src/lib/auth.service.ts
+++ b/projects/auth0-angular/src/lib/auth.service.ts
@@ -321,6 +321,8 @@ export class AuthService implements OnDestroy {
    * responses from Auth0. If the response is successful, results
    * will be valid according to their expiration times.
    *
+   * Calling this method also refreshes the authentication and user states.
+   *
    * @param url The URL to that should be used to retrieve the `state` and `code` values. Defaults to `window.location.href` if not given.
    */
   handleRedirectCallback(url?: string): Observable<RedirectLoginResult> {

--- a/projects/auth0-angular/src/lib/auth.service.ts
+++ b/projects/auth0-angular/src/lib/auth.service.ts
@@ -35,6 +35,7 @@ import {
   switchMap,
   mergeMap,
   scan,
+  withLatestFrom,
 } from 'rxjs/operators';
 
 import { Auth0ClientService } from './auth.client';
@@ -322,12 +323,17 @@ export class AuthService implements OnDestroy {
     );
   }
 
-  private handleRedirectCallback(): Observable<RedirectLoginResult> {
+  handleRedirectCallback(): Observable<RedirectLoginResult> {
     return defer(() => this.auth0Client.handleRedirectCallback()).pipe(
-      tap((result) => {
+      withLatestFrom(this.isLoadingSubject$),
+      tap(([result, isLoading]) => {
+        if (!isLoading) {
+          this.refreshState$.next();
+        }
         const target = result?.appState?.target ?? '/';
         this.navigator.navigateByUrl(target);
-      })
+      }),
+      map(([result]) => result)
     );
   }
 }


### PR DESCRIPTION
This PR exposes the following methods from Auth0 SPA SDK so that the SDK can be used
in the context of an Ionic + Capacitor app, where calling this manually is
necessary in order to be able to handle the callback at the right time:

* `handleRedirectCallback`
* `buildAuthorizeUrl`
* `buildLogoutUrl`

Added unit tests for each.
