### PR TITLE
Allow for angular versions after 14 and before 15 

### DIFF
--- a/projects/auth0-angular/package.json
+++ b/projects/auth0-angular/package.json
@@ -26,9 +26,9 @@
   },
   "homepage": "https://github.com/auth0/auth0-angular#readme",
   "peerDependencies": {
-    "@angular/common": ">=9 <=14",
-    "@angular/core": ">=9 <=14",
-    "@angular/router": ">=9 <=14"
+    "@angular/common": ">=9 <15",
+    "@angular/core": ">=9 <15",
+    "@angular/router": ">=9 <15"
   },
   "dependencies": {
     "tslib": "^2.0.0",


### PR DESCRIPTION
fixes:
peer @angular/core@">=9 <=14" from @auth0/auth0-angular@1.10.0

`
npm ERR! Found: @angular/core@14.0.1
npm ERR! node_modules/@angular/core
npm ERR!   @angular/core@"^14.0.1" from the root project
npm ERR!   peer @angular/core@">=9 <=14" from @auth0/auth0-angular@1.10.0
npm ERR!   node_modules/@auth0/auth0-angular
npm ERR!     @auth0/auth0-angular@"1.10.0" from the root project
`

Allow for angular versions after 14 and before 15 