### PR TITLE
Remove getUser and getIdTokenClaims

### DIFF
--- a/projects/auth0-angular/src/lib/auth.service.spec.ts
+++ b/projects/auth0-angular/src/lib/auth.service.spec.ts
@@ -866,44 +866,6 @@ describe('AuthService', () => {
     });
   });
 
-  describe('getUser', () => {
-    it('should call `getUser`', async () => {
-      const service = createService();
-      await service.getUser().toPromise();
-      expect(auth0Client.getUser).toHaveBeenCalled();
-    });
-
-    it('should return the user from `getUser`', async () => {
-      const expected = { name: 'John Doe' };
-      ((auth0Client.getUser as unknown) as jest.SpyInstance).mockResolvedValue(
-        expected
-      );
-      const service = createService();
-
-      const user = await service.getUser().toPromise();
-      expect(user).toBe(expected);
-    });
-  });
-
-  describe('getIdTokenClaims', () => {
-    it('should call `getIdTokenClaims`', async () => {
-      const service = createService();
-      await service.getIdTokenClaims().toPromise();
-      expect(auth0Client.getIdTokenClaims).toHaveBeenCalled();
-    });
-
-    it('should return the claims from `getIdTokenClaims`', async () => {
-      const expected = { __raw: '', name: 'John Doe' };
-      ((auth0Client.getIdTokenClaims as unknown) as jest.SpyInstance).mockResolvedValue(
-        expected
-      );
-      const service = createService();
-
-      const claims = await service.getIdTokenClaims().toPromise();
-      expect(claims).toBe(expected);
-    });
-  });
-
   describe('handleRedirectCallback', () => {
     let navigator: AbstractNavigator;
 

--- a/projects/auth0-angular/src/lib/auth.service.ts
+++ b/projects/auth0-angular/src/lib/auth.service.ts
@@ -288,47 +288,6 @@ export class AuthService<TAppState extends AppState = AppState>
 
   /**
    * ```js
-   * getUser().subscribe(user => ...);
-   * ```
-   *
-   * Returns the user information if available (decoded
-   * from the `id_token`).
-   *
-   * If you provide an audience or scope, they should match an existing Access Token
-   * (the SDK stores a corresponding ID Token with every Access Token, and uses the
-   * scope and audience to look up the ID Token)
-   *
-   * @remarks
-   *
-   * The returned observable will emit once and then complete.
-   *
-   * @typeparam TUser The type to return, has to extend {@link User}.
-   */
-  getUser<TUser extends User>(): Observable<TUser | undefined> {
-    return defer(() => this.auth0Client.getUser<TUser>());
-  }
-
-  /**
-   * ```js
-   * getIdTokenClaims().subscribe(claims => ...);
-   * ```
-   *
-   * Returns all claims from the id_token if available.
-   *
-   * If you provide an audience or scope, they should match an existing Access Token
-   * (the SDK stores a corresponding ID Token with every Access Token, and uses the
-   * scope and audience to look up the ID Token)
-   *
-   * @remarks
-   *
-   * The returned observable will emit once and then complete.
-   */
-  getIdTokenClaims(): Observable<IdToken | undefined> {
-    return defer(() => this.auth0Client.getIdTokenClaims());
-  }
-
-  /**
-   * ```js
    * handleRedirectCallback(url).subscribe(result => ...)
    * ```
    *


### PR DESCRIPTION
### Description

The SDK has two ways to retrieve the current user as well as the Id token claims.

- `getUser` and `getIdTokenClaims`
- `user$` and `idTokenClaims$`

The `getUser` and `getIdTokenClaims` methods existed to allow the user to pass through the audience and scope to SPA-JS in v1. With the removal of these arguments in SPA-JS v2, there is no point in keeping these methods in our Angular SDK. Instead, users should use our Observables appropriately instead.

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not the default branch
