### PR TITLE
Add initialize method on AuthService

### DIFF
--- a/projects/auth0-angular/src/lib/auth.service.spec.ts
+++ b/projects/auth0-angular/src/lib/auth.service.spec.ts
@@ -141,23 +141,6 @@ describe('AuthService', () => {
         }
       });
     });
-
-    it('should not set isLoading when service destroyed before checkSession finished', (done) => {
-      ((auth0Client.checkSession as unknown) as jest.SpyInstance).mockImplementation(
-        () => new Promise((resolve) => setTimeout(resolve, 5000))
-      );
-      const localService = createService();
-
-      localService.isLoading$
-        .pipe(bufferTime(500), take(1))
-        .subscribe((loading) => {
-          expect(loading.length).toEqual(1);
-          expect(loading).toEqual([true]);
-          done();
-        });
-
-      localService.ngOnDestroy();
-    });
   });
 
   describe('The `isAuthenticated` observable', () => {

--- a/projects/auth0-angular/src/lib/auth.service.spec.ts
+++ b/projects/auth0-angular/src/lib/auth.service.spec.ts
@@ -675,7 +675,7 @@ describe('AuthService', () => {
         true
       );
 
-      service.loginWithPopup().subscribe();
+      service.loginWithPopup();
 
       service.isAuthenticated$.subscribe((authenticated) => {
         if (authenticated) {
@@ -700,7 +700,7 @@ describe('AuthService', () => {
         true
       );
 
-      service.loginWithPopup(options, config).subscribe();
+      service.loginWithPopup(options, config);
 
       service.isAuthenticated$.subscribe((authenticated) => {
         if (authenticated) {

--- a/projects/auth0-angular/src/lib/auth.service.spec.ts
+++ b/projects/auth0-angular/src/lib/auth.service.spec.ts
@@ -48,13 +48,13 @@ describe('AuthService', () => {
 
   const createService = () => {
     const svc = TestBed.inject(AuthService);
-    svc.init();
+    svc.initialize();
     return svc;
   };
 
   const createServiceAndWaitForLoaded = async () => {
     const svc = TestBed.inject(AuthService);
-    svc.init();
+    svc.initialize();
 
     await svc.isLoading$
       .pipe(

--- a/projects/auth0-angular/src/lib/auth.service.ts
+++ b/projects/auth0-angular/src/lib/auth.service.ts
@@ -109,7 +109,7 @@ export class AuthService<TAppState extends AppState = AppState> {
         ),
         tap(() => {
           this.authState.setIsLoading(false);
-        }),
+        })
       )
       .subscribe();
   }
@@ -136,9 +136,15 @@ export class AuthService<TAppState extends AppState = AppState> {
   loginWithRedirect(
     options?: RedirectLoginOptions<TAppState>
   ): Observable<void> {
-    return this.ensureIsLoaded(() =>
+    // TODO: Temportary using a Subject for backwards compatibility
+    // Will remove in a follow PR to have a dedicated PR for it as it's a breaking change on its own.
+    const sub = new Subject<void>();
+
+    this.ensureIsLoaded(() =>
       from(this.auth0Client.loginWithRedirect(options))
-    );
+    ).subscribe(sub);
+
+    return sub.asObservable();
   }
 
   /**
@@ -162,13 +168,19 @@ export class AuthService<TAppState extends AppState = AppState> {
     options?: PopupLoginOptions,
     config?: PopupConfigOptions
   ): Observable<void> {
-    return this.ensureIsLoaded(() =>
+    // TODO: Temportary using a Subject for backwards compatibility
+    // Will remove in a follow PR to have a dedicated PR for it as it's a breaking change on its own.
+    const sub = new Subject<void>();
+
+    this.ensureIsLoaded(() =>
       from(
         this.auth0Client.loginWithPopup(options, config).then(() => {
           this.authState.refresh();
         })
       )
-    );
+    ).subscribe(sub);
+
+    return sub.asObservable();
   }
 
   /**

--- a/projects/auth0-angular/src/lib/auth.service.ts
+++ b/projects/auth0-angular/src/lib/auth.service.ts
@@ -78,7 +78,7 @@ export class AuthService<TAppState extends AppState = AppState> {
    */
   readonly appState$ = this.appStateSubject$.asObservable();
 
-  private init$ = new Subject();
+  private initialize$ = new Subject();
 
   constructor(
     @Inject(Auth0ClientService) private auth0Client: Auth0Client,
@@ -93,7 +93,7 @@ export class AuthService<TAppState extends AppState = AppState> {
         defer(() => this.auth0Client.checkSession())
       );
 
-    this.init$
+    this.initialize$
       .pipe(
         first(),
         mergeMap(() => this.shouldHandleCallback()),
@@ -117,9 +117,12 @@ export class AuthService<TAppState extends AppState = AppState> {
   /**
    * Initialize the SDK.
    * Call this method before interacting with any other method on the SDK.
+   *
+   * @remarks
+   * Calling this method multiple times has no effect.
    */
-  init() {
-    this.init$.next();
+  initialize() {
+    this.initialize$.next();
   }
 
   /**
@@ -136,7 +139,7 @@ export class AuthService<TAppState extends AppState = AppState> {
   loginWithRedirect(
     options?: RedirectLoginOptions<TAppState>
   ): Observable<void> {
-    // TODO: Temportary using a Subject for backwards compatibility
+    // TODO: Temporary using a Subject for backwards compatibility
     // Will remove in a follow PR to have a dedicated PR for it as it's a breaking change on its own.
     const sub = new Subject<void>();
 
@@ -168,7 +171,7 @@ export class AuthService<TAppState extends AppState = AppState> {
     options?: PopupLoginOptions,
     config?: PopupConfigOptions
   ): Observable<void> {
-    // TODO: Temportary using a Subject for backwards compatibility
+    // TODO: Temporary using a Subject for backwards compatibility
     // Will remove in a follow PR to have a dedicated PR for it as it's a breaking change on its own.
     const sub = new Subject<void>();
 
@@ -410,8 +413,10 @@ export class AuthService<TAppState extends AppState = AppState> {
         iif(
           () => isLoading,
           throwError(
-            // eslint-disable-next-line max-len
-            'SDK needs to be initialized before interacting with it. Please call `AuthService.init()` and ensure `AuthService.isLoading$` emits `false`'
+            new Error(
+              // eslint-disable-next-line max-len
+              'The SDK needs to be initialized before interacting with it. Please call `AuthService.initialize()` and ensure `AuthService.isLoading$` emits `false`'
+            )
           ),
           cb()
         )

--- a/projects/playground/src/app/app.component.spec.ts
+++ b/projects/playground/src/app/app.component.spec.ts
@@ -22,6 +22,8 @@ describe('AppComponent', () => {
       getAccessTokenSilently: jest.fn().mockReturnValue(null),
       getAccessTokenWithPopup: jest.fn().mockReturnValue(null),
 
+      init: jest.fn(),
+
       user$: new BehaviorSubject(null),
       isLoading$: new BehaviorSubject(true),
       isAuthenticated$: new BehaviorSubject(false),

--- a/projects/playground/src/app/app.component.spec.ts
+++ b/projects/playground/src/app/app.component.spec.ts
@@ -22,7 +22,7 @@ describe('AppComponent', () => {
       getAccessTokenSilently: jest.fn().mockReturnValue(null),
       getAccessTokenWithPopup: jest.fn().mockReturnValue(null),
 
-      init: jest.fn(),
+      initialize: jest.fn(),
 
       user$: new BehaviorSubject(null),
       isLoading$: new BehaviorSubject(true),

--- a/projects/playground/src/app/app.component.ts
+++ b/projects/playground/src/app/app.component.ts
@@ -46,6 +46,8 @@ export class AppComponent implements OnInit {
   ) {}
 
   ngOnInit(): void {
+    this.auth.init();
+
     this.auth.appState$.subscribe((appState) => {
       this.appStateResult = appState['myValue'];
     });

--- a/projects/playground/src/app/app.component.ts
+++ b/projects/playground/src/app/app.component.ts
@@ -46,7 +46,7 @@ export class AppComponent implements OnInit {
   ) {}
 
   ngOnInit(): void {
-    this.auth.init();
+    this.auth.initialize();
 
     this.auth.appState$.subscribe((appState) => {
       this.appStateResult = appState['myValue'];


### PR DESCRIPTION
### Description

Currently the SDK is initialized in the constuctor of `AuthService`. This means that `AuthService` needs to be injected high in the DOM tree, commonly `AppComponent`, to ensure the SDK gets initialized before interacted with. 

```ts
class AppComponent {
  constructor(authService: AuthService) {}
}
```

However, the service has to be injected but not interacted with, possibly leaving an unused constructor argument. Both people and tools tend to get rid of this kind of unused arguments, and rightfully so.

With this PR, we are moving the SDK's initialization code to a dedicated `initialize` method, still expecting the service to be injected high in the DOM tree, but not leaving it unused, avoiding confusion about the use of the dependency in the first place.

```ts
class AppComponent {
  constructor(authService: AuthService) {
    authService.initialize();
  }
}
```

**Breaking Change:**
This change will break everyone coming from v1. However, it should be resolved by calling `initialize()` from the constructor wherever you are injecting `AuthService`. If you are injecting `AuthService` in multiple places, you want to call it as high in the DOM tree as possible, preferably `AppComponent`.

On top of that, calling the following methods before the SDK has been initialized (`isLoading$` emits `false`) will now throw an error:

- loginWithRedirect
- loginUsingPopup
- getAccessTokenSilently
- getAccessTokenWithPopup
- logout

Ensure to only call the above methods when `isLoading` emits `false`.

### Testing

- [x] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not the default branch
