### PR TITLE
Export IdToken and User types

### DIFF
--- a/projects/auth0-angular/src/public-api.ts
+++ b/projects/auth0-angular/src/public-api.ts
@@ -15,4 +15,6 @@ export {
   Cacheable,
   LocalStorageCache,
   InMemoryCache,
+  IdToken,
+  User
 } from '@auth0/auth0-spa-js';


### PR DESCRIPTION
Add TokenId interface and User class export from auth0-spa-js

### Description

Exporting IdToken interface and User class from auth0-spa-js makes IDEs auto-import working.

These definitions can come in handy when the consumer of the library needs to expand the objects emitted by `idTokenClaims$` and `user$` observables respectively, adding properties reflecting custom claims.

### Testing

```ts
authVm$: Observable<IdToken & {roles: string}>;
this.authVm$ = this.auth.idTokenClaims$.pipe(
  map(claims => ({...claims, roles: claims['https://yourUrl.com/roles']}))
);
```