### PR TITLE
Update username and password for OIDC-Provider

### DIFF
--- a/projects/playground/e2e/integration/playground.spec.ts
+++ b/projects/playground/e2e/integration/playground.spec.ts
@@ -1,5 +1,5 @@
-const EMAIL = Cypress.env('USER_EMAIL') || 'a';
-const PASSWORD = Cypress.env('USER_PASSWORD') || 'a';
+const EMAIL = Cypress.env('USER_EMAIL') || 'testing';
+const PASSWORD = Cypress.env('USER_PASSWORD') || 'testing';
 
 if (!EMAIL || !PASSWORD) {
   throw new Error(


### PR DESCRIPTION
Replaces `a` with `testing` to indicate it's for testing purposes.  Both should work, but `a` is a bit a weird value.