### PR TITLE
Bump Auth0-SPA-JS to 1.18.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -840,13 +840,13 @@
       }
     },
     "@auth0/auth0-spa-js": {
-      "version": "1.17.0",
-      "resolved": "https://registry.npmjs.org/@auth0/auth0-spa-js/-/auth0-spa-js-1.17.0.tgz",
-      "integrity": "sha512-UqfulO/ycA9Lt3F7FKuwv3Xo+g+2bOs9kABPAz8uNvCjiwM891eRYARUKn8lLgeK30TNt2ot2DtpNHI3BVP0Jg==",
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@auth0/auth0-spa-js/-/auth0-spa-js-1.18.0.tgz",
+      "integrity": "sha512-Z8ZIzrZJKBHa3yFY/vRJYqg9CbLPwb2sRnouBdfPj8Pas08fwig63mfJKaTusIJC3gQ8xCIwfw4QFo83wpmFkg==",
       "requires": {
         "abortcontroller-polyfill": "^1.7.3",
         "browser-tabs-lock": "^1.2.14",
-        "core-js": "^3.15.2",
+        "core-js": "^3.16.3",
         "es-cookie": "^1.3.2",
         "fast-text-encoding": "^1.0.3",
         "promise-polyfill": "^8.2.0",
@@ -854,9 +854,9 @@
       },
       "dependencies": {
         "core-js": {
-          "version": "3.16.0",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.16.0.tgz",
-          "integrity": "sha512-5+5VxRFmSf97nM8Jr2wzOwLqRo6zphH2aX+7KsAUONObyzakDNq2G/bgbhinxB4PoV9L3aXQYhiDKyIKWd2c8g=="
+          "version": "3.18.0",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.18.0.tgz",
+          "integrity": "sha512-WJeQqq6jOYgVgg4NrXKL0KLQhi0CT4ZOCvFL+3CQ5o7I6J8HkT5wd53EadMfqTDp1so/MT1J+w2ujhWcCJtN7w=="
         }
       }
     },
@@ -4216,9 +4216,9 @@
       }
     },
     "browser-tabs-lock": {
-      "version": "1.2.14",
-      "resolved": "https://registry.npmjs.org/browser-tabs-lock/-/browser-tabs-lock-1.2.14.tgz",
-      "integrity": "sha512-ssSpCRcvFe4vc098LDnrJOQDfZiG35KhQGB9hthTbwJk5mmUkePwhcMlW61NH3YuIE2Y9uGLqf9yxEBKbaDlaw==",
+      "version": "1.2.15",
+      "resolved": "https://registry.npmjs.org/browser-tabs-lock/-/browser-tabs-lock-1.2.15.tgz",
+      "integrity": "sha512-J8K9vdivK0Di+b8SBdE7EZxDr88TnATing7XoLw6+nFkXMQ6sVBh92K3NQvZlZU91AIkFRi0w3sztk5Z+vsswA==",
       "requires": {
         "lodash": ">=4.17.21"
       }
@@ -11394,6 +11394,19 @@
           "integrity": "sha512-xKqzzWXDttJuOcawBt4KnKHHIf5oQ/Cxax+0PWFG+DFDgHNAdi+TXECADI+RYiFUMmx8792xsMbbgXj4CwnP4g==",
           "dev": true
         },
+        "paseto2": {
+          "version": "npm:paseto@2.1.3",
+          "resolved": "https://registry.npmjs.org/paseto/-/paseto-2.1.3.tgz",
+          "integrity": "sha512-BNkbvr0ZFDbh3oV13QzT5jXIu8xpFc9r0o5mvWBhDU1GBkVt1IzHK1N6dcYmN7XImrUmPQ0HCUXmoe2WPo8xsg==",
+          "dev": true
+        },
+        "paseto3": {
+          "version": "npm:paseto@3.0.1",
+          "resolved": "https://registry.npmjs.org/paseto/-/paseto-3.0.1.tgz",
+          "integrity": "sha512-K43Fi/W3vogewQHcHX+etF8Kx7Va037xLauTamK0AGTOLsE3CPW4jdRaeFvoaVIh6ybZiFg+nXVSc6ckIr0XVw==",
+          "dev": true,
+          "optional": true
+        },
         "raw-body": {
           "version": "2.4.1",
           "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.4.1.tgz",
@@ -11742,18 +11755,6 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/pascalcase/-/pascalcase-0.1.1.tgz",
       "integrity": "sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ=",
-      "dev": true
-    },
-    "paseto2": {
-      "version": "npm:paseto@2.1.3",
-      "resolved": "https://registry.npmjs.org/paseto/-/paseto-2.1.3.tgz",
-      "integrity": "sha512-BNkbvr0ZFDbh3oV13QzT5jXIu8xpFc9r0o5mvWBhDU1GBkVt1IzHK1N6dcYmN7XImrUmPQ0HCUXmoe2WPo8xsg==",
-      "dev": true
-    },
-    "paseto3": {
-      "version": "npm:paseto@3.0.1",
-      "resolved": "https://registry.npmjs.org/paseto/-/paseto-3.0.1.tgz",
-      "integrity": "sha512-K43Fi/W3vogewQHcHX+etF8Kx7Va037xLauTamK0AGTOLsE3CPW4jdRaeFvoaVIh6ybZiFg+nXVSc6ckIr0XVw==",
       "dev": true
     },
     "path-dirname": {

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "@angular/platform-browser": "^12.2.3",
     "@angular/platform-browser-dynamic": "^12.2.3",
     "@angular/router": "^12.2.3",
-    "@auth0/auth0-spa-js": "^1.17.0",
+    "@auth0/auth0-spa-js": "^1.18.0",
     "rxjs": "^6.6.7",
     "tslib": "^2.3.1",
     "zone.js": "~0.11.4"


### PR DESCRIPTION
Bumps SPA-JS to 1.18.0 to bring in the changes for that release (https://github.com/auth0/auth0-spa-js/blob/master/CHANGELOG.md#v1180-2021-09-15)


**Added**

- [SDK-2750] Expose mfa_token from the mfa_required error when getting new tokens [\#789](https://github.com/auth0/auth0-spa-js/pull/789) ([frederikprijck](https://github.com/frederikprijck))

**Changed**

- [SDK-2759] Re-scoping cookies and transactions to client ID [\#796](https://github.com/auth0/auth0-spa-js/pull/796) ([stevehobbsdev](https://github.com/stevehobbsdev))
- [SDK-2320] Throw login_required error in SPA SDK if running in a cross-origin is… [\#790](https://github.com/auth0/auth0-spa-js/pull/790) ([frederikprijck](https://github.com/frederikprijck))

**Fixed**

- [SDK-2692] Remember organization ID for silent authentication [\#788](https://github.com/auth0/auth0-spa-js/pull/788) ([stevehobbsdev](https://github.com/stevehobbsdev))


[SDK-2750]: https://auth0team.atlassian.net/browse/SDK-2750
[SDK-2759]: https://auth0team.atlassian.net/browse/SDK-2759
[SDK-2320]: https://auth0team.atlassian.net/browse/SDK-2320
[SDK-2692]: https://auth0team.atlassian.net/browse/SDK-2692