### PR TITLE
Automate package publishing [fix-up]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 version: 2.1
 orbs:
-  ship: auth0/ship@0.2.0
+  ship: auth0/ship@0.3.0
 parameters:
   docker_image:
     type: string
@@ -45,6 +45,7 @@ workflows:
             - browserstack-env
       - ship/node-publish:
           publish-command: npm run build:prod && cp README.md ./dist/auth0-angular/ && npm publish ./dist/auth0-angular
+          app-directory: "projects/auth0-angular"
           requires:
             - browserstack
           context:


### PR DESCRIPTION
Follow-up PR from https://github.com/auth0/auth0-angular/pull/207.

This one uses a newer version of the publishing script that supports monorepos. And also updates the config file to specify where to locate the project's `package.json` file required for the orb.