### PR TITLE
Add redirect_uri to configuration in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Take note of the **Client ID** and **Domain** values under the "Basic Informatio
 
 #### Static configuration
 
-Install the SDK into your application by importing `AuthModule.forRoot()` and configuring with your Auth0 domain and client id:
+Install the SDK into your application by importing `AuthModule.forRoot()` and configuring with your Auth0 domain and client id, as well as the URL to which Auth0 should redirect back after succesful authentication:
 
 ```ts
 import { NgModule } from '@angular/core';
@@ -78,6 +78,9 @@ import { AuthModule } from '@auth0/auth0-angular';
     AuthModule.forRoot({
       domain: 'YOUR_AUTH0_DOMAIN',
       clientId: 'YOUR_AUTH0_CLIENT_ID',
+      authorizationParams: {
+        redirect_uri: window.location.origin
+      }
     }),
   ],
   // ...


### PR DESCRIPTION
### Description

Just as we do with our React SDK. we should specify the redirect_uri.

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not the default branch
