### PR TITLE
Use correct username and password for cypress

### DIFF
--- a/projects/playground/e2e/integration/playground.spec.ts
+++ b/projects/playground/e2e/integration/playground.spec.ts
@@ -1,5 +1,11 @@
-const EMAIL = 'johnfoo+integration@gmail.com';
-const PASSWORD = Cypress.env('INTEGRATION_PASSWORD');
+const EMAIL = Cypress.env('USER_EMAIL');
+const PASSWORD = Cypress.env('USER_PASSWORD');
+
+if (!EMAIL || !PASSWORD) {
+  throw new Error(
+    'You must provide CYPRESS_USER_EMAIL and CYPRESS_USER_PASSWORD environment variables'
+  );
+}
 
 const loginToAuth0 = () => {
   cy.get('.auth0-lock-form')


### PR DESCRIPTION
Revert changes that got introduced in https://github.com/auth0/auth0-angular/pull/69 regarding the user and password being used for running the cypress tests