### PR TITLE
[SDK-3101] Support user and claims for non-default audiences

### DIFF
--- a/projects/auth0-angular/src/lib/auth.service.spec.ts
+++ b/projects/auth0-angular/src/lib/auth.service.spec.ts
@@ -674,6 +674,52 @@ describe('AuthService', () => {
     });
   });
 
+  describe('getUser', () => {
+    it('should call `getUser`', async () => {
+      await service.getUser().toPromise();
+      expect(auth0Client.getUser).toHaveBeenCalled();
+    });
+
+    it('should call `getUser` and pass options', async () => {
+      const options = { audience: 'http://localhost:3001' };
+
+      await service.getUser(options).toPromise();
+      expect(auth0Client.getUser).toHaveBeenCalledWith(options);
+    });
+
+    it('should return the user from `getUser`', async () => {
+      const options = { audience: 'http://localhost:3001' };
+      const expected = { name: 'John Doe' };
+      (auth0Client.getUser as jasmine.Spy).and.resolveTo(expected);
+
+      const user = await service.getUser(options).toPromise();
+      expect(user).toBe(expected);
+    });
+  });
+
+  describe('getIdTokenClaims', () => {
+    it('should call `getIdTokenClaims`', async () => {
+      await service.getIdTokenClaims().toPromise();
+      expect(auth0Client.getIdTokenClaims).toHaveBeenCalled();
+    });
+
+    it('should call `getIdTokenClaims` and pass options', async () => {
+      const options = { audience: 'http://localhost:3001' };
+
+      await service.getIdTokenClaims(options).toPromise();
+      expect(auth0Client.getIdTokenClaims).toHaveBeenCalledWith(options);
+    });
+
+    it('should return the claims from `getIdTokenClaims`', async () => {
+      const options = { audience: 'http://localhost:3001' };
+      const expected = { __raw: '', name: 'John Doe' };
+      (auth0Client.getIdTokenClaims as jasmine.Spy).and.resolveTo(expected);
+
+      const claims = await service.getIdTokenClaims(options).toPromise();
+      expect(claims).toBe(expected);
+    });
+  });
+
   describe('handleRedirectCallback', () => {
     let navigator: AbstractNavigator;
 

--- a/projects/auth0-angular/src/lib/auth.service.ts
+++ b/projects/auth0-angular/src/lib/auth.service.ts
@@ -306,8 +306,10 @@ export class AuthService<TAppState extends AppState = AppState>
    * @typeparam TUser The type to return, has to extend {@link User}.
    * @param options The options to get the user
    */
-  getUser(options?: GetUserOptions): Observable<User | undefined> {
-    return defer(() => this.auth0Client.getUser(options));
+  getUser<TUser extends User>(
+    options?: GetUserOptions
+  ): Observable<TUser | undefined> {
+    return defer(() => this.auth0Client.getUser<TUser>(options));
   }
 
   /**

--- a/projects/auth0-angular/src/lib/auth.service.ts
+++ b/projects/auth0-angular/src/lib/auth.service.ts
@@ -304,7 +304,7 @@ export class AuthService<TAppState extends AppState = AppState>
    * The returned observable will emit once and then complete.
    *
    * @typeparam TUser The type to return, has to extend {@link User}.
-   * @param options
+   * @param options The options to get the user
    */
   getUser(options?: GetUserOptions): Observable<User | undefined> {
     return defer(() => this.auth0Client.getUser(options));
@@ -325,7 +325,7 @@ export class AuthService<TAppState extends AppState = AppState>
    *
    * The returned observable will emit once and then complete.
    *
-   * @param options
+   * @param options The options to get the Id token claims
    */
   getIdTokenClaims(
     options?: GetIdTokenClaimsOptions

--- a/projects/auth0-angular/src/lib/auth.service.ts
+++ b/projects/auth0-angular/src/lib/auth.service.ts
@@ -11,6 +11,10 @@ import {
   RedirectLoginResult,
   LogoutUrlOptions,
   GetTokenSilentlyVerboseResponse,
+  GetUserOptions,
+  User,
+  GetIdTokenClaimsOptions,
+  IdToken,
 } from '@auth0/auth0-spa-js';
 
 import {
@@ -36,16 +40,14 @@ import {
 
 import { Auth0ClientService } from './auth.client';
 import { AbstractNavigator } from './abstract-navigator';
-import {
-  AuthClientConfig,
-  AppState,
-} from './auth.config';
+import { AuthClientConfig, AppState } from './auth.config';
 import { AuthState } from './auth.state';
 
 @Injectable({
   providedIn: 'root',
 })
-export class AuthService<TAppState extends AppState = AppState> implements OnDestroy {
+export class AuthService<TAppState extends AppState = AppState>
+  implements OnDestroy {
   private appStateSubject$ = new ReplaySubject<TAppState>(1);
 
   // https://stackoverflow.com/a/41177163
@@ -135,7 +137,9 @@ export class AuthService<TAppState extends AppState = AppState> implements OnDes
    *
    * @param options The login options
    */
-  loginWithRedirect(options?: RedirectLoginOptions<TAppState>): Observable<void> {
+  loginWithRedirect(
+    options?: RedirectLoginOptions<TAppState>
+  ): Observable<void> {
     return from(this.auth0Client.loginWithRedirect(options));
   }
 
@@ -285,6 +289,52 @@ export class AuthService<TAppState extends AppState = AppState> implements OnDes
 
   /**
    * ```js
+   * getUser(options).subscribe(user => ...);
+   * ```
+   *
+   * Returns the user information if available (decoded
+   * from the `id_token`).
+   *
+   * If you provide an audience or scope, they should match an existing Access Token
+   * (the SDK stores a corresponding ID Token with every Access Token, and uses the
+   * scope and audience to look up the ID Token)
+   *
+   * @remarks
+   *
+   * The returned observable will emit once and then complete.
+   *
+   * @typeparam TUser The type to return, has to extend {@link User}.
+   * @param options
+   */
+  getUser(options?: GetUserOptions): Observable<User | undefined> {
+    return defer(() => this.auth0Client.getUser(options));
+  }
+
+  /**
+   * ```js
+   * getIdTokenClaims(options).subscribe(claims => ...);
+   * ```
+   *
+   * Returns all claims from the id_token if available.
+   *
+   * If you provide an audience or scope, they should match an existing Access Token
+   * (the SDK stores a corresponding ID Token with every Access Token, and uses the
+   * scope and audience to look up the ID Token)
+   *
+   * @remarks
+   *
+   * The returned observable will emit once and then complete.
+   *
+   * @param options
+   */
+  getIdTokenClaims(
+    options?: GetIdTokenClaimsOptions
+  ): Observable<IdToken | undefined> {
+    return defer(() => this.auth0Client.getIdTokenClaims(options));
+  }
+
+  /**
+   * ```js
    * handleRedirectCallback(url).subscribe(result => ...)
    * ```
    *
@@ -297,8 +347,12 @@ export class AuthService<TAppState extends AppState = AppState> implements OnDes
    *
    * @param url The URL to that should be used to retrieve the `state` and `code` values. Defaults to `window.location.href` if not given.
    */
-  handleRedirectCallback(url?: string): Observable<RedirectLoginResult<TAppState>> {
-    return defer(() => this.auth0Client.handleRedirectCallback<TAppState>(url)).pipe(
+  handleRedirectCallback(
+    url?: string
+  ): Observable<RedirectLoginResult<TAppState>> {
+    return defer(() =>
+      this.auth0Client.handleRedirectCallback<TAppState>(url)
+    ).pipe(
       withLatestFrom(this.authState.isLoading$),
       tap(([result, isLoading]) => {
         if (!isLoading) {


### PR DESCRIPTION
Adds support for getting user and claims for non-default audience by exposing the underlying SPA-JS methods.
These methods return an Observable that emits and completes as it's not tracking anything over time.

Even tho doing this was not impossible, it did require the use of the underlying Auth0Client directly, which I would recommend to avoid.

Closes #225
