### PR TITLE
Emit error after navigation when error occurs

### DIFF
--- a/projects/auth0-angular/src/lib/auth.service.ts
+++ b/projects/auth0-angular/src/lib/auth.service.ts
@@ -103,8 +103,8 @@ export class AuthService<TAppState extends AppState = AppState>
           checkSessionOrCallback$(isCallback).pipe(
             catchError((error) => {
               const config = this.configFactory.get();
-              this.authState.setError(error);
               this.navigator.navigateByUrl(config.errorPath || '/');
+              this.authState.setError(error);
               return of(undefined);
             })
           )


### PR DESCRIPTION
### Description

Updates the SDK so that it emits the error after navigating to the errorPath (or root). This fixes #311 .


### References

Closes #311 

### Testing

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `master`
