### PR TITLE
Provide an Ivy Distribution

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11822,7 +11822,8 @@
       "version": "npm:paseto@3.1.0",
       "resolved": "https://registry.npmjs.org/paseto/-/paseto-3.1.0.tgz",
       "integrity": "sha512-oVSKoCH89M0WU3I+13NoCP9wGRel0BlQumwxsDZPk1yJtqS76PWKRM7vM9D4bz4PcScT0aIiAipC7lW6hSgkBQ==",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "path-dirname": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "start:local:playground": "ng serve --configuration=local",
     "prebuild": "npm run update-useragent",
     "build": "ng build && npm run build:schematics",
-    "build:prod": "ng build --prod && npm run build:schematics",
+    "build:prod": "ng build --configuration production && npm run build:schematics",
     "build:schematics": "npm run build --prefix projects/auth0-angular",
     "prepublishOnly": "node scripts/prepublish-stopper.js",
     "postbuild": "npm run docs",

--- a/projects/auth0-angular/ng-package.json
+++ b/projects/auth0-angular/ng-package.json
@@ -4,5 +4,5 @@
   "lib": {
     "entryFile": "src/public-api.ts"
   },
-  "whitelistedNonPeerDependencies": ["tslib", "@auth0/auth0-spa-js"]
+  "allowedNonPeerDependencies": ["tslib", "@auth0/auth0-spa-js"]
 }

--- a/projects/auth0-angular/package.json
+++ b/projects/auth0-angular/package.json
@@ -26,9 +26,9 @@
   },
   "homepage": "https://github.com/auth0/auth0-angular#readme",
   "peerDependencies": {
-    "@angular/common": ">=9 <=13",
-    "@angular/core": ">=9 <=13",
-    "@angular/router": ">=9 <=13"
+    "@angular/common": ">=11 <=13",
+    "@angular/core": ">=11 <=13",
+    "@angular/router": ">=11 <=13"
   },
   "dependencies": {
     "tslib": "^2.0.0",

--- a/projects/auth0-angular/tsconfig.lib.prod.json
+++ b/projects/auth0-angular/tsconfig.lib.prod.json
@@ -2,6 +2,6 @@
 {
   "extends": "./tsconfig.lib.json",
   "angularCompilerOptions": {
-    "enableIvy": false
+    "compilationMode": "partial"
   }
 }


### PR DESCRIPTION
### Description

Compiles the Library without disabling Ivy. Installing our SDK in Angular13 generates a warning because of the fact that we do not compile using Ivy. This was done previously to support Angular 8 up until 10. However, Angular itself does not support any version prior to 11, so this PR also bumps our minimal peer dependency version to 11, ensuring we can compile using Ivy.

Theoretically this is a breaking change, as it breaks support for Angular 9 and 10. However as those versions of Angular aren't supported by Angular itself, it's worth considering releasing this as a minor.


### References

Closes #255

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `master`
