### PR TITLE
Avoid using jfrog for npm packages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -471,16 +471,16 @@
     },
     "@angular/animations": {
       "version": "12.2.14",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/@angular/animations/-/animations-12.2.14.tgz",
-      "integrity": "sha1-W3Txf11YmT2SURdJ+lzq8t5sFJU=",
+      "resolved": "https://registry.npmjs.org/@angular/animations/-/animations-12.2.14.tgz",
+      "integrity": "sha512-1BR5u32auVePvXNNP96DB2008V+Ku0OGqeZQl2h4XA9xzES/Zk5WllIJZXqRmWMRBVARfXsfb0RdMty9gcaVjA==",
       "requires": {
         "tslib": "^2.2.0"
       }
     },
     "@angular/cli": {
       "version": "12.2.13",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/@angular/cli/-/cli-12.2.13.tgz",
-      "integrity": "sha1-ylhsFKb4O7Q5CHW+Cg+nCbmirik=",
+      "resolved": "https://registry.npmjs.org/@angular/cli/-/cli-12.2.13.tgz",
+      "integrity": "sha512-Yz6MuwdxxP6U2i8iRuCSNZeJxlLDPshT/joymCsFdjwSMGEH9Kk9DdvAfFYfzdHGdHbGrDdASJ4G+uALyNSLxw==",
       "dev": true,
       "requires": {
         "@angular-devkit/architect": "0.1202.13",
@@ -506,8 +506,8 @@
       "dependencies": {
         "@angular-devkit/architect": {
           "version": "0.1202.13",
-          "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/@angular-devkit/architect/-/architect-0.1202.13.tgz",
-          "integrity": "sha1-ubiD1i9iimsxzgcdqR4mj2HaAO8=",
+          "resolved": "https://registry.npmjs.org/@angular-devkit/architect/-/architect-0.1202.13.tgz",
+          "integrity": "sha512-LXgiidXwBgyWPqqWK4xR1/kCPQTMTzG5w+s7+LvENUZwbcdl6CKrOMjfgjo6WPr6yeq+WWQvPCD4pZ6nXRTm7A==",
           "dev": true,
           "requires": {
             "@angular-devkit/core": "12.2.13",
@@ -516,8 +516,8 @@
         },
         "@angular-devkit/core": {
           "version": "12.2.13",
-          "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/@angular-devkit/core/-/core-12.2.13.tgz",
-          "integrity": "sha1-2zkp0b/OcQELN/t8Tmwz74Ck818=",
+          "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-12.2.13.tgz",
+          "integrity": "sha512-9csMF0p+lTvlWnutxxTZ/+pDRMIbXk/TV4MGLbcqUPPfeG3dCRwErns73xLuMTwp9qO/KCLkFqNaM6cGOoqsDA==",
           "dev": true,
           "requires": {
             "ajv": "8.6.2",
@@ -530,8 +530,8 @@
         },
         "@angular-devkit/schematics": {
           "version": "12.2.13",
-          "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/@angular-devkit/schematics/-/schematics-12.2.13.tgz",
-          "integrity": "sha1-ZGTYb6PM0O+16tRseTzvnsRcd1g=",
+          "resolved": "https://registry.npmjs.org/@angular-devkit/schematics/-/schematics-12.2.13.tgz",
+          "integrity": "sha512-LQTv72R5Ma1uowMEeii2wIoDWI4bYQyZvunqPy9jRveBTjli2yVwwcOziGCVyttwlYs46bSdxThgeEvVIako2w==",
           "dev": true,
           "requires": {
             "@angular-devkit/core": "12.2.13",
@@ -541,8 +541,8 @@
         },
         "@schematics/angular": {
           "version": "12.2.13",
-          "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/@schematics/angular/-/angular-12.2.13.tgz",
-          "integrity": "sha1-W/PntpmkLX/X96oSu+RTTmcecgE=",
+          "resolved": "https://registry.npmjs.org/@schematics/angular/-/angular-12.2.13.tgz",
+          "integrity": "sha512-TrigQ9TCmAedf1J5PSSSfTC+sScYrITeAUN8a9rlkjZNvff8hHVyQaiZmhqL+egKQL828mhkqpnFUDd4QsPBIw==",
           "dev": true,
           "requires": {
             "@angular-devkit/core": "12.2.13",
@@ -552,8 +552,8 @@
         },
         "ajv": {
           "version": "8.6.2",
-          "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/ajv/-/ajv-8.6.2.tgz",
-          "integrity": "sha1-L7ReDl/LwIEzJsHD2lNdGIG7BXE=",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.6.2.tgz",
+          "integrity": "sha512-9807RlWAgT564wT+DjeyU5OFMPjmzxVobvDFmNAhY+5zD6A2ly3jDp6sgnfyDtlIQ+7H97oc/DGCzzfu9rjw9w==",
           "dev": true,
           "requires": {
             "fast-deep-equal": "^3.1.1",
@@ -564,8 +564,8 @@
         },
         "ajv-formats": {
           "version": "2.1.0",
-          "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/ajv-formats/-/ajv-formats-2.1.0.tgz",
-          "integrity": "sha1-lur4PjjTIQi2bYKpywz6JIhs3+s=",
+          "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.0.tgz",
+          "integrity": "sha512-USH2jBb+C/hIpwD2iRjp0pe0k+MvzG0mlSn/FIdCgQhUb9ALPRjt2KIQdfZDS9r0ZIeUAg7gOu9KL0PFqGqr5Q==",
           "dev": true,
           "requires": {
             "ajv": "^8.0.0"
@@ -573,8 +573,8 @@
         },
         "chalk": {
           "version": "4.1.2",
-          "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/chalk/-/chalk-4.1.2.tgz",
-          "integrity": "sha1-qsTit3NKdAhnrrFr8CqtVWoeegE=",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
           "dev": true,
           "requires": {
             "ansi-styles": "^4.1.0",
@@ -583,8 +583,8 @@
         },
         "debug": {
           "version": "4.3.2",
-          "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/debug/-/debug-4.3.2.tgz",
-          "integrity": "sha1-8KScGKyHeeMdSgxgKd+3aHPHQos=",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
+          "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
           "dev": true,
           "requires": {
             "ms": "2.1.2"
@@ -592,8 +592,8 @@
         },
         "inquirer": {
           "version": "8.1.2",
-          "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/inquirer/-/inquirer-8.1.2.tgz",
-          "integrity": "sha1-ZbIE0s1/tjQA7dkl3+Qouv1CLj0=",
+          "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-8.1.2.tgz",
+          "integrity": "sha512-DHLKJwLPNgkfwNmsuEUKSejJFbkv0FMO9SMiQbjI3n5NQuCrSIBqP66ggqyz2a6t2qEolKrMjhQ3+W/xXgUQ+Q==",
           "dev": true,
           "requires": {
             "ansi-escapes": "^4.2.1",
@@ -614,8 +614,8 @@
           "dependencies": {
             "rxjs": {
               "version": "7.4.0",
-              "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/rxjs/-/rxjs-7.4.0.tgz",
-              "integrity": "sha1-oSpE1+6/AW9f8kQbh/KMmlHOvGg=",
+              "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.4.0.tgz",
+              "integrity": "sha512-7SQDi7xeTMCJpqViXh8gL/lebcwlp3d831F05+9B44A4B0WfsEwUQHR64gsH1kvJ+Ep/J9K2+n1hVl1CsGN23w==",
               "dev": true,
               "requires": {
                 "tslib": "~2.1.0"
@@ -625,20 +625,20 @@
         },
         "json-schema-traverse": {
           "version": "1.0.0",
-          "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-          "integrity": "sha1-rnvLNlard6c7pcSb9lTzjmtoYOI=",
+          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+          "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
           "dev": true
         },
         "jsonc-parser": {
           "version": "3.0.0",
-          "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/jsonc-parser/-/jsonc-parser-3.0.0.tgz",
-          "integrity": "sha1-q914VwHH5+rKip7IzwcMpRp0WiI=",
+          "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.0.0.tgz",
+          "integrity": "sha512-fQzRfAbIBnR0IQvftw9FJveWiHp72Fg20giDrHz6TdfB12UH/uue0D3hm57UB5KgAVuniLMCaS8P1IMj9NR7cA==",
           "dev": true
         },
         "log-symbols": {
           "version": "4.1.0",
-          "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/log-symbols/-/log-symbols-4.1.0.tgz",
-          "integrity": "sha1-P727lbRoOsn8eFER55LlWNSr1QM=",
+          "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.1.0.tgz",
+          "integrity": "sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==",
           "dev": true,
           "requires": {
             "chalk": "^4.1.0",
@@ -647,8 +647,8 @@
         },
         "open": {
           "version": "8.2.1",
-          "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/open/-/open-8.2.1.tgz",
-          "integrity": "sha1-gt5C2gzL9Cm8EtCZ2tLgl14U6K8=",
+          "resolved": "https://registry.npmjs.org/open/-/open-8.2.1.tgz",
+          "integrity": "sha512-rXILpcQlkF/QuFez2BJDf3GsqpjGKbkUUToAIGo9A0Q6ZkoSGogZJulrUdwRkrAsoQvoZsrjCYt8+zblOk7JQQ==",
           "dev": true,
           "requires": {
             "define-lazy-prop": "^2.0.0",
@@ -658,8 +658,8 @@
         },
         "ora": {
           "version": "5.4.1",
-          "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/ora/-/ora-5.4.1.tgz",
-          "integrity": "sha1-GyZ4Qmr0rEpQkAjl5KyemVnbnhg=",
+          "resolved": "https://registry.npmjs.org/ora/-/ora-5.4.1.tgz",
+          "integrity": "sha512-5b6Y85tPxZZ7QytO+BQzysW31HJku27cRIlkbAXaNx+BdcVi+LlRFmVXzeF6a7JCwJpyw5c4b+YSVImQIrBpuQ==",
           "dev": true,
           "requires": {
             "bl": "^4.1.0",
@@ -675,8 +675,8 @@
         },
         "resolve": {
           "version": "1.20.0",
-          "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/resolve/-/resolve-1.20.0.tgz",
-          "integrity": "sha1-YpoBP7P3B1XW8LeTXMHCxTeLGXU=",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.20.0.tgz",
+          "integrity": "sha512-wENBPt4ySzg4ybFQW2TT1zMQucPK95HSh/nq2CFTZVOGut2+pQvSsgtda4d26YrYcr067wjbmzOG8byDPBX63A==",
           "dev": true,
           "requires": {
             "is-core-module": "^2.2.0",
@@ -685,44 +685,44 @@
         },
         "symbol-observable": {
           "version": "4.0.0",
-          "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/symbol-observable/-/symbol-observable-4.0.0.tgz",
-          "integrity": "sha1-W0JfGSJ56H8vm5N6yFQNGYSzkgU=",
+          "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-4.0.0.tgz",
+          "integrity": "sha512-b19dMThMV4HVFynSAM1++gBHAbk2Tc/osgLIBZMKsyqh34jb2e8Os7T6ZW/Bt3pJFdBTd2JwAnAAEQV7rSNvcQ==",
           "dev": true
         },
         "tslib": {
           "version": "2.1.0",
-          "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/tslib/-/tslib-2.1.0.tgz",
-          "integrity": "sha1-2mCGDxwuyqVwOrfTm8Bba/mIuXo=",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.1.0.tgz",
+          "integrity": "sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A==",
           "dev": true
         },
         "uuid": {
           "version": "8.3.2",
-          "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/uuid/-/uuid-8.3.2.tgz",
-          "integrity": "sha1-gNW1ztJxu5r2xEXyGhoExgbO++I=",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+          "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
           "dev": true
         }
       }
     },
     "@angular/common": {
       "version": "12.2.14",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/@angular/common/-/common-12.2.14.tgz",
-      "integrity": "sha1-DNDXW+gFLovnaWbklPJF3Fla/hA=",
+      "resolved": "https://registry.npmjs.org/@angular/common/-/common-12.2.14.tgz",
+      "integrity": "sha512-ffYUYdwZETmFJw0AcWY30WsaWBhJxj/zSmFXWjgEGEGZH56zwbbNwfMZOYZ1jz4haAVxGu+TdXsOl2yMGzN7jQ==",
       "requires": {
         "tslib": "^2.2.0"
       }
     },
     "@angular/compiler": {
       "version": "12.2.14",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/@angular/compiler/-/compiler-12.2.14.tgz",
-      "integrity": "sha1-NglA9eUFoAiStG3SjKabmje99q8=",
+      "resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-12.2.14.tgz",
+      "integrity": "sha512-dwmZi+n66IUzRFlGWu9mjXq170ZEsaDvlNLZzaPgs6vZTa4Kt7PWvIF/Y7TMvnVv/uqNG6kOhfmOkf6rfz1Gjg==",
       "requires": {
         "tslib": "^2.2.0"
       }
     },
     "@angular/compiler-cli": {
       "version": "12.2.14",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/@angular/compiler-cli/-/compiler-cli-12.2.14.tgz",
-      "integrity": "sha1-/aynPGlBsSMRltmArI7wLAfM820=",
+      "resolved": "https://registry.npmjs.org/@angular/compiler-cli/-/compiler-cli-12.2.14.tgz",
+      "integrity": "sha512-EktEOF2xnuMsUyanXjZw3hyn7w97NX9h8LJ3O9l27secbjYXhyrao5bmrMILdDTEJNeZSC/OuCga1pvdaJTYmg==",
       "dev": true,
       "requires": {
         "@babel/core": "^7.8.6",
@@ -743,14 +743,14 @@
       "dependencies": {
         "ansi-regex": {
           "version": "5.0.1",
-          "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/ansi-regex/-/ansi-regex-5.0.1.tgz",
-          "integrity": "sha1-CCyyyJyf6GWaMRpTvWpNxTAdswQ=",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+          "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
           "dev": true
         },
         "cliui": {
           "version": "7.0.4",
-          "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/cliui/-/cliui-7.0.4.tgz",
-          "integrity": "sha1-oCZe5lVHb8gHrqnfPfjfd4OAi08=",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
+          "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
           "dev": true,
           "requires": {
             "string-width": "^4.2.0",
@@ -760,14 +760,14 @@
         },
         "source-map": {
           "version": "0.6.1",
-          "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
           "dev": true
         },
         "string-width": {
           "version": "4.2.3",
-          "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/string-width/-/string-width-4.2.3.tgz",
-          "integrity": "sha1-JpxxF9J7Ba0uU2gwqOyJXvnG0BA=",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+          "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
           "dev": true,
           "requires": {
             "emoji-regex": "^8.0.0",
@@ -777,8 +777,8 @@
           "dependencies": {
             "strip-ansi": {
               "version": "6.0.1",
-              "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/strip-ansi/-/strip-ansi-6.0.1.tgz",
-              "integrity": "sha1-nibGPTD1NEPpSJSVshBdN7Z6hdk=",
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+              "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
               "dev": true,
               "requires": {
                 "ansi-regex": "^5.0.1"
@@ -788,8 +788,8 @@
         },
         "wrap-ansi": {
           "version": "7.0.0",
-          "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
-          "integrity": "sha1-Z+FFz/UQpqaYS98RUpEdadLrnkM=",
+          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+          "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
           "dev": true,
           "requires": {
             "ansi-styles": "^4.0.0",
@@ -799,14 +799,14 @@
         },
         "y18n": {
           "version": "5.0.8",
-          "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/y18n/-/y18n-5.0.8.tgz",
-          "integrity": "sha1-f0k00PfKjFb5UxSTndzS3ZHOHVU=",
+          "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+          "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
           "dev": true
         },
         "yargs": {
           "version": "17.3.0",
-          "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/yargs/-/yargs-17.3.0.tgz",
-          "integrity": "sha1-KVxP/Q7vFI7z5I96Lg9Y0OTyaxw=",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.3.0.tgz",
+          "integrity": "sha512-GQl1pWyDoGptFPJx9b9L6kmR33TGusZvXIZUT+BOz9f7X2L94oeAskFYLEg/FkhV06zZPBYLvLZRWeYId29lew==",
           "dev": true,
           "requires": {
             "cliui": "^7.0.2",
@@ -820,24 +820,24 @@
         },
         "yargs-parser": {
           "version": "21.0.0",
-          "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/yargs-parser/-/yargs-parser-21.0.0.tgz",
-          "integrity": "sha1-pIXTlmvkMXQm3Va9tqMBMbKB3FU=",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.0.0.tgz",
+          "integrity": "sha512-z9kApYUOCwoeZ78rfRYYWdiU/iNL6mwwYlkkZfJoyMR1xps+NEBX5X7XmRpxkZHhXJ6+Ey00IwKxBBSW9FIjyA==",
           "dev": true
         }
       }
     },
     "@angular/core": {
       "version": "12.2.14",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/@angular/core/-/core-12.2.14.tgz",
-      "integrity": "sha1-auFOY6iMU0zUjQMYTLsITsAxutE=",
+      "resolved": "https://registry.npmjs.org/@angular/core/-/core-12.2.14.tgz",
+      "integrity": "sha512-dlVk7yqUHL2R/eCmM8LsWuxhEBfzg0y1zHt0UqCuFwlCoiw+IG4HFy4OlZEUw9NUEZJSv0aDv3sWqxLkvK5vvg==",
       "requires": {
         "tslib": "^2.2.0"
       }
     },
     "@angular/forms": {
       "version": "12.2.14",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/@angular/forms/-/forms-12.2.14.tgz",
-      "integrity": "sha1-y4jBwUMuP8ddaDLfpOl8lmc5ZYY=",
+      "resolved": "https://registry.npmjs.org/@angular/forms/-/forms-12.2.14.tgz",
+      "integrity": "sha512-/9/gSJUBXVRVdRnzgJnALAQZYJATuGDMkFC9ms9DEMG4PMAhe9x4if1lJjN6noz5RAom3qNuVBNWaYAPUxlcBQ==",
       "dev": true,
       "requires": {
         "tslib": "^2.2.0"
@@ -845,24 +845,24 @@
     },
     "@angular/platform-browser": {
       "version": "12.2.14",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/@angular/platform-browser/-/platform-browser-12.2.14.tgz",
-      "integrity": "sha1-LADV80GCfcHeSt6Yq88ynwgkeQw=",
+      "resolved": "https://registry.npmjs.org/@angular/platform-browser/-/platform-browser-12.2.14.tgz",
+      "integrity": "sha512-fWcE2rnJ3ZCISa1oPfsIDV7FBZBoLFEdDuMXAiDYqDPKvF/E5U5nHrS+K4SlLAi094bMobtTOReNWl/Ienniyw==",
       "requires": {
         "tslib": "^2.2.0"
       }
     },
     "@angular/platform-browser-dynamic": {
       "version": "12.2.14",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/@angular/platform-browser-dynamic/-/platform-browser-dynamic-12.2.14.tgz",
-      "integrity": "sha1-IC/Ym6f3WMqZjuW2SY1Kg0Ry9mQ=",
+      "resolved": "https://registry.npmjs.org/@angular/platform-browser-dynamic/-/platform-browser-dynamic-12.2.14.tgz",
+      "integrity": "sha512-0NPF7mS91Tct8rBmOLZPmnLSuS4kbLHXo6eTgrg80OC0vlzBiQwGDVW4X3KncCoX9CpevaGJCdSMc+uPNsFOUQ==",
       "requires": {
         "tslib": "^2.2.0"
       }
     },
     "@angular/router": {
       "version": "12.2.14",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/@angular/router/-/router-12.2.14.tgz",
-      "integrity": "sha1-k/ll0uULtOz1oX/1IXzvJm+2fAY=",
+      "resolved": "https://registry.npmjs.org/@angular/router/-/router-12.2.14.tgz",
+      "integrity": "sha512-yP5grSnqBvc4vNhtYdcxDgDYIebUKs5f0xyFkUJM5030UnQ0CV45tBsSxHMkQbPZucIfOuxpRy8xy5+4GizuwQ==",
       "requires": {
         "tslib": "^2.2.0"
       }
@@ -2576,8 +2576,8 @@
     },
     "@gar/promisify": {
       "version": "1.1.2",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/@gar/promisify/-/promisify-1.1.2.tgz",
-      "integrity": "sha1-MKqCXxHUOGcdWFvUTn/VZFNfwhA=",
+      "resolved": "https://registry.npmjs.org/@gar/promisify/-/promisify-1.1.2.tgz",
+      "integrity": "sha512-82cpyJyKRoQoRi+14ibCeGPu0CwypgtBAdBhq1WfvagpCZNKqwXbKwXllYSMG91DhmG4jt9gN8eP6lGOtozuaw==",
       "dev": true
     },
     "@hapi/hoek": {
@@ -2660,8 +2660,8 @@
     },
     "@npmcli/fs": {
       "version": "1.0.0",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/@npmcli/fs/-/fs-1.0.0.tgz",
-      "integrity": "sha1-WJYSz606bqD+r8uQHSnGP9UtsJ8=",
+      "resolved": "https://registry.npmjs.org/@npmcli/fs/-/fs-1.0.0.tgz",
+      "integrity": "sha512-8ltnOpRR/oJbOp8vaGUnipOi3bqkcW+sLHFlyXIr08OGHmVJLB1Hn7QtGXbYcpVtH1gAYZTlmDXtE4YV0+AMMQ==",
       "dev": true,
       "requires": {
         "@gar/promisify": "^1.0.1",
@@ -2670,8 +2670,8 @@
     },
     "@npmcli/git": {
       "version": "2.1.0",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/@npmcli/git/-/git-2.1.0.tgz",
-      "integrity": "sha1-L7134UdTAkfTfzJZMNRXs+volPY=",
+      "resolved": "https://registry.npmjs.org/@npmcli/git/-/git-2.1.0.tgz",
+      "integrity": "sha512-/hBFX/QG1b+N7PZBFs0bi+evgRZcK9nWBxQKZkGoXUT5hJSwl5c4d7y8/hm+NQZRPhQ67RzFaj5UM9YeyKoryw==",
       "dev": true,
       "requires": {
         "@npmcli/promise-spawn": "^1.3.2",
@@ -2686,14 +2686,14 @@
       "dependencies": {
         "mkdirp": {
           "version": "1.0.4",
-          "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/mkdirp/-/mkdirp-1.0.4.tgz",
-          "integrity": "sha1-PrXtYmInVteaXw4qIh3+utdcL34=",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+          "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
           "dev": true
         },
         "which": {
           "version": "2.0.2",
-          "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/which/-/which-2.0.2.tgz",
-          "integrity": "sha1-fGqN0KY2oDJ+ELWckobu6T8/UbE=",
+          "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+          "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
           "dev": true,
           "requires": {
             "isexe": "^2.0.0"
@@ -2703,8 +2703,8 @@
     },
     "@npmcli/installed-package-contents": {
       "version": "1.0.7",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/@npmcli/installed-package-contents/-/installed-package-contents-1.0.7.tgz",
-      "integrity": "sha1-q3QIxhR5EblwqKviYc5RIjKj9Po=",
+      "resolved": "https://registry.npmjs.org/@npmcli/installed-package-contents/-/installed-package-contents-1.0.7.tgz",
+      "integrity": "sha512-9rufe0wnJusCQoLpV9ZPKIVP55itrM5BxOXs10DmdbRfgWtHy1LDyskbwRnBghuB0PrF7pNPOqREVtpz4HqzKw==",
       "dev": true,
       "requires": {
         "npm-bundled": "^1.1.1",
@@ -2731,14 +2731,14 @@
     },
     "@npmcli/node-gyp": {
       "version": "1.0.3",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/@npmcli/node-gyp/-/node-gyp-1.0.3.tgz",
-      "integrity": "sha1-qRLmN0GP/F8ts3XpO4WDdpGkOjM=",
+      "resolved": "https://registry.npmjs.org/@npmcli/node-gyp/-/node-gyp-1.0.3.tgz",
+      "integrity": "sha512-fnkhw+fmX65kiLqk6E3BFLXNC26rUhK90zVwe2yncPliVT/Qos3xjhTLE59Df8KnPlcwIERXKVlU1bXoUQ+liA==",
       "dev": true
     },
     "@npmcli/promise-spawn": {
       "version": "1.3.2",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/@npmcli/promise-spawn/-/promise-spawn-1.3.2.tgz",
-      "integrity": "sha1-QtTlao6SdPuhgNq8CupuOPKSdPU=",
+      "resolved": "https://registry.npmjs.org/@npmcli/promise-spawn/-/promise-spawn-1.3.2.tgz",
+      "integrity": "sha512-QyAGYo/Fbj4MXeGdJcFzZ+FkDkomfRBrPM+9QYJSg+PxgAUL+LU3FneQk37rKR2/zjqkCV1BLHccX98wRXG3Sg==",
       "dev": true,
       "requires": {
         "infer-owner": "^1.0.4"
@@ -2746,8 +2746,8 @@
     },
     "@npmcli/run-script": {
       "version": "1.8.6",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/@npmcli/run-script/-/run-script-1.8.6.tgz",
-      "integrity": "sha1-GDFIAqZmCw1Lqkw6/n8a052MKLc=",
+      "resolved": "https://registry.npmjs.org/@npmcli/run-script/-/run-script-1.8.6.tgz",
+      "integrity": "sha512-e42bVZnC6VluBZBAFEr3YrdqSspG3bgilyg4nSLBJ7TRGNCzxHa92XAHxQBLYg0BmgwO4b2mf3h/l5EkEWRn3g==",
       "dev": true,
       "requires": {
         "@npmcli/node-gyp": "^1.0.2",
@@ -3395,8 +3395,8 @@
     },
     "@yarnpkg/lockfile": {
       "version": "1.1.0",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/@yarnpkg/lockfile/-/lockfile-1.1.0.tgz",
-      "integrity": "sha1-53qX+9NFt22DJF7c0X05OxtB+zE=",
+      "resolved": "https://registry.npmjs.org/@yarnpkg/lockfile/-/lockfile-1.1.0.tgz",
+      "integrity": "sha512-GpSwvyXOcOOlV70vbnzjj4fW5xW/FdUF6nQEt1ENy7m4ZCczi1+/buVUPAqmGfqznsORNFzUMjctTIp8a9tuCQ==",
       "dev": true
     },
     "abab": {
@@ -3407,8 +3407,8 @@
     },
     "abbrev": {
       "version": "1.1.1",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/abbrev/-/abbrev-1.1.1.tgz",
-      "integrity": "sha1-+PLIh60Qv2f2NPAFtph/7TF5qsg=",
+      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
+      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
       "dev": true
     },
     "abortcontroller-polyfill": {
@@ -3459,8 +3459,8 @@
     },
     "agentkeepalive": {
       "version": "4.1.4",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/agentkeepalive/-/agentkeepalive-4.1.4.tgz",
-      "integrity": "sha1-2SgCikhiyxFxjlUieHLoQqRMlFs=",
+      "resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-4.1.4.tgz",
+      "integrity": "sha512-+V/rGa3EuU74H6wR04plBb7Ks10FbtUQgRj/FQOG7uUIEuaINI+AiqJR1k6t3SVNs7o7ZjIdus6706qqzVq8jQ==",
       "dev": true,
       "requires": {
         "debug": "^4.1.0",
@@ -3604,8 +3604,8 @@
     },
     "aproba": {
       "version": "1.2.0",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/aproba/-/aproba-1.2.0.tgz",
-      "integrity": "sha1-aALmJk79GMeQobDVF/DyYnvyyUo=",
+      "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
+      "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
       "dev": true
     },
     "arch": {
@@ -3668,8 +3668,8 @@
     },
     "are-we-there-yet": {
       "version": "1.1.7",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/are-we-there-yet/-/are-we-there-yet-1.1.7.tgz",
-      "integrity": "sha1-sVR0qTKtq0/4pQ2a36fk6SbyEUY=",
+      "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.7.tgz",
+      "integrity": "sha512-nxwy40TuMiUGqMyRHgCSWZ9FM4VAoRP4xUYSTv5ImRog+h9yISPbVH7H8fASCIzYn9wlEv4zvFL7uKDMCFQm3g==",
       "dev": true,
       "requires": {
         "delegates": "^1.0.0",
@@ -4546,7 +4546,7 @@
     },
     "builtins": {
       "version": "1.0.3",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/builtins/-/builtins-1.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/builtins/-/builtins-1.0.3.tgz",
       "integrity": "sha1-y5T662HIaWRR2zZTThQi+U8K7og=",
       "dev": true
     },
@@ -4696,8 +4696,8 @@
     },
     "canonical-path": {
       "version": "1.0.0",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/canonical-path/-/canonical-path-1.0.0.tgz",
-      "integrity": "sha1-/LRwwjlY3vhQgYVr56hukE8YDR0=",
+      "resolved": "https://registry.npmjs.org/canonical-path/-/canonical-path-1.0.0.tgz",
+      "integrity": "sha512-feylzsbDxi1gPZ1IjystzIQZagYYLvfKrSuygUCgf7z6x790VEzze5QEkdSV1U58RA7Hi0+v6fv4K54atOzATg==",
       "dev": true
     },
     "caseless": {
@@ -5378,7 +5378,7 @@
     },
     "console-control-strings": {
       "version": "1.1.0",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/console-control-strings/-/console-control-strings-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
       "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
       "dev": true
     },
@@ -6599,8 +6599,8 @@
     },
     "dependency-graph": {
       "version": "0.11.0",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/dependency-graph/-/dependency-graph-0.11.0.tgz",
-      "integrity": "sha1-rAzn7WilTaIhZahel6AdU/XrLic=",
+      "resolved": "https://registry.npmjs.org/dependency-graph/-/dependency-graph-0.11.0.tgz",
+      "integrity": "sha512-JeMq7fEshyepOWDfcfHK06N3MhyPhz++vtqWhMT5O9A3K42rdsEDpfdVqjaqaAhsw6a+ZqeDvQVtD0hFHQWrzg==",
       "dev": true
     },
     "destroy": {
@@ -6791,8 +6791,8 @@
     },
     "encoding": {
       "version": "0.1.13",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/encoding/-/encoding-0.1.13.tgz",
-      "integrity": "sha1-VldK/deR9UqOmyeFwFgqLSYhD6k=",
+      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
+      "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
       "dev": true,
       "optional": true,
       "requires": {
@@ -6801,8 +6801,8 @@
       "dependencies": {
         "iconv-lite": {
           "version": "0.6.3",
-          "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/iconv-lite/-/iconv-lite-0.6.3.tgz",
-          "integrity": "sha1-pS+AvzjaGVLrXGgXkHGYcaGnJQE=",
+          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+          "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -6891,14 +6891,14 @@
     },
     "env-paths": {
       "version": "2.2.1",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/env-paths/-/env-paths-2.2.1.tgz",
-      "integrity": "sha1-QgOZ1BbOH76bwKB8Yvpo1n/Q+PI=",
+      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
+      "integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
       "dev": true
     },
     "err-code": {
       "version": "2.0.3",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/err-code/-/err-code-2.0.3.tgz",
-      "integrity": "sha1-I8Lzt1b/38YI0w4nyalBAkgH5/k=",
+      "resolved": "https://registry.npmjs.org/err-code/-/err-code-2.0.3.tgz",
+      "integrity": "sha512-2bmlRpNKBxT/CRmPOlyISQpNj+qSeYvcym/uT0Jx2bMOlKLtSy1ZmLuVxSEKKyor/N5yhvp/ZiG1oE3DEYMSFA==",
       "dev": true
     },
     "errno": {
@@ -7692,7 +7692,7 @@
     },
     "gauge": {
       "version": "2.7.4",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/gauge/-/gauge-2.7.4.tgz",
+      "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
       "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
       "dev": true,
       "requires": {
@@ -7708,13 +7708,13 @@
       "dependencies": {
         "ansi-regex": {
           "version": "2.1.1",
-          "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/ansi-regex/-/ansi-regex-2.1.1.tgz",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
           "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
           "dev": true
         },
         "is-fullwidth-code-point": {
           "version": "1.0.0",
-          "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "dev": true,
           "requires": {
@@ -7723,7 +7723,7 @@
         },
         "string-width": {
           "version": "1.0.2",
-          "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/string-width/-/string-width-1.0.2.tgz",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "dev": true,
           "requires": {
@@ -7734,7 +7734,7 @@
         },
         "strip-ansi": {
           "version": "3.0.1",
-          "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
           "requires": {
@@ -8014,7 +8014,7 @@
     },
     "has-unicode": {
       "version": "2.0.1",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/has-unicode/-/has-unicode-2.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
       "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
       "dev": true
     },
@@ -8078,8 +8078,8 @@
     },
     "hosted-git-info": {
       "version": "4.0.2",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/hosted-git-info/-/hosted-git-info-4.0.2.tgz",
-      "integrity": "sha1-XkJVB+7eT+qEa3Ji8IOEVsQgmWE=",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-4.0.2.tgz",
+      "integrity": "sha512-c9OGXbZ3guC/xOlCg1Ci/VgWlwsqDv1yMQL1CWqXDL0hDjXuNcq0zuR4xqPSuasI3kqFDhqSyTjREz5gzq0fXg==",
       "dev": true,
       "requires": {
         "lru-cache": "^6.0.0"
@@ -8191,8 +8191,8 @@
     },
     "http-proxy-agent": {
       "version": "4.0.1",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/http-proxy-agent/-/http-proxy-agent-4.0.1.tgz",
-      "integrity": "sha1-ioyO9/WTLM+VPClsqCkblap0qjo=",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-4.0.1.tgz",
+      "integrity": "sha512-k0zdNgqWTGA6aeIRVpvfVob4fL52dTfaehylg0Y4UvSySvOq/Y+BOyPrgpUrA7HylqvU8vIZGsRuXmspskV0Tg==",
       "dev": true,
       "requires": {
         "@tootallnate/once": "1",
@@ -8202,8 +8202,8 @@
       "dependencies": {
         "agent-base": {
           "version": "6.0.2",
-          "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/agent-base/-/agent-base-6.0.2.tgz",
-          "integrity": "sha1-Sf/1hXfP7j83F2/qtMIuAPhtf3c=",
+          "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+          "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
           "dev": true,
           "requires": {
             "debug": "4"
@@ -8378,7 +8378,7 @@
     },
     "humanize-ms": {
       "version": "1.2.1",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/humanize-ms/-/humanize-ms-1.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/humanize-ms/-/humanize-ms-1.2.1.tgz",
       "integrity": "sha1-xG4xWaKT9riW2ikxbYtv6Lt5u+0=",
       "dev": true,
       "requires": {
@@ -8922,7 +8922,7 @@
     },
     "is-lambda": {
       "version": "1.0.1",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/is-lambda/-/is-lambda-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/is-lambda/-/is-lambda-1.0.1.tgz",
       "integrity": "sha1-PZh3iZ5qU+/AFgUEzeFfgubwYdU=",
       "dev": true
     },
@@ -9380,7 +9380,7 @@
     },
     "jsonparse": {
       "version": "1.3.1",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/jsonparse/-/jsonparse-1.3.1.tgz",
+      "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
       "integrity": "sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA=",
       "dev": true
     },
@@ -10391,8 +10391,8 @@
     },
     "make-fetch-happen": {
       "version": "9.1.0",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/make-fetch-happen/-/make-fetch-happen-9.1.0.tgz",
-      "integrity": "sha1-UwhaCeeXFDPmdl95cb9j9OBcuWg=",
+      "resolved": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-9.1.0.tgz",
+      "integrity": "sha512-+zopwDy7DNknmwPQplem5lAZX/eCOzSvSNNcSKm5eVwTkOBzoktEfXsa9L23J/GIRhxRsaxzkPEhrJEpE2F4Gg==",
       "dev": true,
       "requires": {
         "agentkeepalive": "^4.1.3",
@@ -10415,8 +10415,8 @@
       "dependencies": {
         "agent-base": {
           "version": "6.0.2",
-          "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/agent-base/-/agent-base-6.0.2.tgz",
-          "integrity": "sha1-Sf/1hXfP7j83F2/qtMIuAPhtf3c=",
+          "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+          "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
           "dev": true,
           "requires": {
             "debug": "4"
@@ -10424,8 +10424,8 @@
         },
         "cacache": {
           "version": "15.3.0",
-          "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/cacache/-/cacache-15.3.0.tgz",
-          "integrity": "sha1-3IU4D7L1Vv492kxxm/oOyHWn8es=",
+          "resolved": "https://registry.npmjs.org/cacache/-/cacache-15.3.0.tgz",
+          "integrity": "sha512-VVdYzXEn+cnbXpFgWs5hTT7OScegHVmLhJIR8Ufqk3iFD6A6j5iSX1KuBTfNEv4tdJWE2PzA6IVFtcLC7fN9wQ==",
           "dev": true,
           "requires": {
             "@npmcli/fs": "^1.0.0",
@@ -10450,8 +10450,8 @@
         },
         "https-proxy-agent": {
           "version": "5.0.0",
-          "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/https-proxy-agent/-/https-proxy-agent-5.0.0.tgz",
-          "integrity": "sha1-4qkFQqu2inYuCghQ9sntrf2FBrI=",
+          "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.0.tgz",
+          "integrity": "sha512-EkYm5BcKUGiduxzSt3Eppko+PiNWNEpa4ySk9vTC6wDsQJW9rHSa+UhGNJoRYp7bz6Ht1eaRIa6QaJqO5rCFbA==",
           "dev": true,
           "requires": {
             "agent-base": "6",
@@ -10460,8 +10460,8 @@
         },
         "mkdirp": {
           "version": "1.0.4",
-          "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/mkdirp/-/mkdirp-1.0.4.tgz",
-          "integrity": "sha1-PrXtYmInVteaXw4qIh3+utdcL34=",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+          "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
           "dev": true
         }
       }
@@ -10712,8 +10712,8 @@
     },
     "minipass-fetch": {
       "version": "1.4.1",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/minipass-fetch/-/minipass-fetch-1.4.1.tgz",
-      "integrity": "sha1-114AkdqsGw/9fp1BYp+v99DB8bY=",
+      "resolved": "https://registry.npmjs.org/minipass-fetch/-/minipass-fetch-1.4.1.tgz",
+      "integrity": "sha512-CGH1eblLq26Y15+Azk7ey4xh0J/XfJfrCox5LDJiKqI2Q2iwOLOKrlmIaODiSQS8d18jalF6y2K2ePUm0CmShw==",
       "dev": true,
       "requires": {
         "encoding": "^0.1.12",
@@ -10733,8 +10733,8 @@
     },
     "minipass-json-stream": {
       "version": "1.0.1",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/minipass-json-stream/-/minipass-json-stream-1.0.1.tgz",
-      "integrity": "sha1-ftu5JYj7/C/x2y/BA5est7a0Sqc=",
+      "resolved": "https://registry.npmjs.org/minipass-json-stream/-/minipass-json-stream-1.0.1.tgz",
+      "integrity": "sha512-ODqY18UZt/I8k+b7rl2AENgbWE8IDYam+undIJONvigAz8KR5GWblsFTEfQs0WODsjbSXWlm+JHEv8Gr6Tfdbg==",
       "dev": true,
       "requires": {
         "jsonparse": "^1.3.1",
@@ -10752,8 +10752,8 @@
     },
     "minipass-sized": {
       "version": "1.0.3",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/minipass-sized/-/minipass-sized-1.0.3.tgz",
-      "integrity": "sha1-cO5afFBSBwr6z7wil36nne81O3A=",
+      "resolved": "https://registry.npmjs.org/minipass-sized/-/minipass-sized-1.0.3.tgz",
+      "integrity": "sha512-MbkQQ2CTiBMlA2Dm/5cY+9SWFEN8pzzOXi6rlM5Xxq0Yqbda5ZQy9sU75a673FE9ZK0Zsbr6Y5iP6u9nktfg2g==",
       "dev": true,
       "requires": {
         "minipass": "^3.0.0"
@@ -11056,8 +11056,8 @@
     },
     "node-gyp": {
       "version": "7.1.2",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/node-gyp/-/node-gyp-7.1.2.tgz",
-      "integrity": "sha1-IagQrrsYcSAlHDvOyXmvFYexiK4=",
+      "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-7.1.2.tgz",
+      "integrity": "sha512-CbpcIo7C3eMu3dL1c3d0xw449fHIGALIJsRP4DDPHpyiW8vcriNY7ubh9TE4zEKfSxscY7PjeFnshE7h75ynjQ==",
       "dev": true,
       "requires": {
         "env-paths": "^2.2.0",
@@ -11074,8 +11074,8 @@
       "dependencies": {
         "which": {
           "version": "2.0.2",
-          "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/which/-/which-2.0.2.tgz",
-          "integrity": "sha1-fGqN0KY2oDJ+ELWckobu6T8/UbE=",
+          "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+          "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
           "dev": true,
           "requires": {
             "isexe": "^2.0.0"
@@ -11100,8 +11100,8 @@
     },
     "nopt": {
       "version": "5.0.0",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/nopt/-/nopt-5.0.0.tgz",
-      "integrity": "sha1-UwlCu1ilEvzK/lP+IQ8TolNV3Ig=",
+      "resolved": "https://registry.npmjs.org/nopt/-/nopt-5.0.0.tgz",
+      "integrity": "sha512-Tbj67rffqceeLpcRXrT7vKAN8CwfPeIBgM7E6iBkmKLV7bEMwpGgYLGv0jACUsECaa/vuxP0IjEont6umdMgtQ==",
       "dev": true,
       "requires": {
         "abbrev": "1"
@@ -11153,8 +11153,8 @@
     },
     "npm-bundled": {
       "version": "1.1.2",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/npm-bundled/-/npm-bundled-1.1.2.tgz",
-      "integrity": "sha1-lEx4eJvXOQNbcLqiylzDK42GC8E=",
+      "resolved": "https://registry.npmjs.org/npm-bundled/-/npm-bundled-1.1.2.tgz",
+      "integrity": "sha512-x5DHup0SuyQcmL3s7Rx/YQ8sbw/Hzg0rj48eN0dV7hf5cmQq5PXIeioroH3raV1QC1yh3uTYuMThvEQF3iKgGQ==",
       "dev": true,
       "requires": {
         "npm-normalize-package-bin": "^1.0.1"
@@ -11162,8 +11162,8 @@
     },
     "npm-install-checks": {
       "version": "4.0.0",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/npm-install-checks/-/npm-install-checks-4.0.0.tgz",
-      "integrity": "sha1-o3+sx2Oi/eBJfvLG0Kx8P74A17Q=",
+      "resolved": "https://registry.npmjs.org/npm-install-checks/-/npm-install-checks-4.0.0.tgz",
+      "integrity": "sha512-09OmyDkNLYwqKPOnbI8exiOZU2GVVmQp7tgez2BPi5OZC8M82elDAps7sxC4l//uSUtotWqoEIDwjRvWH4qz8w==",
       "dev": true,
       "requires": {
         "semver": "^7.1.1"
@@ -11171,14 +11171,14 @@
     },
     "npm-normalize-package-bin": {
       "version": "1.0.1",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/npm-normalize-package-bin/-/npm-normalize-package-bin-1.0.1.tgz",
-      "integrity": "sha1-bnmkHyP9I1wGIyGCKNp9nCO49uI=",
+      "resolved": "https://registry.npmjs.org/npm-normalize-package-bin/-/npm-normalize-package-bin-1.0.1.tgz",
+      "integrity": "sha512-EPfafl6JL5/rU+ot6P3gRSCpPDW5VmIzX959Ob1+ySFUuuYHWHekXpwdUZcKP5C+DS4GEtdJluwBjnsNDl+fSA==",
       "dev": true
     },
     "npm-package-arg": {
       "version": "8.1.5",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/npm-package-arg/-/npm-package-arg-8.1.5.tgz",
-      "integrity": "sha1-M2my1f6P3GdLqn8XhlFN3BVGbkQ=",
+      "resolved": "https://registry.npmjs.org/npm-package-arg/-/npm-package-arg-8.1.5.tgz",
+      "integrity": "sha512-LhgZrg0n0VgvzVdSm1oiZworPbTxYHUJCgtsJW8mGvlDpxTM1vSJc3m5QZeUkhAHIzbz3VCHd/R4osi1L1Tg/Q==",
       "dev": true,
       "requires": {
         "hosted-git-info": "^4.0.1",
@@ -11188,8 +11188,8 @@
     },
     "npm-packlist": {
       "version": "2.2.2",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/npm-packlist/-/npm-packlist-2.2.2.tgz",
-      "integrity": "sha1-B2uXKT+mIPYygzGGp6j2WqphSMg=",
+      "resolved": "https://registry.npmjs.org/npm-packlist/-/npm-packlist-2.2.2.tgz",
+      "integrity": "sha512-Jt01acDvJRhJGthnUJVF/w6gumWOZxO7IkpY/lsX9//zqQgnF7OJaxgQXcerd4uQOLu7W5bkb4mChL9mdfm+Zg==",
       "dev": true,
       "requires": {
         "glob": "^7.1.6",
@@ -11200,8 +11200,8 @@
     },
     "npm-pick-manifest": {
       "version": "6.1.1",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/npm-pick-manifest/-/npm-pick-manifest-6.1.1.tgz",
-      "integrity": "sha1-e1SEyiyQhWX0O38nZE82u4FvUUg=",
+      "resolved": "https://registry.npmjs.org/npm-pick-manifest/-/npm-pick-manifest-6.1.1.tgz",
+      "integrity": "sha512-dBsdBtORT84S8V8UTad1WlUyKIY9iMsAmqxHbLdeEeBNMLQDlDWWra3wYUx9EBEIiG/YwAy0XyNHDd2goAsfuA==",
       "dev": true,
       "requires": {
         "npm-install-checks": "^4.0.0",
@@ -11212,8 +11212,8 @@
     },
     "npm-registry-fetch": {
       "version": "11.0.0",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/npm-registry-fetch/-/npm-registry-fetch-11.0.0.tgz",
-      "integrity": "sha1-aMG7gQxGVCdg1ipqll+FpwLUOnY=",
+      "resolved": "https://registry.npmjs.org/npm-registry-fetch/-/npm-registry-fetch-11.0.0.tgz",
+      "integrity": "sha512-jmlgSxoDNuhAtxUIG6pVwwtz840i994dL14FoNVZisrmZW5kWd63IUTNv1m/hyRSGSqWjCUp/YZlS1BJyNp9XA==",
       "dev": true,
       "requires": {
         "make-fetch-happen": "^9.0.1",
@@ -11235,8 +11235,8 @@
     },
     "npmlog": {
       "version": "4.1.2",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/npmlog/-/npmlog-4.1.2.tgz",
-      "integrity": "sha1-CKfyqL9zRgR3mp76StXMcXq7lUs=",
+      "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
+      "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
       "dev": true,
       "requires": {
         "are-we-there-yet": "~1.1.2",
@@ -11421,6 +11421,19 @@
           "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.0.2.tgz",
           "integrity": "sha512-xKqzzWXDttJuOcawBt4KnKHHIf5oQ/Cxax+0PWFG+DFDgHNAdi+TXECADI+RYiFUMmx8792xsMbbgXj4CwnP4g==",
           "dev": true
+        },
+        "paseto2": {
+          "version": "npm:paseto@2.1.3",
+          "resolved": "https://registry.npmjs.org/paseto/-/paseto-2.1.3.tgz",
+          "integrity": "sha512-BNkbvr0ZFDbh3oV13QzT5jXIu8xpFc9r0o5mvWBhDU1GBkVt1IzHK1N6dcYmN7XImrUmPQ0HCUXmoe2WPo8xsg==",
+          "dev": true
+        },
+        "paseto3": {
+          "version": "npm:paseto@3.1.0",
+          "resolved": "https://registry.npmjs.org/paseto/-/paseto-3.1.0.tgz",
+          "integrity": "sha512-oVSKoCH89M0WU3I+13NoCP9wGRel0BlQumwxsDZPk1yJtqS76PWKRM7vM9D4bz4PcScT0aIiAipC7lW6hSgkBQ==",
+          "dev": true,
+          "optional": true
         },
         "raw-body": {
           "version": "2.4.1",
@@ -11652,8 +11665,8 @@
     },
     "pacote": {
       "version": "11.3.5",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/pacote/-/pacote-11.3.5.tgz",
-      "integrity": "sha1-c88fw3crUz9XXjnvqWxQvow9ydI=",
+      "resolved": "https://registry.npmjs.org/pacote/-/pacote-11.3.5.tgz",
+      "integrity": "sha512-fT375Yczn4zi+6Hkk2TBe1x1sP8FgFsEIZ2/iWaXY2r/NkhDJfxbcn5paz1+RTFCyNf+dPnaoBDJoAxXSU8Bkg==",
       "dev": true,
       "requires": {
         "@npmcli/git": "^2.1.0",
@@ -11679,8 +11692,8 @@
       "dependencies": {
         "mkdirp": {
           "version": "1.0.4",
-          "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/mkdirp/-/mkdirp-1.0.4.tgz",
-          "integrity": "sha1-PrXtYmInVteaXw4qIh3+utdcL34=",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+          "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
           "dev": true
         }
       }
@@ -11771,19 +11784,6 @@
       "resolved": "https://registry.npmjs.org/pascalcase/-/pascalcase-0.1.1.tgz",
       "integrity": "sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ=",
       "dev": true
-    },
-    "paseto2": {
-      "version": "npm:paseto@2.1.3",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/paseto/-/paseto-2.1.3.tgz",
-      "integrity": "sha1-mRP59GFyzojDl6DwNf3+3TTYJ+8=",
-      "dev": true
-    },
-    "paseto3": {
-      "version": "npm:paseto@3.1.0",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/paseto/-/paseto-3.1.0.tgz",
-      "integrity": "sha1-4Y4yijXS+Ijp+1bkZP45jYQpQkM=",
-      "dev": true,
-      "optional": true
     },
     "path-dirname": {
       "version": "1.0.2",
@@ -13863,8 +13863,8 @@
     },
     "promise-retry": {
       "version": "2.0.1",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/promise-retry/-/promise-retry-2.0.1.tgz",
-      "integrity": "sha1-/3R6E2IKtXumiPX8Z4VUEMNw2iI=",
+      "resolved": "https://registry.npmjs.org/promise-retry/-/promise-retry-2.0.1.tgz",
+      "integrity": "sha512-y+WKFlBR8BGXnsNlIHFGPZmyDf3DFMoLhaflAnyZgV6rG6xu+JwesTo2Q9R6XwYmtmwAFCkAk3e35jEdoeh/3g==",
       "dev": true,
       "requires": {
         "err-code": "^2.0.2",
@@ -14194,8 +14194,8 @@
     },
     "read-package-json-fast": {
       "version": "2.0.3",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/read-package-json-fast/-/read-package-json-fast-2.0.3.tgz",
-      "integrity": "sha1-MjylKWMNqCyzSzbMC5lmk8mMK4M=",
+      "resolved": "https://registry.npmjs.org/read-package-json-fast/-/read-package-json-fast-2.0.3.tgz",
+      "integrity": "sha512-W/BKtbL+dUjTuRL2vziuYhp76s5HZ9qQhd/dKfWIZveD0O40453QNyZhC0e63lqZrAQ4jiOapVoeJ7JrszenQQ==",
       "dev": true,
       "requires": {
         "json-parse-even-better-errors": "^2.3.0",
@@ -14274,8 +14274,8 @@
     },
     "reflect-metadata": {
       "version": "0.1.13",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/reflect-metadata/-/reflect-metadata-0.1.13.tgz",
-      "integrity": "sha1-Z648pXyXKiqhZCsQ/jY/4y1J3Ag=",
+      "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.1.13.tgz",
+      "integrity": "sha512-Ts1Y/anZELhSsjMcU605fU9RE4Oi3p5ORujwbIKXfWa+0Zxs510Qrmrce5/Jowq3cHSZSJqBjypxmHarc+vEWg==",
       "dev": true
     },
     "regenerate": {
@@ -15084,8 +15084,8 @@
     },
     "smart-buffer": {
       "version": "4.2.0",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/smart-buffer/-/smart-buffer-4.2.0.tgz",
-      "integrity": "sha1-bh1x+k8YwF99D/IW3RakgdDo2a4=",
+      "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
+      "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
       "dev": true
     },
     "snapdragon": {
@@ -15323,8 +15323,8 @@
     },
     "socks": {
       "version": "2.6.1",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/socks/-/socks-2.6.1.tgz",
-      "integrity": "sha1-mJ5lNKB88zfesbHJSqpEKWUg0w4=",
+      "resolved": "https://registry.npmjs.org/socks/-/socks-2.6.1.tgz",
+      "integrity": "sha512-kLQ9N5ucj8uIcxrDwjm0Jsqk06xdpBjGNQtpXy4Q8/QY2k+fY7nZH8CARy+hkbG+SGAovmzzuauCpBlb8FrnBA==",
       "dev": true,
       "requires": {
         "ip": "^1.1.5",
@@ -15333,8 +15333,8 @@
     },
     "socks-proxy-agent": {
       "version": "6.1.1",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/socks-proxy-agent/-/socks-proxy-agent-6.1.1.tgz",
-      "integrity": "sha1-5mTo8ar04fs9+UXwnj2U+RETf4c=",
+      "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-6.1.1.tgz",
+      "integrity": "sha512-t8J0kG3csjA4g6FTbsMOWws+7R7vuRC8aQ/wy3/1OWmsgwA68zs/+cExQ0koSitUDXqhufF/YJr9wtNMZHw5Ew==",
       "dev": true,
       "requires": {
         "agent-base": "^6.0.2",
@@ -15344,8 +15344,8 @@
       "dependencies": {
         "agent-base": {
           "version": "6.0.2",
-          "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/agent-base/-/agent-base-6.0.2.tgz",
-          "integrity": "sha1-Sf/1hXfP7j83F2/qtMIuAPhtf3c=",
+          "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+          "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
           "dev": true,
           "requires": {
             "debug": "4"
@@ -15353,8 +15353,8 @@
         },
         "debug": {
           "version": "4.3.3",
-          "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/debug/-/debug-4.3.3.tgz",
-          "integrity": "sha1-BCZuC3CpjURi5uKI44JZITMytmQ=",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
+          "integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
           "dev": true,
           "requires": {
             "ms": "2.1.2"
@@ -16694,7 +16694,7 @@
     },
     "validate-npm-package-name": {
       "version": "3.0.0",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/validate-npm-package-name/-/validate-npm-package-name-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/validate-npm-package-name/-/validate-npm-package-name-3.0.0.tgz",
       "integrity": "sha1-X6kS2B630MdK/BQN5zF/DKffQ34=",
       "dev": true,
       "requires": {
@@ -17450,8 +17450,8 @@
     },
     "wide-align": {
       "version": "1.1.5",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/wide-align/-/wide-align-1.1.5.tgz",
-      "integrity": "sha1-3x1MIGhUNp7PPJpImPGyP72dFdM=",
+      "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.5.tgz",
+      "integrity": "sha512-eDMORYaPNZ4sQIuuYPDHdQvf4gyCF9rEEV/yPxGfwPkRodwEgiMUUXTx/dex+Me0wxx53S+NgUHaP7y3MGlDmg==",
       "dev": true,
       "requires": {
         "string-width": "^1.0.2 || 2 || 3 || 4"


### PR DESCRIPTION
CI is failing because it needs a password to pull from jfrog. This is because jfrog was accidentally used to upgrade Auth0-SPA-JS.
This PR ensures we do not pull from jfrog.