### PR TITLE
Fix dead link to getTokenSilently method

### DIFF
--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -251,7 +251,7 @@ AuthModule.forRoot({
 });
 ```
 
-**Note:** Under the hood, tokenOptions is passed as-is to [the getTokenSilently method](https://auth0.github.io/auth0-spa-js/classes/auth0client.html#gettokensilently) on the underlying SDK, so all the same options apply here.
+**Note:** Under the hood, tokenOptions is passed as-is to [the getTokenSilently method](https://auth0.github.io/auth0-spa-js/classes/Auth0Client.html#getTokenSilently) on the underlying SDK, so all the same options apply here.
 
 **Uri matching**
 


### PR DESCRIPTION
### Description

Updates a dead link in the `Examples.md` file which points to the `getTokenSilently` method.

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not the default branch
