### PR TITLE
[SDK-3840] Ensure logout returns an observable instead of a promise

### DIFF
--- a/projects/auth0-angular/src/lib/auth.service.ts
+++ b/projects/auth0-angular/src/lib/auth.service.ts
@@ -183,12 +183,14 @@ export class AuthService<TAppState extends AppState = AppState>
    *
    * @param options The logout options
    */
-  async logout(options?: LogoutOptions): Promise<void> {
-    await this.auth0Client.logout(options);
-
-    if (options?.onRedirect) {
-      this.authState.refresh();
-    }
+  logout(options?: LogoutOptions): Observable<void> {
+    return from(
+      this.auth0Client.logout(options).then(() => {
+        if (options?.onRedirect) {
+          this.authState.refresh();
+        }
+      })
+    );
   }
 
   /**


### PR DESCRIPTION
### Description

This changes the return type for `logout()` from `Promise<void>` to `Observable<void>`. For more backwards compatibility, you can still call `logout()` without a subscription.

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not the default branch
