### PR TITLE
Fix incorrect docs for error observable

### DIFF
--- a/README.md
+++ b/README.md
@@ -363,7 +363,7 @@ A common reason you might want to handle the above errors, emitted by the `error
 ```
 ngOnInit() {
   this.authService.error$.pipe(
-    filter(e => e.error === 'login_required'),
+    filter((e) => e instanceof GenericError && e.error === 'login_required'),
     mergeMap(() => this.authService.loginWithRedirect())
   ).subscribe();
 }


### PR DESCRIPTION
The error observable emits objects of type `Error`. This does not have an `error` property.
However, if we check if it is an instance of `GenericError` first, we can guarantee it had an `error` property and TypeScript will allow using the `error` property.

Fixes #171