### PR TITLE
Update circle config to use browserstack-env context

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,3 +48,5 @@ workflows:
       - browserstack:
           requires:
             - build
+          context:
+            - browserstack-env


### PR DESCRIPTION
Using the context ensures we do not need to configure browserstack credentials on the project itself.