### PR TITLE
Avoid using jfrog for npm packages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1313,9 +1313,8 @@
     },
     "node_modules/@auth0/auth0-spa-js": {
       "version": "1.19.3",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/@auth0/auth0-spa-js/-/auth0-spa-js-1.19.3.tgz",
-      "integrity": "sha1-dMJ5HUnoCdqAPprKGDiAsOI4zXk=",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@auth0/auth0-spa-js/-/auth0-spa-js-1.19.3.tgz",
+      "integrity": "sha512-w6GzjgbktbdDDpkH5ZuHe/lcVrP0dfkW+398zPErk4VBpcGLhiHOp1AwrF6QE8K0anX8O05nqgEPLbKzrgnYPQ==",
       "dependencies": {
         "abortcontroller-polyfill": "^1.7.3",
         "browser-tabs-lock": "^1.2.15",
@@ -1328,10 +1327,9 @@
     },
     "node_modules/@auth0/auth0-spa-js/node_modules/core-js": {
       "version": "3.19.2",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/core-js/-/core-js-3.19.2.tgz",
-      "integrity": "sha1-riFtf09+kk2aLj/x5LGUAiD5FXs=",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.19.2.tgz",
+      "integrity": "sha512-ciYCResnLIATSsXuXnIOH4CbdfgV+H1Ltg16hJFN7/v6OxqnFr/IFGeLacaZ+fHLAm0TBbXwNK9/DNBzBUrO/g==",
       "hasInstallScript": true,
-      "license": "MIT",
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/core-js"
@@ -4587,8 +4585,7 @@
     "node_modules/abortcontroller-polyfill": {
       "version": "1.7.3",
       "resolved": "https://registry.npmjs.org/abortcontroller-polyfill/-/abortcontroller-polyfill-1.7.3.tgz",
-      "integrity": "sha512-zetDJxd89y3X99Kvo4qFx8GKlt6GsvN3UcRZHwU6iFA/0KiOmhkTVhe8oRoTBiTVPZu09x3vCra47+w8Yz1+2Q==",
-      "license": "MIT"
+      "integrity": "sha512-zetDJxd89y3X99Kvo4qFx8GKlt6GsvN3UcRZHwU6iFA/0KiOmhkTVhe8oRoTBiTVPZu09x3vCra47+w8Yz1+2Q=="
     },
     "node_modules/accepts": {
       "version": "1.3.7",
@@ -5759,7 +5756,6 @@
       "resolved": "https://registry.npmjs.org/browser-tabs-lock/-/browser-tabs-lock-1.2.15.tgz",
       "integrity": "sha512-J8K9vdivK0Di+b8SBdE7EZxDr88TnATing7XoLw6+nFkXMQ6sVBh92K3NQvZlZU91AIkFRi0w3sztk5Z+vsswA==",
       "hasInstallScript": true,
-      "license": "MIT",
       "dependencies": {
         "lodash": ">=4.17.21"
       }
@@ -9513,8 +9509,7 @@
     "node_modules/es-cookie": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/es-cookie/-/es-cookie-1.3.2.tgz",
-      "integrity": "sha512-UTlYYhXGLOy05P/vKVT2Ui7WtC7NiRzGtJyAKKn32g5Gvcjn7KAClLPWlipCtxIus934dFg9o9jXiBL0nP+t9Q==",
-      "license": "MIT"
+      "integrity": "sha512-UTlYYhXGLOy05P/vKVT2Ui7WtC7NiRzGtJyAKKn32g5Gvcjn7KAClLPWlipCtxIus934dFg9o9jXiBL0nP+t9Q=="
     },
     "node_modules/es-module-lexer": {
       "version": "0.4.1",
@@ -10177,8 +10172,7 @@
     "node_modules/fast-text-encoding": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/fast-text-encoding/-/fast-text-encoding-1.0.3.tgz",
-      "integrity": "sha512-dtm4QZH9nZtcDt8qJiOH9fcQd1NAgi+K1O2DbE6GG1PPCK/BWfOH3idCTRQ4ImXRUOyopDEgDEnVEE7Y/2Wrig==",
-      "license": "Apache-2.0"
+      "integrity": "sha512-dtm4QZH9nZtcDt8qJiOH9fcQd1NAgi+K1O2DbE6GG1PPCK/BWfOH3idCTRQ4ImXRUOyopDEgDEnVEE7Y/2Wrig=="
     },
     "node_modules/fastparse": {
       "version": "1.1.2",
@@ -19325,8 +19319,7 @@
     "node_modules/promise-polyfill": {
       "version": "8.2.1",
       "resolved": "https://registry.npmjs.org/promise-polyfill/-/promise-polyfill-8.2.1.tgz",
-      "integrity": "sha512-3p9zj0cEHbp7NVUxEYUWjQlffXqnXaZIMPkAO7HhFh8u5636xLRDHOUo2vpWSK0T2mqm6fKLXYn1KP6PAZ2gKg==",
-      "license": "MIT"
+      "integrity": "sha512-3p9zj0cEHbp7NVUxEYUWjQlffXqnXaZIMPkAO7HhFh8u5636xLRDHOUo2vpWSK0T2mqm6fKLXYn1KP6PAZ2gKg=="
     },
     "node_modules/promise-retry": {
       "version": "2.0.1",
@@ -22971,8 +22964,7 @@
     "node_modules/unfetch": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/unfetch/-/unfetch-4.2.0.tgz",
-      "integrity": "sha512-F9p7yYCn6cIW9El1zi0HI6vqpeIvBsr3dSuRO6Xuppb1u5rXpCPmMvLSyECLhybr9isec8Ohl0hPekMVrEinDA==",
-      "license": "MIT"
+      "integrity": "sha512-F9p7yYCn6cIW9El1zi0HI6vqpeIvBsr3dSuRO6Xuppb1u5rXpCPmMvLSyECLhybr9isec8Ohl0hPekMVrEinDA=="
     },
     "node_modules/unicode-canonical-property-names-ecmascript": {
       "version": "1.0.4",
@@ -25656,8 +25648,8 @@
     },
     "@auth0/auth0-spa-js": {
       "version": "1.19.3",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/@auth0/auth0-spa-js/-/auth0-spa-js-1.19.3.tgz",
-      "integrity": "sha1-dMJ5HUnoCdqAPprKGDiAsOI4zXk=",
+      "resolved": "https://registry.npmjs.org/@auth0/auth0-spa-js/-/auth0-spa-js-1.19.3.tgz",
+      "integrity": "sha512-w6GzjgbktbdDDpkH5ZuHe/lcVrP0dfkW+398zPErk4VBpcGLhiHOp1AwrF6QE8K0anX8O05nqgEPLbKzrgnYPQ==",
       "requires": {
         "abortcontroller-polyfill": "^1.7.3",
         "browser-tabs-lock": "^1.2.15",
@@ -25670,8 +25662,8 @@
       "dependencies": {
         "core-js": {
           "version": "3.19.2",
-          "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/core-js/-/core-js-3.19.2.tgz",
-          "integrity": "sha1-riFtf09+kk2aLj/x5LGUAiD5FXs="
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.19.2.tgz",
+          "integrity": "sha512-ciYCResnLIATSsXuXnIOH4CbdfgV+H1Ltg16hJFN7/v6OxqnFr/IFGeLacaZ+fHLAm0TBbXwNK9/DNBzBUrO/g=="
         }
       }
     },


### PR DESCRIPTION
CI is failing because it needs a password to pull from jfrog. This is because jfrog was accidentally used to upgrade Auth0-SPA-JS.
This PR ensures we do not pull from jfrog.