### PR TITLE
Do not use deprecated API's to build the lib

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "start:local:playground": "ng serve --configuration=local",
     "prebuild": "npm run update-useragent",
     "build": "ng build && npm run build:schematics",
-    "build:prod": "ng build --prod && npm run build:schematics",
+    "build:prod": "ng build --configuration=production && npm run build:schematics",
     "build:schematics": "npm run build --prefix projects/auth0-angular",
     "prepublishOnly": "node scripts/prepublish-stopper.js",
     "postbuild": "npm run docs",

--- a/projects/auth0-angular/ng-package.json
+++ b/projects/auth0-angular/ng-package.json
@@ -4,5 +4,5 @@
   "lib": {
     "entryFile": "src/public-api.ts"
   },
-  "whitelistedNonPeerDependencies": ["tslib", "@auth0/auth0-spa-js"]
+  "allowedNonPeerDependencies": ["tslib", "@auth0/auth0-spa-js"]
 }


### PR DESCRIPTION
### Description

Use `--configuration=production` instead of `--prod`, as `--prod` is deprecated.
Use `allowedNonPeerDependencies` as `whitelistedNonPeerDependencies` is deprecated.

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not the default branch
