### PR TITLE
[SDK-2786] Ensure SDK works when useHash is true

### DIFF
--- a/projects/auth0-angular/src/lib/auth.service.spec.ts
+++ b/projects/auth0-angular/src/lib/auth.service.spec.ts
@@ -64,8 +64,6 @@ describe('AuthService', () => {
 
     window.history.replaceState(null, '', '');
 
-    // window.location.search = '';
-
     moduleSetup = {
       providers: [
         AbstractNavigator,

--- a/projects/auth0-angular/src/lib/auth.service.spec.ts
+++ b/projects/auth0-angular/src/lib/auth.service.spec.ts
@@ -32,7 +32,6 @@ describe('AuthService', () => {
   let auth0Client: Auth0Client;
   let moduleSetup: any;
   let service: AuthService;
-  let locationSpy: jasmine.SpyObj<Location>;
   let authConfig: Partial<AuthConfig>;
   let authState: AuthState;
 
@@ -63,8 +62,9 @@ describe('AuthService', () => {
       '__access_token_from_popup__'
     );
 
-    locationSpy = jasmine.createSpyObj('Location', ['path']);
-    locationSpy.path.and.returnValue('');
+    window.history.replaceState(null, '', '');
+
+    // window.location.search = '';
 
     moduleSetup = {
       providers: [
@@ -72,10 +72,6 @@ describe('AuthService', () => {
         {
           provide: Auth0ClientService,
           useValue: auth0Client,
-        },
-        {
-          provide: Location,
-          useValue: locationSpy,
         },
       ],
     };
@@ -349,17 +345,13 @@ describe('AuthService', () => {
             useValue: auth0Client,
           },
           {
-            provide: Location,
-            useValue: locationSpy,
-          },
-          {
             provide: AuthConfigService,
             useValue: authConfig,
           },
         ],
       });
 
-      locationSpy.path.and.returnValue('?code=123&state=456');
+      window.history.replaceState(null, '', '?code=123&state=456');
     });
 
     it('should handle the callback when code and state are available', (done) => {
@@ -482,7 +474,9 @@ describe('AuthService', () => {
     });
 
     it('should process the callback when an error appears in the query string', (done) => {
-      locationSpy.path.and.returnValue(
+      window.history.replaceState(
+        null,
+        '',
         `?error=${encodeURIComponent('This is an error')}&state=456`
       );
 
@@ -686,10 +680,6 @@ describe('AuthService', () => {
             useValue: auth0Client,
           },
           {
-            provide: Location,
-            useValue: locationSpy,
-          },
-          {
             provide: AuthConfigService,
             useValue: {
               ...authConfig,
@@ -699,7 +689,7 @@ describe('AuthService', () => {
         ],
       });
 
-      locationSpy.path.and.returnValue('');
+      window.history.replaceState(null, '', '');
     });
 
     it('should call the underlying SDK', (done) => {

--- a/projects/auth0-angular/src/lib/auth.service.ts
+++ b/projects/auth0-angular/src/lib/auth.service.ts
@@ -28,7 +28,6 @@ import {
   tap,
   map,
   takeUntil,
-  distinctUntilChanged,
   catchError,
   switchMap,
   withLatestFrom,
@@ -36,7 +35,6 @@ import {
 
 import { Auth0ClientService } from './auth.client';
 import { AbstractNavigator } from './abstract-navigator';
-import { Location } from '@angular/common';
 import { AuthClientConfig } from './auth.config';
 import { AuthState } from './auth.state';
 
@@ -83,7 +81,6 @@ export class AuthService implements OnDestroy {
   constructor(
     @Inject(Auth0ClientService) private auth0Client: Auth0Client,
     private configFactory: AuthClientConfig,
-    private location: Location,
     private navigator: AbstractNavigator,
     private authState: AuthState
   ) {
@@ -321,7 +318,7 @@ export class AuthService implements OnDestroy {
   }
 
   private shouldHandleCallback(): Observable<boolean> {
-    return of(this.location.path()).pipe(
+    return of(location.search).pipe(
       map((search) => {
         return (
           (search.includes('code=') || search.includes('error=')) &&


### PR DESCRIPTION
When configuring the Angular Router to use `{ useHash: true }`, Angular's `Location.path()` will not include the `query arguments` when Auth0 redirects back to Angular as it redirects back to `https://domain?code=...`. instead of `https://domain/#/?code=...`. 

When we manually try navigating to `https://domain/#/?code=...`, our SDK processes the `code` and `state` correctly. However, when sending `https://domain/#/`,  `https://domain/#` or  `https://domain#` as the `redirect_uri`, Auth0 still redirects back to `https://domain?code=...`, making our SDK unable to process `code` and `state`.

**Call to /authorize**
![image](https://user-images.githubusercontent.com/2146903/133104030-89c628ae-a68c-4c2b-b857-ec86228eb5e1.png)

**Redirect sent by Auth0**
![image](https://user-images.githubusercontent.com/2146903/133104111-f89d360c-cedb-490e-b24e-a029e97144be.png)

Closes #189