### PR TITLE
Replace integration test password with environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -513,7 +513,13 @@ Run `ng test` to execute the unit tests via [Karma](https://karma-runner.github.
 
 ### Running end-to-end tests
 
-Run `ng e2e` to execute the end-to-end tests via [Protractor](http://www.protractortest.org/).
+The end-to-end tests are executed using [Cypress](https://www.cypress.io/) against the built-in playground app.
+
+The E2E tests require that the user password be specified as an environment variable. This is already set up in the CI environment, but locally you can do:
+
+```
+CYPRESS_INTEGRATION_PASSWORD=<password> ng e2e
+```
 
 ### Running the playground app
 

--- a/projects/playground/e2e/integration/playground.spec.ts
+++ b/projects/playground/e2e/integration/playground.spec.ts
@@ -1,5 +1,5 @@
 const EMAIL = 'johnfoo+integration@gmail.com';
-const PASSWORD = '1234';
+const PASSWORD = Cypress.env('INTEGRATION_PASSWORD');
 
 const loginToAuth0 = () => {
   cy.get('.auth0-lock-form')


### PR DESCRIPTION
This PR removes the hard-coded user password for the integration tests and replaces with the environment variable `CYPRESS_INTEGRATION_PASSWORD`.

Additionally:

* The readme has been updated to include this requirement when running the tests locally
* The CI environment has been updated with this variable and correct value
