### PR TITLE
App State Observable

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ export class AppComponent {
   loginWithRedirect(): void {
     this.auth.loginWithRedirect({
       appState: {
-        // Specify which application state you would like to preserve here (yes, objects ARE allowed)
+        myValue: 'My State to Track',
       },
     });
   }
@@ -163,7 +163,7 @@ export class AppComponent {
 
   ngOnInit() {
     this.auth.appState$.subscribe((appState) => {
-      // Your value will be available here
+      console.log(appState.myValue);
     });
   }
 }

--- a/README.md
+++ b/README.md
@@ -121,58 +121,6 @@ On your template, provide a button that will allow the user to log in to the app
 </button>
 ```
 
-### Preserve application state through redirects
-
-To preserve application state through the redirect to Auth0 and the subsequent redirect back to your application (if the user authentications succesfully), you can pass in the state that you want preserved to the `loginWithRedirect` method:
-
-```ts
-import { Component } from '@angular/core';
-import { AuthService } from '@auth0/auth0-angular';
-
-@Component({
-  selector: 'app-root',
-  templateUrl: './app.component.html',
-  styleUrls: ['./app.component.css'],
-})
-export class AppComponent {
-  constructor(public auth: AuthService) {}
-
-  loginWithRedirect(): void {
-    this.auth.loginWithRedirect({
-      appState: {
-        myValue: 'My State to Track',
-      },
-    });
-  }
-}
-```
-
-After Auth0 redirects the user back to your application, you can access the stored state using the `appState$` observable on the `AuthService`:
-
-```ts
-import { Component, OnInit } from '@angular/core';
-import { AuthService } from '@auth0/auth0-angular';
-
-@Component({
-  selector: 'app-root',
-  templateUrl: './app.component.html',
-  styleUrls: ['./app.component.css'],
-})
-export class AppComponent {
-  constructor(public auth: AuthService) {}
-
-  ngOnInit() {
-    this.auth.appState$.subscribe((appState) => {
-      console.log(appState.myValue);
-    });
-  }
-}
-```
-
-> By default, this method of saving application state will store it in Session Storage; however, if `useCookiesForTransactions` is set, a Cookie will be used instead.
-
-> This information will be removed from storage once the user is redirected back to your application after a successful login attempt (although it will continue to be accessible on the `AuthService`).
-
 ### Add logout to your application
 
 Add a `logout` method to your component and call the SDK's `logout` method:

--- a/README.md
+++ b/README.md
@@ -121,6 +121,56 @@ On your template, provide a button that will allow the user to log in to the app
 </button>
 ```
 
+### Preserve application state through redirects
+
+To preserve application state through the redirect to Auth0 and the subsequent redirect back to your application (if the user authentications succesfully), you can pass in the state that you want preserved to the `loginWithRedirect` method:
+
+```ts
+import { Component } from '@angular/core';
+import { AuthService } from '@auth0/auth0-angular';
+
+@Component({
+  selector: 'app-root',
+  templateUrl: './app.component.html',
+  styleUrls: ['./app.component.css'],
+})
+export class AppComponent {
+  constructor(public auth: AuthService) {}
+
+  loginWithRedirect(): void {
+    this.auth.loginWithRedirect({
+      appState: {
+        // Specify which application state you would like to preserve here (yes, objects ARE allowed)
+      },
+    });
+  }
+}
+```
+
+After Auth0 redirects the user back to your application, you can access the stored state using the `appState$` observable on the `AuthService`:
+
+```ts
+import { Component, OnInit } from '@angular/core';
+import { AuthService } from '@auth0/auth0-angular';
+
+@Component({
+  selector: 'app-root',
+  templateUrl: './app.component.html',
+  styleUrls: ['./app.component.css'],
+})
+export class AppComponent {
+  constructor(public auth: AuthService) {}
+
+  ngOnInit() {
+    this.auth.appState$.subscribe((appState) => {
+      // Your value will be available here
+    });
+  }
+}
+```
+
+> This method of saving application state will save it in Session Storage which is capable of holding multiple MBs worth of data, so you should have more than enough space for your needs
+
 ### Add logout to your application
 
 Add a `logout` method to your component and call the SDK's `logout` method:

--- a/README.md
+++ b/README.md
@@ -169,7 +169,9 @@ export class AppComponent {
 }
 ```
 
-> This method of saving application state will save it in Session Storage which is capable of holding multiple MBs worth of data, so you should have more than enough space for your needs
+> By default, this method of saving application state will store it in Session Storage; however, if `useCookiesForTransactions` is set, a Cookie will be used instead.
+
+> This information will be removed from storage once the user is redirected back to your application after a successful login attempt (although it will continue to be accessible on the `AuthService`).
 
 ### Add logout to your application
 

--- a/projects/auth0-angular/src/lib/auth.service.spec.ts
+++ b/projects/auth0-angular/src/lib/auth.service.spec.ts
@@ -400,6 +400,27 @@ describe('AuthService', () => {
       });
     });
 
+    it('should record the appState in the appState$ observable if it is present', (done) => {
+      const appState = {
+        very: {
+          deeply: {
+            nested: 'value',
+          },
+        },
+      };
+
+      (auth0Client.handleRedirectCallback as jasmine.Spy).and.resolveTo({
+        appState,
+      });
+
+      const localService = createService();
+
+      localService.appState$.subscribe((recievedState) => {
+        expect(recievedState).toEqual(appState);
+        done();
+      });
+    });
+
     it('should record errors in the error$ observable', (done) => {
       const errorObj = new Error('An error has occured');
 
@@ -694,6 +715,28 @@ describe('AuthService', () => {
           mergeMap(() => localService.handleRedirectCallback())
         )
         .subscribe();
+    });
+
+    it('should record the appState in the appState$ observable if it is present', (done) => {
+      const appState = {
+        very: {
+          deeply: {
+            nested: 'value',
+          },
+        },
+      };
+
+      (auth0Client.handleRedirectCallback as jasmine.Spy).and.resolveTo({
+        appState,
+      });
+
+      const localService = createService();
+      localService.handleRedirectCallback().subscribe(() => {
+        localService.appState$.subscribe((recievedState) => {
+          expect(recievedState).toEqual(appState);
+          done();
+        });
+      });
     });
   });
 

--- a/projects/auth0-angular/src/lib/auth.service.spec.ts
+++ b/projects/auth0-angular/src/lib/auth.service.spec.ts
@@ -402,11 +402,7 @@ describe('AuthService', () => {
 
     it('should record the appState in the appState$ observable if it is present', (done) => {
       const appState = {
-        very: {
-          deeply: {
-            nested: 'value',
-          },
-        },
+        myValue: 'State to Preserve',
       };
 
       (auth0Client.handleRedirectCallback as jasmine.Spy).and.resolveTo({
@@ -719,11 +715,7 @@ describe('AuthService', () => {
 
     it('should record the appState in the appState$ observable if it is present', (done) => {
       const appState = {
-        very: {
-          deeply: {
-            nested: 'value',
-          },
-        },
+        myValue: 'State to Preserve',
       };
 
       (auth0Client.handleRedirectCallback as jasmine.Spy).and.resolveTo({

--- a/projects/auth0-angular/src/lib/auth.service.ts
+++ b/projects/auth0-angular/src/lib/auth.service.ts
@@ -52,6 +52,7 @@ export class AuthService implements OnDestroy {
   private errorSubject$ = new ReplaySubject<Error>(1);
   private refreshState$ = new Subject<void>();
   private accessToken$ = new ReplaySubject<string>(1);
+  private appStateSubject$ = new ReplaySubject<any>(1);
 
   // https://stackoverflow.com/a/41177163
   private ngUnsubscribe$ = new Subject<void>();
@@ -136,6 +137,12 @@ export class AuthService implements OnDestroy {
    * Emits errors that occur during login, or when checking for an active session on startup.
    */
   readonly error$ = this.errorSubject$.asObservable();
+
+  /**
+   * Emits the value (if any) that was passed to the `loginWithRedirect` method call
+   * but only **after** `handleRedirectCallback` is first called
+   */
+  readonly appState$ = this.appStateSubject$.asObservable();
 
   constructor(
     @Inject(Auth0ClientService) private auth0Client: Auth0Client,
@@ -333,7 +340,10 @@ export class AuthService implements OnDestroy {
         if (!isLoading) {
           this.refreshState$.next();
         }
-        const target = result?.appState?.target ?? '/';
+        const appState = result.appState;
+        const target = appState?.target ?? '/';
+
+        this.appStateSubject$.next(appState);
         this.navigator.navigateByUrl(target);
       }),
       map(([result]) => result)

--- a/projects/auth0-angular/src/lib/auth.service.ts
+++ b/projects/auth0-angular/src/lib/auth.service.ts
@@ -340,7 +340,7 @@ export class AuthService implements OnDestroy {
         if (!isLoading) {
           this.refreshState$.next();
         }
-        const appState = result.appState;
+        const appState = result?.appState;
         const target = appState?.target ?? '/';
 
         this.appStateSubject$.next(appState);

--- a/projects/auth0-angular/src/lib/auth.service.ts
+++ b/projects/auth0-angular/src/lib/auth.service.ts
@@ -343,7 +343,10 @@ export class AuthService implements OnDestroy {
         const appState = result?.appState;
         const target = appState?.target ?? '/';
 
-        this.appStateSubject$.next(appState);
+        if (appState) {
+          this.appStateSubject$.next(appState);
+        }
+
         this.navigator.navigateByUrl(target);
       }),
       map(([result]) => result)

--- a/projects/playground/e2e/integration/playground.spec.ts
+++ b/projects/playground/e2e/integration/playground.spec.ts
@@ -42,7 +42,7 @@ describe('Smoke tests', () => {
     cy.get('#logout').should('be.visible').click();
   });
 
-  it('do redirect login and show user and access token', () => {
+  it('do redirect login and show user, access token and appState', () => {
     const appState = 'Any Random String';
 
     cy.visit('/');

--- a/projects/playground/e2e/integration/playground.spec.ts
+++ b/projects/playground/e2e/integration/playground.spec.ts
@@ -1,5 +1,6 @@
 const EMAIL = 'johnfoo+integration@gmail.com';
 const PASSWORD = Cypress.env('INTEGRATION_PASSWORD');
+const APP_STATE = 'Any Random String';
 
 const loginToAuth0 = () => {
   cy.get('.auth0-lock-form')
@@ -44,6 +45,7 @@ describe('Smoke tests', () => {
 
   it('do redirect login and show user and access token', () => {
     cy.visit('/');
+    cy.get('[data-cy=app-state-input]').type(APP_STATE);
     cy.get('#login').should('be.visible').click();
     cy.url().should('include', 'https://brucke.auth0.com/login');
     loginToAuth0();
@@ -59,6 +61,8 @@ describe('Smoke tests', () => {
         cy.get('#accessToken').click();
         cy.get('[data-cy=accessToken]').should('have.text', token);
       });
+
+    cy.get('[data-cy=app-state-result]').should('have.value', APP_STATE);
 
     cy.get('#logout').should('be.visible').click();
     cy.get('#login').should('be.visible');

--- a/projects/playground/e2e/integration/playground.spec.ts
+++ b/projects/playground/e2e/integration/playground.spec.ts
@@ -1,6 +1,5 @@
 const EMAIL = 'johnfoo+integration@gmail.com';
 const PASSWORD = Cypress.env('INTEGRATION_PASSWORD');
-const APP_STATE = 'Any Random String';
 
 const loginToAuth0 = () => {
   cy.get('.auth0-lock-form')
@@ -44,8 +43,10 @@ describe('Smoke tests', () => {
   });
 
   it('do redirect login and show user and access token', () => {
+    const appState = 'Any Random String';
+
     cy.visit('/');
-    cy.get('[data-cy=app-state-input]').type(APP_STATE);
+    cy.get('[data-cy=app-state-input]').type(appState);
     cy.get('#login').should('be.visible').click();
     cy.url().should('include', 'https://brucke.auth0.com/login');
     loginToAuth0();
@@ -62,7 +63,7 @@ describe('Smoke tests', () => {
         cy.get('[data-cy=accessToken]').should('have.text', token);
       });
 
-    cy.get('[data-cy=app-state-result]').should('have.value', APP_STATE);
+    cy.get('[data-cy=app-state-result]').should('have.value', appState);
 
     cy.get('#logout').should('be.visible').click();
     cy.get('#login').should('be.visible');

--- a/projects/playground/src/app/app.component.html
+++ b/projects/playground/src/app/app.component.html
@@ -27,6 +27,22 @@
           data-cy="login-popup"
         />
       </label>
+
+      <br />
+      <br />
+
+      <label>
+        App State:
+        <input
+          type="text"
+          formControlName="appState"
+          data-cy="app-state-input"
+        />
+      </label>
+
+      <br />
+      <br />
+
       <button id="login" (click)="launchLogin()">Log in</button>
       <button id="loginWithInvitation" (click)="loginHandleInvitationUrl()">
         Log in with Invitation
@@ -132,6 +148,17 @@
         <textarea data-cy="accessToken" cols="50" rows="2" disabled="true">{{
           accessToken
         }}</textarea>
+
+        <br />
+        <br />
+
+        <textarea
+          data-cy="app-state-result"
+          cols="50"
+          rows="2"
+          disabled="true"
+          >{{ appState }}</textarea
+        >
       </li>
     </ul>
   </div>

--- a/projects/playground/src/app/app.component.html
+++ b/projects/playground/src/app/app.component.html
@@ -35,7 +35,7 @@
         App State:
         <input
           type="text"
-          formControlName="appState"
+          formControlName="appStateInput"
           data-cy="app-state-input"
         />
       </label>
@@ -157,7 +157,7 @@
           cols="50"
           rows="2"
           disabled="true"
-          >{{ appState }}</textarea
+          >{{ appStateResult }}</textarea
         >
       </li>
     </ul>

--- a/projects/playground/src/app/app.component.spec.ts
+++ b/projects/playground/src/app/app.component.spec.ts
@@ -2,7 +2,7 @@ import { TestBed, ComponentFixture } from '@angular/core/testing';
 import { RouterTestingModule } from '@angular/router/testing';
 import { AppComponent } from './app.component';
 import { AuthService } from 'projects/auth0-angular/src/lib/auth.service';
-import { BehaviorSubject, of } from 'rxjs';
+import { BehaviorSubject, of, ReplaySubject } from 'rxjs';
 import { ReactiveFormsModule } from '@angular/forms';
 import { HttpClientModule } from '@angular/common/http';
 
@@ -26,6 +26,7 @@ describe('AppComponent', () => {
         user$: new BehaviorSubject(null),
         isLoading$: new BehaviorSubject(true),
         isAuthenticated$: new BehaviorSubject(false),
+        appState$: new ReplaySubject(),
       }
     ) as any;
 
@@ -291,15 +292,22 @@ describe('AppComponent', () => {
     });
 
     it('should login with redirect', () => {
+      const appStateValue = 'Value to Preserve';
+
       const wrapLogin = ne.querySelector('.login-wrapper');
       const form = component.loginOptionsForm.controls;
       form.usePopup.setValue(false);
+      form.appStateInput.setValue(appStateValue);
 
       const btnRefresh = wrapLogin?.querySelector('button');
       btnRefresh?.click();
       fixture.detectChanges();
 
-      expect(authMock.loginWithRedirect).toHaveBeenCalledWith({});
+      expect(authMock.loginWithRedirect).toHaveBeenCalledWith({
+        appState: {
+          myValue: appStateValue,
+        },
+      });
     });
 
     it('should login with popup', () => {

--- a/projects/playground/src/app/app.component.ts
+++ b/projects/playground/src/app/app.component.ts
@@ -1,4 +1,4 @@
-import { Component, Inject } from '@angular/core';
+import { Component, Inject, OnInit } from '@angular/core';
 import { FormGroup, FormControl } from '@angular/forms';
 import { AuthService } from 'projects/auth0-angular/src/lib/auth.service';
 import { iif } from 'rxjs';
@@ -12,17 +12,19 @@ import { HttpClient } from '@angular/common/http';
   templateUrl: './app.component.html',
   styleUrls: ['./app.component.css'],
 })
-export class AppComponent {
+export class AppComponent implements OnInit {
   isAuthenticated$ = this.auth.isAuthenticated$;
   isLoading$ = this.auth.isLoading$;
   user$ = this.auth.user$;
   claims$ = this.auth.idTokenClaims$;
   accessToken = '';
+  appState = '';
   error$ = this.auth.error$;
 
   organization = '';
 
   loginOptionsForm = new FormGroup({
+    appState: new FormControl(''),
     usePopup: new FormControl(false),
   });
 
@@ -35,6 +37,12 @@ export class AppComponent {
     usePopup: new FormControl(false),
     ignoreCache: new FormControl(false),
   });
+
+  ngOnInit(): void {
+    this.auth.appState$.subscribe((appState) => {
+      this.appState = appState.deeply.nested.value;
+    });
+  }
 
   constructor(
     public auth: AuthService,
@@ -51,6 +59,13 @@ export class AppComponent {
     } else {
       this.auth.loginWithRedirect({
         ...(this.organization ? { organization: this.organization } : null),
+        appState: {
+          deeply: {
+            nested: {
+              value: this.loginOptionsForm.value.appState,
+            },
+          },
+        },
       });
     }
   }

--- a/projects/playground/src/app/app.component.ts
+++ b/projects/playground/src/app/app.component.ts
@@ -18,13 +18,13 @@ export class AppComponent implements OnInit {
   user$ = this.auth.user$;
   claims$ = this.auth.idTokenClaims$;
   accessToken = '';
-  appState = '';
+  appStateResult = '';
   error$ = this.auth.error$;
 
   organization = '';
 
   loginOptionsForm = new FormGroup({
-    appState: new FormControl(''),
+    appStateInput: new FormControl(''),
     usePopup: new FormControl(false),
   });
 
@@ -40,7 +40,7 @@ export class AppComponent implements OnInit {
 
   ngOnInit(): void {
     this.auth.appState$.subscribe((appState) => {
-      this.appState = appState.deeply.nested.value;
+      this.appStateResult = appState.myValue;
     });
   }
 
@@ -60,11 +60,7 @@ export class AppComponent implements OnInit {
       this.auth.loginWithRedirect({
         ...(this.organization ? { organization: this.organization } : null),
         appState: {
-          deeply: {
-            nested: {
-              value: this.loginOptionsForm.value.appState,
-            },
-          },
+          myValue: this.loginOptionsForm.value.appStateInput,
         },
       });
     }


### PR DESCRIPTION
### Description

My changes enable direct access to the `appState` that is returned from the `handleRedirectCallback` method.
This `appState` is made available through a new `appState$` observable on the `AuthService` class.

### References

The need for this feature has been voiced by a few other developers: https://community.auth0.com/t/handle-appstate-and-redirect-to-dynamic-url-after-successful-login-auth0-angular/50982

### Testing

You can run both the unit tests and the e2e tests the normal way

### Checklist
- [x] This change adds test coverage for new/changed/fixed functionality
- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `master`
