### PR TITLE
Change the way the SDK initializes itself internally

### DIFF
--- a/projects/auth0-angular/src/lib/auth.client.spec.ts
+++ b/projects/auth0-angular/src/lib/auth.client.spec.ts
@@ -1,6 +1,6 @@
-import { AuthConfig, AuthClientConfig } from './auth.config';
+import { AuthConfig } from './auth.config';
 import { AuthClient } from './auth.client';
-import { EMPTY, of, Subject } from 'rxjs';
+import { of, Subject } from 'rxjs';
 import { expect } from '@jest/globals';
 import { fakeAsync, tick } from '@angular/core/testing';
 
@@ -23,7 +23,7 @@ describe('AuthClient', () => {
         clientId: 'abc123',
       };
 
-      const authClient = new AuthClient({ config$: of(config) } as any);
+      const authClient = new AuthClient({ config$: of(config) } as any, false);
 
       authClient
         .getInstance$()
@@ -32,15 +32,28 @@ describe('AuthClient', () => {
       expect.assertions(1);
     });
 
-    it('throws an error when no config was supplied after timeout duration', fakeAsync(() => {
-      const authClient = new AuthClient({ config$: new Subject() } as any);
+    it('throws an error instantly when no config was supplied', fakeAsync(() => {
+      const authClient = new AuthClient({ config$: new Subject() } as any, false);
 
       authClient.getInstance$().subscribe({
         error: (error) =>
           expect(error.message).toContain('Configuration must be specified'),
       });
 
-      tick(10000);
+      tick(0);
+
+      expect.assertions(1);
+    }));
+
+    it('throws an error when no config was supplied after timeout duration when lazy set to true', fakeAsync(() => {
+      const authClient = new AuthClient({ config$: new Subject() } as any, true);
+
+      authClient.getInstance$().subscribe({
+        error: (error) =>
+          expect(error.message).toContain('Configuration must be specified'),
+      });
+
+      tick(15000);
 
       expect.assertions(1);
     }));
@@ -53,7 +66,7 @@ describe('AuthClient', () => {
         useRefreshTokensFallback: false,
       };
 
-      const authClient = new AuthClient({ config$: of(config) } as any);
+      const authClient = new AuthClient({ config$: of(config) } as any, false);
 
       authClient.getInstance$().subscribe((client) => {
         expect(client).not.toBeUndefined();
@@ -73,7 +86,7 @@ describe('AuthClient', () => {
         useRefreshTokens: true,
       };
 
-      const authClient = new AuthClient({ config$: of(config) } as any);
+      const authClient = new AuthClient({ config$: of(config) } as any, false);
 
       authClient.getInstance$().subscribe((client) => {
         expect(client).not.toBeUndefined();

--- a/projects/auth0-angular/src/lib/auth.client.spec.ts
+++ b/projects/auth0-angular/src/lib/auth.client.spec.ts
@@ -45,7 +45,7 @@ describe('AuthClient', () => {
       expect.assertions(1);
     }));
 
-    it('throws an error when no config was supplied after timeout duration when lazy set to true', fakeAsync(() => {
+    it('throws an error when no config was supplied after timeout duration when forceInitialization set to true', fakeAsync(() => {
       const authClient = new AuthClient({ config$: new Subject() } as any, true);
 
       authClient.getInstance$().subscribe({

--- a/projects/auth0-angular/src/lib/auth.client.spec.ts
+++ b/projects/auth0-angular/src/lib/auth.client.spec.ts
@@ -40,7 +40,7 @@ describe('AuthClient', () => {
           expect(error.message).toContain('Configuration must be specified'),
       });
 
-      tick(30000);
+      tick(10000);
 
       expect.assertions(1);
     }));

--- a/projects/auth0-angular/src/lib/auth.client.ts
+++ b/projects/auth0-angular/src/lib/auth.client.ts
@@ -1,6 +1,6 @@
-import { Injectable, VERSION } from '@angular/core';
+import { Inject, Injectable, Optional, VERSION } from '@angular/core';
 import { Auth0Client } from '@auth0/auth0-spa-js';
-import { AuthClientConfig, AuthConfig } from './auth.config';
+import { AuthClientConfig, AuthConfig, LAZY_LOAD_TOKEN } from './auth.config';
 import useragent from '../useragent';
 import { Observable, race, throwError, timer } from 'rxjs';
 import { map, mergeMap, shareReplay, take } from 'rxjs/operators';
@@ -12,7 +12,7 @@ export class AuthClient {
       map((config) => this.createClient(config)),
       shareReplay(1)
     ),
-    timer(10000).pipe(
+    timer(this.lazy ? 15000 : 0).pipe(
       mergeMap(() =>
         throwError(
           new Error(
@@ -23,7 +23,10 @@ export class AuthClient {
     )
   );
 
-  constructor(private config: AuthClientConfig) {}
+  constructor(
+    private config: AuthClientConfig,
+    @Inject(LAZY_LOAD_TOKEN) private lazy: boolean
+  ) {}
 
   getInstance$(): Observable<Auth0Client> {
     return this.instance$.pipe(take(1));

--- a/projects/auth0-angular/src/lib/auth.client.ts
+++ b/projects/auth0-angular/src/lib/auth.client.ts
@@ -5,7 +5,7 @@ import useragent from '../useragent';
 import { Observable, race, throwError, timer } from 'rxjs';
 import { map, mergeMap, shareReplay, take } from 'rxjs/operators';
 
-@Injectable()
+@Injectable({ providedIn: 'root' })
 export class AuthClient {
   private instance$ = race(
     this.config.config$.pipe(

--- a/projects/auth0-angular/src/lib/auth.client.ts
+++ b/projects/auth0-angular/src/lib/auth.client.ts
@@ -1,6 +1,6 @@
-import { Inject, Injectable, Optional, VERSION } from '@angular/core';
+import { Inject, Injectable, VERSION } from '@angular/core';
 import { Auth0Client } from '@auth0/auth0-spa-js';
-import { AuthClientConfig, AuthConfig, LAZY_LOAD_TOKEN } from './auth.config';
+import { AuthClientConfig, AuthConfig, FORCE_INITIALIZATION_TOKEN } from './auth.config';
 import useragent from '../useragent';
 import { Observable, race, throwError, timer } from 'rxjs';
 import { map, mergeMap, shareReplay, take } from 'rxjs/operators';
@@ -12,7 +12,7 @@ export class AuthClient {
       map((config) => this.createClient(config)),
       shareReplay(1)
     ),
-    timer(this.lazy ? 15000 : 0).pipe(
+    timer(this.forceInitialization ? 15000 : 0).pipe(
       mergeMap(() =>
         throwError(
           new Error(
@@ -25,7 +25,7 @@ export class AuthClient {
 
   constructor(
     private config: AuthClientConfig,
-    @Inject(LAZY_LOAD_TOKEN) private lazy: boolean
+    @Inject(FORCE_INITIALIZATION_TOKEN) private forceInitialization: boolean
   ) {}
 
   getInstance$(): Observable<Auth0Client> {

--- a/projects/auth0-angular/src/lib/auth.client.ts
+++ b/projects/auth0-angular/src/lib/auth.client.ts
@@ -7,7 +7,7 @@ import { map, mergeMap, shareReplay, take } from 'rxjs/operators';
 
 @Injectable()
 export class AuthClient {
-  private _instance$ = race(
+  private instance$ = race(
     this.config.config$.pipe(
       map((config) => this.createClient(config)),
       shareReplay(1)
@@ -26,7 +26,7 @@ export class AuthClient {
   constructor(private config: AuthClientConfig) {}
 
   getInstance$(): Observable<Auth0Client> {
-    return this._instance$.pipe(take(1));
+    return this.instance$.pipe(take(1));
   }
 
   private createClient(config: AuthConfig): Auth0Client {

--- a/projects/auth0-angular/src/lib/auth.client.ts
+++ b/projects/auth0-angular/src/lib/auth.client.ts
@@ -12,7 +12,7 @@ export class AuthClient {
       map((config) => this.createClient(config)),
       shareReplay(1)
     ),
-    timer(30000).pipe(
+    timer(10000).pipe(
       mergeMap(() =>
         throwError(
           new Error(

--- a/projects/auth0-angular/src/lib/auth.config.ts
+++ b/projects/auth0-angular/src/lib/auth.config.ts
@@ -199,13 +199,13 @@ export interface AppState {
 export class AuthClientConfig {
   private config?: AuthConfig;
 
-  private _config$ = new ReplaySubject<AuthConfig>(1);
-  public config$ = this._config$.asObservable();
+  private configSubject$ = new ReplaySubject<AuthConfig>(1);
+  public config$ = this.configSubject$.asObservable();
 
   constructor(@Optional() @Inject(AuthConfigService) config?: AuthConfig) {
     if (config) {
       this.set(config);
-      this._config$.next(config);
+      this.configSubject$.next(config);
     }
   }
 
@@ -216,7 +216,7 @@ export class AuthClientConfig {
    */
   set(config: AuthConfig): void {
     this.config = config;
-    this._config$.next(config);
+    this.configSubject$.next(config);
   }
 
   /**

--- a/projects/auth0-angular/src/lib/auth.config.ts
+++ b/projects/auth0-angular/src/lib/auth.config.ts
@@ -136,13 +136,20 @@ export interface AuthConfig extends Auth0ClientOptions {
    */
   errorPath?: string;
 
-  lazy?: false;
+  /**
+   * Setting this to true will try and initialize the SDK as soon as AuthModule is instantiated,
+   * which happens at application load.
+   *
+   * This is mainly to support situations that involve specific setups together with Angular's lazy-loading.
+   * For more info, read [LINK TO EXAMPLE HERE]
+   */
+  forceInitialization?: false;
 }
 
 /**
  * Configuration for the authentication module's forRoot static method.
  */
-export type RootAuthConfig = AuthConfig | {lazy?: true};
+ export type RootAuthConfig = AuthConfig | {forceInitialization?: true};
 
 /**
  * Angular specific state to be stored before redirect
@@ -249,4 +256,7 @@ export const AuthConfigService = new InjectionToken<AuthConfig>(
 );
 
 
-export const LAZY_LOAD_TOKEN = new InjectionToken('LAZY_LOAD');
+/**
+ * Injection token for accessing force
+ */
+export const FORCE_INITIALIZATION_TOKEN = new InjectionToken('FORCE_INITIALIZATION');

--- a/projects/auth0-angular/src/lib/auth.config.ts
+++ b/projects/auth0-angular/src/lib/auth.config.ts
@@ -6,6 +6,7 @@ import {
 } from '@auth0/auth0-spa-js';
 
 import { InjectionToken, Injectable, Optional, Inject } from '@angular/core';
+import { ReplaySubject } from 'rxjs';
 
 /**
  * Defines a common set of HTTP methods.
@@ -198,9 +199,13 @@ export interface AppState {
 export class AuthClientConfig {
   private config?: AuthConfig;
 
+  private _config$ = new ReplaySubject<AuthConfig>(1);
+  public config$ = this._config$.asObservable();
+
   constructor(@Optional() @Inject(AuthConfigService) config?: AuthConfig) {
     if (config) {
       this.set(config);
+      this._config$.next(config);
     }
   }
 
@@ -211,6 +216,7 @@ export class AuthClientConfig {
    */
   set(config: AuthConfig): void {
     this.config = config;
+    this._config$.next(config);
   }
 
   /**

--- a/projects/auth0-angular/src/lib/auth.config.ts
+++ b/projects/auth0-angular/src/lib/auth.config.ts
@@ -205,7 +205,6 @@ export class AuthClientConfig {
   constructor(@Optional() @Inject(AuthConfigService) config?: AuthConfig) {
     if (config) {
       this.set(config);
-      this.configSubject$.next(config);
     }
   }
 

--- a/projects/auth0-angular/src/lib/auth.config.ts
+++ b/projects/auth0-angular/src/lib/auth.config.ts
@@ -147,11 +147,6 @@ export interface AuthConfig extends Auth0ClientOptions {
 }
 
 /**
- * Configuration for the authentication module's forRoot static method.
- */
- export type RootAuthConfig = AuthConfig | {forceInitialization?: true};
-
-/**
  * Angular specific state to be stored before redirect
  */
 export interface AppState {

--- a/projects/auth0-angular/src/lib/auth.config.ts
+++ b/projects/auth0-angular/src/lib/auth.config.ts
@@ -135,7 +135,14 @@ export interface AuthConfig extends Auth0ClientOptions {
    * returns an error. Defaults to `/`
    */
   errorPath?: string;
+
+  lazy?: false;
 }
+
+/**
+ * Configuration for the authentication module's forRoot static method.
+ */
+export type RootAuthConfig = AuthConfig | {lazy?: true};
 
 /**
  * Angular specific state to be stored before redirect
@@ -240,3 +247,6 @@ export class AuthClientConfig {
 export const AuthConfigService = new InjectionToken<AuthConfig>(
   'auth0-angular.config'
 );
+
+
+export const LAZY_LOAD_TOKEN = new InjectionToken('LAZY_LOAD');

--- a/projects/auth0-angular/src/lib/auth.interceptor.spec.ts
+++ b/projects/auth0-angular/src/lib/auth.interceptor.spec.ts
@@ -13,11 +13,11 @@ import {
   AuthClientConfig,
   HttpInterceptorConfig,
 } from './auth.config';
-import { BehaviorSubject, Subject, throwError } from 'rxjs';
+import { BehaviorSubject, of, Subject, throwError } from 'rxjs';
 import { Auth0Client } from '@auth0/auth0-spa-js';
-import { Auth0ClientService } from './auth.client';
 import { AuthState } from './auth.state';
 import { AuthService } from './auth.service';
+import { AuthClient } from './auth.client';
 
 // NOTE: Read Async testing: https://github.com/angular/angular/issues/25733#issuecomment-636154553
 
@@ -130,8 +130,8 @@ describe('The Auth HTTP Interceptor', () => {
           multi: true,
         },
         {
-          provide: Auth0ClientService,
-          useValue: auth0Client,
+          provide: AuthClient,
+          useValue: { getInstance$: () => of(auth0Client) },
         },
         {
           provide: AuthClientConfig,

--- a/projects/auth0-angular/src/lib/auth.interceptor.ts
+++ b/projects/auth0-angular/src/lib/auth.interceptor.ts
@@ -6,7 +6,7 @@ import {
 } from '@angular/common/http';
 
 import { Observable, from, of, iif, throwError } from 'rxjs';
-import { Inject, Injectable } from '@angular/core';
+import { Injectable } from '@angular/core';
 
 import {
   ApiRouteDefinition,
@@ -26,8 +26,8 @@ import {
   mapTo,
   pluck,
 } from 'rxjs/operators';
-import { Auth0Client, GetTokenSilentlyOptions } from '@auth0/auth0-spa-js';
-import { Auth0ClientService } from './auth.client';
+import { GetTokenSilentlyOptions } from '@auth0/auth0-spa-js';
+import { AuthClient } from './auth.client';
 import { AuthState } from './auth.state';
 import { AuthService } from './auth.service';
 
@@ -39,7 +39,7 @@ const waitUntil = <TSignal>(signal$: Observable<TSignal>) => <TSource>(
 export class AuthHttpInterceptor implements HttpInterceptor {
   constructor(
     private configFactory: AuthClientConfig,
-    @Inject(Auth0ClientService) private auth0Client: Auth0Client,
+    private authClient: AuthClient,
     private authState: AuthState,
     private authService: AuthService,
   ) {}
@@ -110,7 +110,7 @@ export class AuthHttpInterceptor implements HttpInterceptor {
   private getAccessTokenSilently(
     options?: GetTokenSilentlyOptions
   ): Observable<string> {
-    return of(this.auth0Client).pipe(
+    return this.authClient.getInstance$().pipe(
       concatMap((client) => client.getTokenSilently(options)),
       tap((token) => this.authState.setAccessToken(token)),
       catchError((error) => {

--- a/projects/auth0-angular/src/lib/auth.module.ts
+++ b/projects/auth0-angular/src/lib/auth.module.ts
@@ -1,11 +1,17 @@
 import { NgModule, ModuleWithProviders } from '@angular/core';
 import { AuthService } from './auth.service';
-import { AuthConfig, AuthConfigService, AuthClientConfig } from './auth.config';
-import { Auth0ClientService, Auth0ClientFactory } from './auth.client';
+import { AuthConfig, AuthConfigService } from './auth.config';
+import { AuthClient } from './auth.client';
 import { AuthGuard } from './auth.guard';
 
 @NgModule()
 export class AuthModule {
+  constructor(
+    // Needs to be injected, but left unused
+    // Ideally we would ensure it's used, but that would change the public API which we decided not to do for now.
+    private authService: AuthService
+  ) {}
+
   /**
    * Initialize the authentication module system. Configuration can either be specified here,
    * or by calling AuthClientConfig.set (perhaps from an APP_INITIALIZER factory function).
@@ -22,11 +28,7 @@ export class AuthModule {
           provide: AuthConfigService,
           useValue: config,
         },
-        {
-          provide: Auth0ClientService,
-          useFactory: Auth0ClientFactory.createClient,
-          deps: [AuthClientConfig],
-        },
+        AuthClient,
       ],
     };
   }

--- a/projects/auth0-angular/src/lib/auth.module.ts
+++ b/projects/auth0-angular/src/lib/auth.module.ts
@@ -17,7 +17,6 @@ export class AuthModule {
     // If forceInitialization is set to true,
     // we need to instantiate the AuthService when the AuthModule is instantiated.
     if (forceInitialization) {
-      console.log('force')
       injector.get<AuthService>(AuthService);
     }
   }

--- a/projects/auth0-angular/src/lib/auth.module.ts
+++ b/projects/auth0-angular/src/lib/auth.module.ts
@@ -1,7 +1,11 @@
 import { NgModule, ModuleWithProviders } from '@angular/core';
 import { AuthService } from './auth.service';
-import { AuthConfig, AuthConfigService } from './auth.config';
 import { AuthClient } from './auth.client';
+import {
+  AuthConfigService,
+  LAZY_LOAD_TOKEN,
+  RootAuthConfig,
+} from './auth.config';
 import { AuthGuard } from './auth.guard';
 
 @NgModule()
@@ -18,7 +22,11 @@ export class AuthModule {
    *
    * @param config The optional configuration for the SDK.
    */
-  static forRoot(config?: AuthConfig): ModuleWithProviders<AuthModule> {
+  static forRoot(
+    config: RootAuthConfig & { lazy: true }
+  ): ModuleWithProviders<AuthModule>;
+  static forRoot(config?: RootAuthConfig): ModuleWithProviders<AuthModule>;
+  static forRoot(config?: RootAuthConfig): ModuleWithProviders<AuthModule> {
     return {
       ngModule: AuthModule,
       providers: [
@@ -29,6 +37,10 @@ export class AuthModule {
           useValue: config,
         },
         AuthClient,
+        {
+          provide: LAZY_LOAD_TOKEN,
+          useValue: config?.lazy || false,
+        },
       ],
     };
   }

--- a/projects/auth0-angular/src/lib/auth.module.ts
+++ b/projects/auth0-angular/src/lib/auth.module.ts
@@ -17,6 +17,7 @@ export class AuthModule {
     // If forceInitialization is set to true,
     // we need to instantiate the AuthService when the AuthModule is instantiated.
     if (forceInitialization) {
+      console.log('force')
       injector.get<AuthService>(AuthService);
     }
   }
@@ -44,7 +45,7 @@ export class AuthModule {
         AuthClient,
         {
           provide: FORCE_INITIALIZATION_TOKEN,
-          useValue: false,
+          useValue: config?.forceInitialization || false,
         },
       ],
     };

--- a/projects/auth0-angular/src/lib/auth.module.ts
+++ b/projects/auth0-angular/src/lib/auth.module.ts
@@ -2,9 +2,9 @@ import { NgModule, ModuleWithProviders, Injector, Inject } from '@angular/core';
 import { AuthService } from './auth.service';
 import { AuthClient } from './auth.client';
 import {
-  RootAuthConfig,
   AuthConfigService,
   FORCE_INITIALIZATION_TOKEN,
+  AuthConfig,
 } from './auth.config';
 import { AuthGuard } from './auth.guard';
 
@@ -28,11 +28,7 @@ export class AuthModule {
    *
    * @param config The optional configuration for the SDK.
    */
-  static forRoot(
-    config: RootAuthConfig & { lazy: true }
-  ): ModuleWithProviders<AuthModule>;
-  static forRoot(config?: RootAuthConfig): ModuleWithProviders<AuthModule>;
-  static forRoot(config?: RootAuthConfig): ModuleWithProviders<AuthModule> {
+  static forRoot(config?: AuthConfig | {forceInitialization?: true}): ModuleWithProviders<AuthModule> {
     return {
       ngModule: AuthModule,
       providers: [

--- a/projects/auth0-angular/src/lib/auth.service.spec.ts
+++ b/projects/auth0-angular/src/lib/auth.service.spec.ts
@@ -1,6 +1,5 @@
 import { fakeAsync, TestBed } from '@angular/core/testing';
 import { AuthService } from './auth.service';
-import { Auth0ClientService } from './auth.client';
 import { Auth0Client, IdToken } from '@auth0/auth0-spa-js';
 import { AbstractNavigator } from './abstract-navigator';
 import {
@@ -14,6 +13,8 @@ import {
 } from 'rxjs/operators';
 import { AuthConfig, AuthConfigService } from './auth.config';
 import { AuthState } from './auth.state';
+import { AuthClient } from './auth.client';
+import { of } from 'rxjs';
 
 const mockWindow = global as any;
 
@@ -77,8 +78,8 @@ describe('AuthService', () => {
       providers: [
         AbstractNavigator,
         {
-          provide: Auth0ClientService,
-          useValue: auth0Client,
+          provide: AuthClient,
+          useValue: { getInstance$: () => of(auth0Client) },
         },
         {
           provide: AuthConfigService,
@@ -464,8 +465,8 @@ describe('AuthService', () => {
             useValue: navigator,
           },
           {
-            provide: Auth0ClientService,
-            useValue: auth0Client,
+            provide: AuthClient,
+            useValue: { getInstance$: () => of(auth0Client) },
           },
           {
             provide: AuthConfigService,
@@ -651,7 +652,7 @@ describe('AuthService', () => {
     expect(auth0Client.loginWithRedirect).toHaveBeenCalledWith(options);
   });
 
-  it('should call `loginWithPopup`', (done) => {
+  it('should call loginWithPopup', (done) => {
     const service = createService();
     loaded(service).subscribe(() => {
       ((auth0Client.isAuthenticated as unknown) as jest.SpyInstance).mockReset();
@@ -884,8 +885,8 @@ describe('AuthService', () => {
             useValue: navigator,
           },
           {
-            provide: Auth0ClientService,
-            useValue: auth0Client,
+            provide: AuthClient,
+            useValue: { getInstance$: () => of(auth0Client) },
           },
           {
             provide: AuthConfigService,

--- a/projects/auth0-angular/src/lib/auth.service.spec.ts
+++ b/projects/auth0-angular/src/lib/auth.service.spec.ts
@@ -652,7 +652,7 @@ describe('AuthService', () => {
     expect(auth0Client.loginWithRedirect).toHaveBeenCalledWith(options);
   });
 
-  it('should call loginWithPopup', (done) => {
+  it('should call `loginWithPopup`', (done) => {
     const service = createService();
     loaded(service).subscribe(() => {
       ((auth0Client.isAuthenticated as unknown) as jest.SpyInstance).mockReset();

--- a/projects/auth0-angular/src/lib/auth.service.ts
+++ b/projects/auth0-angular/src/lib/auth.service.ts
@@ -92,11 +92,11 @@ export class AuthService<TAppState extends AppState = AppState>
       iif(
         () => isCallback,
         this.handleRedirectCallback(),
-        this.withClient((client) => defer(() => client.checkSession()))
+        this.withClient((client) => client.checkSession())
       );
 
-    this.withClient(() =>
-      this.shouldHandleCallback().pipe(
+    this.withClient(() => this.shouldHandleCallback())
+      .pipe(
         switchMap((isCallback) =>
           checkSessionOrCallback$(isCallback).pipe(
             catchError((error) => {
@@ -112,7 +112,7 @@ export class AuthService<TAppState extends AppState = AppState>
         }),
         takeUntil(this.ngUnsubscribe$)
       )
-    ).subscribe();
+      .subscribe();
   }
 
   /**


### PR DESCRIPTION
### Description

Currently, there is a specific situation where our SDK might not work as expected. When an application is using lazy loading, and anything that uses our SDK is inside a lazily loaded module, while the user is navigated back to the root of their application after authentication.

In this case, there is no instance created to handle the redirect and exchange `code` and `state` for tokens.
To solve this, users need to ensure they inject `AuthService` in their AppComponent, without ever using it.

Apart from the fact this being unintuitive, it's also easy for users to get rid of this unused dependency, not knowing they might be breaking our SDK's functionality.

To solve this, we have reworked the internals of the SDK in such a way that users do not require injecting AuthService in this scenario, instead we are injecting AuthService ourselves inside AuthModule, without using it ourselves.

The main idea behind this PR is that it changes the SDK in such a way that, instead of expecting the existence of an Auth0Client when instantiating the AuthService, we have reworked the AuthService to allow for async initialization of Auth0Client, and using that client throughout the service.

To use this, people having the above use-case will need to set `forceInitialization` to true when calling `AuthModule.forRoot`:

```ts
imports: [
  AuthModule.forRoot({ forceInitialization: true })
]
```

An alternative could be to add some kind of `initialization` method on `AuthService`. However, this would impact the public API for all use-cases, while this change only impacts a specific use-case. Therefore, we have opted to fix this scenario with a minimal impact to the users of the SDK.

### Testing

- [x] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not the default branch
