### PR TITLE
Update node version for Ship Orb

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,6 +45,7 @@ workflows:
       - ship/node-publish:
           publish-command: npm run build:prod && cp README.md ./dist/auth0-angular/ && npm publish ./dist/auth0-angular --tag beta
           app-directory: 'projects/auth0-angular'
+          node-version: 16.16.0
           requires:
             - browserstack
           context:


### PR DESCRIPTION
### Description

Angular requires Node > 16.10, while the ship orb runs on 16.6 by default.

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not the default branch
