### PR TITLE
Do not disable Ivy but use compilationMode partial

### DIFF
--- a/projects/auth0-angular/package.json
+++ b/projects/auth0-angular/package.json
@@ -26,9 +26,9 @@
   },
   "homepage": "https://github.com/auth0/auth0-angular#readme",
   "peerDependencies": {
-    "@angular/common": ">=9 <=14",
-    "@angular/core": ">=9 <=14",
-    "@angular/router": ">=9 <=14"
+    "@angular/common": ">=12 <=14",
+    "@angular/core": ">=12 <=14",
+    "@angular/router": ">=12 <=14"
   },
   "dependencies": {
     "tslib": "^2.0.0",

--- a/projects/auth0-angular/tsconfig.lib.prod.json
+++ b/projects/auth0-angular/tsconfig.lib.prod.json
@@ -2,6 +2,6 @@
 {
   "extends": "./tsconfig.lib.json",
   "angularCompilerOptions": {
-    "enableIvy": false
+    "compilationMode": "partial"
   }
 }


### PR DESCRIPTION
### Description

Do not disable Ivy when compiling the library, also ensure we compile with `compilationMode` set to `partial`.
Doing so, would allow our library to be used with any version of Angular that is the same or higher as the version of Angular used to compile this library (which is Angular 12 at the time of opening this PR).

This drops support for any version of Angular that is below the version used to compile the SDK. Meaning, that once this change is released, we will have no longer support for Angular 

Closes #255 

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not the default branch
