### PR TITLE
[SDK-3850] Fix links and export spa-js interfaces to improve docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ export class AppComponent {
   }
 ```
 
-By default the application will ask Auth0 to redirect back to the root URL of your application after authentication. This can be configured by setting the [redirectUri](https://auth0.github.io/auth0-angular/interfaces/auth_config.AuthConfig.html#redirectUri) option.
+By default the application will ask Auth0 to redirect back to the root URL of your application after authentication. This can be configured by setting the [redirectUri](https://auth0.github.io/auth0-angular/interfaces/AuthorizationParams.html#redirect_uri) option.
 
 For more code samples on how to integrate the **auth0-angular** SDK in your **Angular** application, have a look at our [examples](https://github.com/auth0/auth0-angular/tree/master/EXAMPLES.md).
 
@@ -157,8 +157,8 @@ For more code samples on how to integrate the **auth0-angular** SDK in your **An
 
 Explore public API's available in auth0-angular.
 
-- [AuthService](https://auth0.github.io/auth0-angular/classes/auth_service.AuthService.html) - service used to interact with the SDK.
-- [AuthConfig](https://auth0.github.io/auth0-angular/interfaces/auth_config.AuthConfig.html) - used to configure the SDK.
+- [AuthService](https://auth0.github.io/auth0-angular/classes/AuthService.html) - service used to interact with the SDK.
+- [AuthConfig](https://auth0.github.io/auth0-angular/interfaces/AuthConfig.html) - used to configure the SDK.
 
 ## Feedback
 

--- a/docs/classes/Auth0ClientFactory.html
+++ b/docs/classes/Auth0ClientFactory.html
@@ -90,7 +90,7 @@
             <li>
               Defined in
               <a
-                href="https://github.com/auth0/auth0-angular/blob/560b670/projects/auth0-angular/src/lib/auth.client.ts#L6"
+                href="https://github.com/auth0/auth0-angular/blob/014575f/projects/auth0-angular/src/lib/auth.client.ts#L6"
                 >projects/auth0-angular/src/lib/auth.client.ts:6</a
               >
             </li>
@@ -355,7 +355,7 @@
                     <li>
                       Defined in
                       <a
-                        href="https://github.com/auth0/auth0-angular/blob/560b670/projects/auth0-angular/src/lib/auth.client.ts#L7"
+                        href="https://github.com/auth0/auth0-angular/blob/014575f/projects/auth0-angular/src/lib/auth.client.ts#L7"
                         >projects/auth0-angular/src/lib/auth.client.ts:7</a
                       >
                     </li>

--- a/docs/classes/AuthClientConfig.html
+++ b/docs/classes/AuthClientConfig.html
@@ -104,7 +104,7 @@
             <li>
               Defined in
               <a
-                href="https://github.com/auth0/auth0-angular/blob/560b670/projects/auth0-angular/src/lib/auth.config.ts#L198"
+                href="https://github.com/auth0/auth0-angular/blob/014575f/projects/auth0-angular/src/lib/auth.config.ts#L198"
                 >projects/auth0-angular/src/lib/auth.config.ts:198</a
               >
             </li>
@@ -321,7 +321,7 @@
                     <li>
                       Defined in
                       <a
-                        href="https://github.com/auth0/auth0-angular/blob/560b670/projects/auth0-angular/src/lib/auth.config.ts#L201"
+                        href="https://github.com/auth0/auth0-angular/blob/014575f/projects/auth0-angular/src/lib/auth.config.ts#L201"
                         >projects/auth0-angular/src/lib/auth.config.ts:201</a
                       >
                     </li>
@@ -403,7 +403,7 @@
                     <li>
                       Defined in
                       <a
-                        href="https://github.com/auth0/auth0-angular/blob/560b670/projects/auth0-angular/src/lib/auth.config.ts#L219"
+                        href="https://github.com/auth0/auth0-angular/blob/014575f/projects/auth0-angular/src/lib/auth.config.ts#L219"
                         >projects/auth0-angular/src/lib/auth.config.ts:219</a
                       >
                     </li>
@@ -498,7 +498,7 @@
                     <li>
                       Defined in
                       <a
-                        href="https://github.com/auth0/auth0-angular/blob/560b670/projects/auth0-angular/src/lib/auth.config.ts#L212"
+                        href="https://github.com/auth0/auth0-angular/blob/014575f/projects/auth0-angular/src/lib/auth.config.ts#L212"
                         >projects/auth0-angular/src/lib/auth.config.ts:212</a
                       >
                     </li>

--- a/docs/classes/AuthGuard.html
+++ b/docs/classes/AuthGuard.html
@@ -98,7 +98,7 @@
             <li>
               Defined in
               <a
-                href="https://github.com/auth0/auth0-angular/blob/560b670/projects/auth0-angular/src/lib/auth.guard.ts#L18"
+                href="https://github.com/auth0/auth0-angular/blob/014575f/projects/auth0-angular/src/lib/auth.guard.ts#L18"
                 >projects/auth0-angular/src/lib/auth.guard.ts:18</a
               >
             </li>
@@ -339,7 +339,7 @@
                     <li>
                       Defined in
                       <a
-                        href="https://github.com/auth0/auth0-angular/blob/560b670/projects/auth0-angular/src/lib/auth.guard.ts#L19"
+                        href="https://github.com/auth0/auth0-angular/blob/014575f/projects/auth0-angular/src/lib/auth.guard.ts#L19"
                         >projects/auth0-angular/src/lib/auth.guard.ts:19</a
                       >
                     </li>
@@ -443,7 +443,7 @@
                     <li>
                       Defined in
                       <a
-                        href="https://github.com/auth0/auth0-angular/blob/560b670/projects/auth0-angular/src/lib/auth.guard.ts#L25"
+                        href="https://github.com/auth0/auth0-angular/blob/014575f/projects/auth0-angular/src/lib/auth.guard.ts#L25"
                         >projects/auth0-angular/src/lib/auth.guard.ts:25</a
                       >
                     </li>
@@ -545,7 +545,7 @@
                     <li>
                       Defined in
                       <a
-                        href="https://github.com/auth0/auth0-angular/blob/560b670/projects/auth0-angular/src/lib/auth.guard.ts#L32"
+                        href="https://github.com/auth0/auth0-angular/blob/014575f/projects/auth0-angular/src/lib/auth.guard.ts#L32"
                         >projects/auth0-angular/src/lib/auth.guard.ts:32</a
                       >
                     </li>
@@ -638,7 +638,7 @@
                     <li>
                       Defined in
                       <a
-                        href="https://github.com/auth0/auth0-angular/blob/560b670/projects/auth0-angular/src/lib/auth.guard.ts#L21"
+                        href="https://github.com/auth0/auth0-angular/blob/014575f/projects/auth0-angular/src/lib/auth.guard.ts#L21"
                         >projects/auth0-angular/src/lib/auth.guard.ts:21</a
                       >
                     </li>

--- a/docs/classes/AuthModule.html
+++ b/docs/classes/AuthModule.html
@@ -90,7 +90,7 @@
             <li>
               Defined in
               <a
-                href="https://github.com/auth0/auth0-angular/blob/560b670/projects/auth0-angular/src/lib/auth.module.ts#L8"
+                href="https://github.com/auth0/auth0-angular/blob/014575f/projects/auth0-angular/src/lib/auth.module.ts#L8"
                 >projects/auth0-angular/src/lib/auth.module.ts:8</a
               >
             </li>
@@ -375,7 +375,7 @@
                     <li>
                       Defined in
                       <a
-                        href="https://github.com/auth0/auth0-angular/blob/560b670/projects/auth0-angular/src/lib/auth.module.ts#L15"
+                        href="https://github.com/auth0/auth0-angular/blob/014575f/projects/auth0-angular/src/lib/auth.module.ts#L15"
                         >projects/auth0-angular/src/lib/auth.module.ts:15</a
                       >
                     </li>

--- a/docs/classes/AuthService.html
+++ b/docs/classes/AuthService.html
@@ -119,7 +119,7 @@
             <li>
               Defined in
               <a
-                href="https://github.com/auth0/auth0-angular/blob/560b670/projects/auth0-angular/src/lib/auth.service.ts#L43"
+                href="https://github.com/auth0/auth0-angular/blob/014575f/projects/auth0-angular/src/lib/auth.service.ts#L43"
                 >projects/auth0-angular/src/lib/auth.service.ts:43</a
               >
             </li>
@@ -573,7 +573,7 @@
                     <li>
                       Defined in
                       <a
-                        href="https://github.com/auth0/auth0-angular/blob/560b670/projects/auth0-angular/src/lib/auth.service.ts#L81"
+                        href="https://github.com/auth0/auth0-angular/blob/014575f/projects/auth0-angular/src/lib/auth.service.ts#L81"
                         >projects/auth0-angular/src/lib/auth.service.ts:81</a
                       >
                     </li>
@@ -632,7 +632,7 @@
                 <li>
                   Defined in
                   <a
-                    href="https://github.com/auth0/auth0-angular/blob/560b670/projects/auth0-angular/src/lib/auth.service.ts#L79"
+                    href="https://github.com/auth0/auth0-angular/blob/014575f/projects/auth0-angular/src/lib/auth.service.ts#L79"
                     >projects/auth0-angular/src/lib/auth.service.ts:79</a
                   >
                 </li>
@@ -680,7 +680,7 @@
                 <li>
                   Defined in
                   <a
-                    href="https://github.com/auth0/auth0-angular/blob/560b670/projects/auth0-angular/src/lib/auth.service.ts#L73"
+                    href="https://github.com/auth0/auth0-angular/blob/014575f/projects/auth0-angular/src/lib/auth.service.ts#L73"
                     >projects/auth0-angular/src/lib/auth.service.ts:73</a
                   >
                 </li>
@@ -741,7 +741,7 @@
                 <li>
                   Defined in
                   <a
-                    href="https://github.com/auth0/auth0-angular/blob/560b670/projects/auth0-angular/src/lib/auth.service.ts#L68"
+                    href="https://github.com/auth0/auth0-angular/blob/014575f/projects/auth0-angular/src/lib/auth.service.ts#L68"
                     >projects/auth0-angular/src/lib/auth.service.ts:68</a
                   >
                 </li>
@@ -794,7 +794,7 @@
                 <li>
                   Defined in
                   <a
-                    href="https://github.com/auth0/auth0-angular/blob/560b670/projects/auth0-angular/src/lib/auth.service.ts#L58"
+                    href="https://github.com/auth0/auth0-angular/blob/014575f/projects/auth0-angular/src/lib/auth.service.ts#L58"
                     >projects/auth0-angular/src/lib/auth.service.ts:58</a
                   >
                 </li>
@@ -844,7 +844,7 @@
                 <li>
                   Defined in
                   <a
-                    href="https://github.com/auth0/auth0-angular/blob/560b670/projects/auth0-angular/src/lib/auth.service.ts#L52"
+                    href="https://github.com/auth0/auth0-angular/blob/014575f/projects/auth0-angular/src/lib/auth.service.ts#L52"
                     >projects/auth0-angular/src/lib/auth.service.ts:52</a
                   >
                 </li>
@@ -900,7 +900,7 @@
                 <li>
                   Defined in
                   <a
-                    href="https://github.com/auth0/auth0-angular/blob/560b670/projects/auth0-angular/src/lib/auth.service.ts#L63"
+                    href="https://github.com/auth0/auth0-angular/blob/014575f/projects/auth0-angular/src/lib/auth.service.ts#L63"
                     >projects/auth0-angular/src/lib/auth.service.ts:63</a
                   >
                 </li>
@@ -943,7 +943,11 @@
                   class="tsd-signature-symbol"
                   >(</span
                 >options<span class="tsd-signature-symbol">: </span
-                ><span class="tsd-signature-type">GetTokenSilentlyOptions</span
+                ><a
+                  href="../interfaces/GetTokenSilentlyOptions.html"
+                  class="tsd-signature-type"
+                  data-tsd-kind="Interface"
+                  >GetTokenSilentlyOptions</a
                 ><span class="tsd-signature-symbol"> &amp; </span
                 ><span class="tsd-signature-symbol">{ </span><br /><span
                   >    </span
@@ -990,8 +994,11 @@
                     <li>
                       <h5>
                         options:
-                        <span class="tsd-signature-type"
-                          >GetTokenSilentlyOptions</span
+                        <a
+                          href="../interfaces/GetTokenSilentlyOptions.html"
+                          class="tsd-signature-type"
+                          data-tsd-kind="Interface"
+                          >GetTokenSilentlyOptions</a
                         ><span class="tsd-signature-symbol"> &amp; </span
                         ><span class="tsd-signature-symbol">{ </span><br /><span
                           >    </span
@@ -1021,7 +1028,7 @@
                     <li>
                       Defined in
                       <a
-                        href="https://github.com/auth0/auth0-angular/blob/560b670/projects/auth0-angular/src/lib/auth.service.ts#L198"
+                        href="https://github.com/auth0/auth0-angular/blob/014575f/projects/auth0-angular/src/lib/auth.service.ts#L198"
                         >projects/auth0-angular/src/lib/auth.service.ts:198</a
                       >
                     </li>
@@ -1036,7 +1043,11 @@
                   class="tsd-signature-symbol"
                   >(</span
                 >options<span class="tsd-signature-symbol">?: </span
-                ><span class="tsd-signature-type">GetTokenSilentlyOptions</span
+                ><a
+                  href="../interfaces/GetTokenSilentlyOptions.html"
+                  class="tsd-signature-type"
+                  data-tsd-kind="Interface"
+                  >GetTokenSilentlyOptions</a
                 ><span class="tsd-signature-symbol">)</span
                 ><span class="tsd-signature-symbol">: </span
                 ><span class="tsd-signature-type">Observable</span
@@ -1072,8 +1083,11 @@
                       <h5>
                         <code class="tsd-tag ts-flagOptional">Optional</code>
                         options:
-                        <span class="tsd-signature-type"
-                          >GetTokenSilentlyOptions</span
+                        <a
+                          href="../interfaces/GetTokenSilentlyOptions.html"
+                          class="tsd-signature-type"
+                          data-tsd-kind="Interface"
+                          >GetTokenSilentlyOptions</a
                         >
                       </h5>
                       <div class="tsd-comment tsd-typography">
@@ -1093,7 +1107,7 @@
                     <li>
                       Defined in
                       <a
-                        href="https://github.com/auth0/auth0-angular/blob/560b670/projects/auth0-angular/src/lib/auth.service.ts#L207"
+                        href="https://github.com/auth0/auth0-angular/blob/014575f/projects/auth0-angular/src/lib/auth.service.ts#L207"
                         >projects/auth0-angular/src/lib/auth.service.ts:207</a
                       >
                     </li>
@@ -1135,7 +1149,11 @@
                   class="tsd-signature-symbol"
                   >(</span
                 >options<span class="tsd-signature-symbol">?: </span
-                ><span class="tsd-signature-type">GetTokenWithPopupOptions</span
+                ><a
+                  href="../interfaces/GetTokenWithPopupOptions.html"
+                  class="tsd-signature-type"
+                  data-tsd-kind="Interface"
+                  >GetTokenWithPopupOptions</a
                 ><span class="tsd-signature-symbol">)</span
                 ><span class="tsd-signature-symbol">: </span
                 ><span class="tsd-signature-type">Observable</span
@@ -1182,8 +1200,11 @@
                       <h5>
                         <code class="tsd-tag ts-flagOptional">Optional</code>
                         options:
-                        <span class="tsd-signature-type"
-                          >GetTokenWithPopupOptions</span
+                        <a
+                          href="../interfaces/GetTokenWithPopupOptions.html"
+                          class="tsd-signature-type"
+                          data-tsd-kind="Interface"
+                          >GetTokenWithPopupOptions</a
                         >
                       </h5>
                     </li>
@@ -1202,7 +1223,7 @@
                     <li>
                       Defined in
                       <a
-                        href="https://github.com/auth0/auth0-angular/blob/560b670/projects/auth0-angular/src/lib/auth.service.ts#L270"
+                        href="https://github.com/auth0/auth0-angular/blob/014575f/projects/auth0-angular/src/lib/auth.service.ts#L270"
                         >projects/auth0-angular/src/lib/auth.service.ts:270</a
                       >
                     </li>
@@ -1324,7 +1345,7 @@
                     <li>
                       Defined in
                       <a
-                        href="https://github.com/auth0/auth0-angular/blob/560b670/projects/auth0-angular/src/lib/auth.service.ts#L302"
+                        href="https://github.com/auth0/auth0-angular/blob/014575f/projects/auth0-angular/src/lib/auth.service.ts#L302"
                         >projects/auth0-angular/src/lib/auth.service.ts:302</a
                       >
                     </li>
@@ -1365,9 +1386,17 @@
                 login<wbr />With<wbr />Popup<span class="tsd-signature-symbol"
                   >(</span
                 >options<span class="tsd-signature-symbol">?: </span
-                ><span class="tsd-signature-type">PopupLoginOptions</span>,
-                config<span class="tsd-signature-symbol">?: </span
-                ><span class="tsd-signature-type">PopupConfigOptions</span
+                ><a
+                  href="../interfaces/PopupLoginOptions.html"
+                  class="tsd-signature-type"
+                  data-tsd-kind="Interface"
+                  >PopupLoginOptions</a
+                >, config<span class="tsd-signature-symbol">?: </span
+                ><a
+                  href="../interfaces/PopupConfigOptions.html"
+                  class="tsd-signature-type"
+                  data-tsd-kind="Interface"
+                  >PopupConfigOptions</a
                 ><span class="tsd-signature-symbol">)</span
                 ><span class="tsd-signature-symbol">: </span
                 ><span class="tsd-signature-type">Observable</span
@@ -1417,8 +1446,11 @@
                       <h5>
                         <code class="tsd-tag ts-flagOptional">Optional</code>
                         options:
-                        <span class="tsd-signature-type"
-                          >PopupLoginOptions</span
+                        <a
+                          href="../interfaces/PopupLoginOptions.html"
+                          class="tsd-signature-type"
+                          data-tsd-kind="Interface"
+                          >PopupLoginOptions</a
                         >
                       </h5>
                       <div class="tsd-comment tsd-typography">
@@ -1429,8 +1461,11 @@
                       <h5>
                         <code class="tsd-tag ts-flagOptional">Optional</code>
                         config:
-                        <span class="tsd-signature-type"
-                          >PopupConfigOptions</span
+                        <a
+                          href="../interfaces/PopupConfigOptions.html"
+                          class="tsd-signature-type"
+                          data-tsd-kind="Interface"
+                          >PopupConfigOptions</a
                         >
                       </h5>
                       <div class="tsd-comment tsd-typography">
@@ -1450,7 +1485,7 @@
                     <li>
                       Defined in
                       <a
-                        href="https://github.com/auth0/auth0-angular/blob/560b670/projects/auth0-angular/src/lib/auth.service.ts#L157"
+                        href="https://github.com/auth0/auth0-angular/blob/014575f/projects/auth0-angular/src/lib/auth.service.ts#L157"
                         >projects/auth0-angular/src/lib/auth.service.ts:157</a
                       >
                     </li>
@@ -1572,7 +1607,7 @@
                     <li>
                       Defined in
                       <a
-                        href="https://github.com/auth0/auth0-angular/blob/560b670/projects/auth0-angular/src/lib/auth.service.ts#L134"
+                        href="https://github.com/auth0/auth0-angular/blob/014575f/projects/auth0-angular/src/lib/auth.service.ts#L134"
                         >projects/auth0-angular/src/lib/auth.service.ts:134</a
                       >
                     </li>
@@ -1686,7 +1721,7 @@
                     <li>
                       Defined in
                       <a
-                        href="https://github.com/auth0/auth0-angular/blob/560b670/projects/auth0-angular/src/lib/auth.service.ts#L183"
+                        href="https://github.com/auth0/auth0-angular/blob/014575f/projects/auth0-angular/src/lib/auth.service.ts#L183"
                         >projects/auth0-angular/src/lib/auth.service.ts:183</a
                       >
                     </li>
@@ -1760,7 +1795,7 @@
                     <li>
                       Defined in
                       <a
-                        href="https://github.com/auth0/auth0-angular/blob/560b670/projects/auth0-angular/src/lib/auth.service.ts#L117"
+                        href="https://github.com/auth0/auth0-angular/blob/014575f/projects/auth0-angular/src/lib/auth.service.ts#L117"
                         >projects/auth0-angular/src/lib/auth.service.ts:117</a
                       >
                     </li>

--- a/docs/classes/AuthState.html
+++ b/docs/classes/AuthState.html
@@ -95,7 +95,7 @@
             <li>
               Defined in
               <a
-                href="https://github.com/auth0/auth0-angular/blob/560b670/projects/auth0-angular/src/lib/auth.state.ts#L26"
+                href="https://github.com/auth0/auth0-angular/blob/014575f/projects/auth0-angular/src/lib/auth.state.ts#L26"
                 >projects/auth0-angular/src/lib/auth.state.ts:26</a
               >
             </li>
@@ -411,7 +411,7 @@
                     <li>
                       Defined in
                       <a
-                        href="https://github.com/auth0/auth0-angular/blob/560b670/projects/auth0-angular/src/lib/auth.state.ts#L112"
+                        href="https://github.com/auth0/auth0-angular/blob/014575f/projects/auth0-angular/src/lib/auth.state.ts#L112"
                         >projects/auth0-angular/src/lib/auth.state.ts:112</a
                       >
                     </li>
@@ -464,7 +464,7 @@
                 <li>
                   Defined in
                   <a
-                    href="https://github.com/auth0/auth0-angular/blob/560b670/projects/auth0-angular/src/lib/auth.state.ts#L110"
+                    href="https://github.com/auth0/auth0-angular/blob/014575f/projects/auth0-angular/src/lib/auth.state.ts#L110"
                     >projects/auth0-angular/src/lib/auth.state.ts:110</a
                   >
                 </li>
@@ -525,7 +525,7 @@
                 <li>
                   Defined in
                   <a
-                    href="https://github.com/auth0/auth0-angular/blob/560b670/projects/auth0-angular/src/lib/auth.state.ts#L101"
+                    href="https://github.com/auth0/auth0-angular/blob/014575f/projects/auth0-angular/src/lib/auth.state.ts#L101"
                     >projects/auth0-angular/src/lib/auth.state.ts:101</a
                   >
                 </li>
@@ -578,7 +578,7 @@
                 <li>
                   Defined in
                   <a
-                    href="https://github.com/auth0/auth0-angular/blob/560b670/projects/auth0-angular/src/lib/auth.state.ts#L83"
+                    href="https://github.com/auth0/auth0-angular/blob/014575f/projects/auth0-angular/src/lib/auth.state.ts#L83"
                     >projects/auth0-angular/src/lib/auth.state.ts:83</a
                   >
                 </li>
@@ -628,7 +628,7 @@
                 <li>
                   Defined in
                   <a
-                    href="https://github.com/auth0/auth0-angular/blob/560b670/projects/auth0-angular/src/lib/auth.state.ts#L35"
+                    href="https://github.com/auth0/auth0-angular/blob/014575f/projects/auth0-angular/src/lib/auth.state.ts#L35"
                     >projects/auth0-angular/src/lib/auth.state.ts:35</a
                   >
                 </li>
@@ -684,7 +684,7 @@
                 <li>
                   Defined in
                   <a
-                    href="https://github.com/auth0/auth0-angular/blob/560b670/projects/auth0-angular/src/lib/auth.state.ts#L91"
+                    href="https://github.com/auth0/auth0-angular/blob/014575f/projects/auth0-angular/src/lib/auth.state.ts#L91"
                     >projects/auth0-angular/src/lib/auth.state.ts:91</a
                   >
                 </li>
@@ -756,7 +756,7 @@
                     <li>
                       Defined in
                       <a
-                        href="https://github.com/auth0/auth0-angular/blob/560b670/projects/auth0-angular/src/lib/auth.state.ts#L127"
+                        href="https://github.com/auth0/auth0-angular/blob/014575f/projects/auth0-angular/src/lib/auth.state.ts#L127"
                         >projects/auth0-angular/src/lib/auth.state.ts:127</a
                       >
                     </li>
@@ -848,7 +848,7 @@
                     <li>
                       Defined in
                       <a
-                        href="https://github.com/auth0/auth0-angular/blob/560b670/projects/auth0-angular/src/lib/auth.state.ts#L136"
+                        href="https://github.com/auth0/auth0-angular/blob/014575f/projects/auth0-angular/src/lib/auth.state.ts#L136"
                         >projects/auth0-angular/src/lib/auth.state.ts:136</a
                       >
                     </li>
@@ -935,7 +935,7 @@
                     <li>
                       Defined in
                       <a
-                        href="https://github.com/auth0/auth0-angular/blob/560b670/projects/auth0-angular/src/lib/auth.state.ts#L145"
+                        href="https://github.com/auth0/auth0-angular/blob/014575f/projects/auth0-angular/src/lib/auth.state.ts#L145"
                         >projects/auth0-angular/src/lib/auth.state.ts:145</a
                       >
                     </li>
@@ -1024,7 +1024,7 @@
                     <li>
                       Defined in
                       <a
-                        href="https://github.com/auth0/auth0-angular/blob/560b670/projects/auth0-angular/src/lib/auth.state.ts#L119"
+                        href="https://github.com/auth0/auth0-angular/blob/014575f/projects/auth0-angular/src/lib/auth.state.ts#L119"
                         >projects/auth0-angular/src/lib/auth.state.ts:119</a
                       >
                     </li>

--- a/docs/enums/HttpMethod.html
+++ b/docs/enums/HttpMethod.html
@@ -93,7 +93,7 @@
             <li>
               Defined in
               <a
-                href="https://github.com/auth0/auth0-angular/blob/560b670/projects/auth0-angular/src/lib/auth.config.ts#L13"
+                href="https://github.com/auth0/auth0-angular/blob/014575f/projects/auth0-angular/src/lib/auth.config.ts#L13"
                 >projects/auth0-angular/src/lib/auth.config.ts:13</a
               >
             </li>
@@ -263,7 +263,7 @@
                 <li>
                   Defined in
                   <a
-                    href="https://github.com/auth0/auth0-angular/blob/560b670/projects/auth0-angular/src/lib/auth.config.ts#L18"
+                    href="https://github.com/auth0/auth0-angular/blob/014575f/projects/auth0-angular/src/lib/auth.config.ts#L18"
                     >projects/auth0-angular/src/lib/auth.config.ts:18</a
                   >
                 </li>
@@ -300,7 +300,7 @@
                 <li>
                   Defined in
                   <a
-                    href="https://github.com/auth0/auth0-angular/blob/560b670/projects/auth0-angular/src/lib/auth.config.ts#L14"
+                    href="https://github.com/auth0/auth0-angular/blob/014575f/projects/auth0-angular/src/lib/auth.config.ts#L14"
                     >projects/auth0-angular/src/lib/auth.config.ts:14</a
                   >
                 </li>
@@ -337,7 +337,7 @@
                 <li>
                   Defined in
                   <a
-                    href="https://github.com/auth0/auth0-angular/blob/560b670/projects/auth0-angular/src/lib/auth.config.ts#L19"
+                    href="https://github.com/auth0/auth0-angular/blob/014575f/projects/auth0-angular/src/lib/auth.config.ts#L19"
                     >projects/auth0-angular/src/lib/auth.config.ts:19</a
                   >
                 </li>
@@ -374,7 +374,7 @@
                 <li>
                   Defined in
                   <a
-                    href="https://github.com/auth0/auth0-angular/blob/560b670/projects/auth0-angular/src/lib/auth.config.ts#L17"
+                    href="https://github.com/auth0/auth0-angular/blob/014575f/projects/auth0-angular/src/lib/auth.config.ts#L17"
                     >projects/auth0-angular/src/lib/auth.config.ts:17</a
                   >
                 </li>
@@ -411,7 +411,7 @@
                 <li>
                   Defined in
                   <a
-                    href="https://github.com/auth0/auth0-angular/blob/560b670/projects/auth0-angular/src/lib/auth.config.ts#L15"
+                    href="https://github.com/auth0/auth0-angular/blob/014575f/projects/auth0-angular/src/lib/auth.config.ts#L15"
                     >projects/auth0-angular/src/lib/auth.config.ts:15</a
                   >
                 </li>
@@ -448,7 +448,7 @@
                 <li>
                   Defined in
                   <a
-                    href="https://github.com/auth0/auth0-angular/blob/560b670/projects/auth0-angular/src/lib/auth.config.ts#L16"
+                    href="https://github.com/auth0/auth0-angular/blob/014575f/projects/auth0-angular/src/lib/auth.config.ts#L16"
                     >projects/auth0-angular/src/lib/auth.config.ts:16</a
                   >
                 </li>

--- a/docs/functions/isHttpInterceptorRouteConfig.html
+++ b/docs/functions/isHttpInterceptorRouteConfig.html
@@ -177,7 +177,7 @@
                   <li>
                     Defined in
                     <a
-                      href="https://github.com/auth0/auth0-angular/blob/560b670/projects/auth0-angular/src/lib/auth.config.ts#L35"
+                      href="https://github.com/auth0/auth0-angular/blob/014575f/projects/auth0-angular/src/lib/auth.config.ts#L35"
                       >projects/auth0-angular/src/lib/auth.config.ts:35</a
                     >
                   </li>
@@ -558,6 +558,51 @@
                 >Auth<wbr />Config</a
               >
             </li>
+            <li class="tsd-kind-interface tsd-is-external">
+              <a
+                href="../interfaces/AuthorizationParams.html"
+                class="tsd-index-link"
+                ><svg
+                  class="tsd-kind-icon"
+                  width="24"
+                  height="24"
+                  viewBox="0 0 24 24"
+                >
+                  <use href="#icon-256-path"></use>
+                  <use href="#icon-256-text"></use></svg
+                >Authorization<wbr />Params</a
+              >
+            </li>
+            <li class="tsd-kind-interface tsd-is-external">
+              <a
+                href="../interfaces/GetTokenSilentlyOptions.html"
+                class="tsd-index-link"
+                ><svg
+                  class="tsd-kind-icon"
+                  width="24"
+                  height="24"
+                  viewBox="0 0 24 24"
+                >
+                  <use href="#icon-256-path"></use>
+                  <use href="#icon-256-text"></use></svg
+                >Get<wbr />Token<wbr />Silently<wbr />Options</a
+              >
+            </li>
+            <li class="tsd-kind-interface tsd-is-external">
+              <a
+                href="../interfaces/GetTokenWithPopupOptions.html"
+                class="tsd-index-link"
+                ><svg
+                  class="tsd-kind-icon"
+                  width="24"
+                  height="24"
+                  viewBox="0 0 24 24"
+                >
+                  <use href="#icon-256-path"></use>
+                  <use href="#icon-256-text"></use></svg
+                >Get<wbr />Token<wbr />With<wbr />Popup<wbr />Options</a
+              >
+            </li>
             <li class="tsd-kind-interface">
               <a
                 href="../interfaces/HttpInterceptorConfig.html"
@@ -625,6 +670,36 @@
                   <use href="#icon-256-path"></use>
                   <use href="#icon-256-text"></use></svg
                 >Logout<wbr />Options</a
+              >
+            </li>
+            <li class="tsd-kind-interface tsd-is-external">
+              <a
+                href="../interfaces/PopupConfigOptions.html"
+                class="tsd-index-link"
+                ><svg
+                  class="tsd-kind-icon"
+                  width="24"
+                  height="24"
+                  viewBox="0 0 24 24"
+                >
+                  <use href="#icon-256-path"></use>
+                  <use href="#icon-256-text"></use></svg
+                >Popup<wbr />Config<wbr />Options</a
+              >
+            </li>
+            <li class="tsd-kind-interface tsd-is-external">
+              <a
+                href="../interfaces/PopupLoginOptions.html"
+                class="tsd-index-link"
+                ><svg
+                  class="tsd-kind-icon"
+                  width="24"
+                  height="24"
+                  viewBox="0 0 24 24"
+                >
+                  <use href="#icon-256-path"></use>
+                  <use href="#icon-256-text"></use></svg
+                >Popup<wbr />Login<wbr />Options</a
               >
             </li>
             <li class="tsd-kind-interface">

--- a/docs/index.html
+++ b/docs/index.html
@@ -86,19 +86,6 @@
             A library for integrating <a href="https://auth0.com">Auth0</a> into
             an Angular application.
           </p>
-          <blockquote>
-            <p>
-              :warning: Please be aware that v2 is currently in
-              <a
-                href="https://auth0.com/docs/troubleshoot/product-lifecycle/product-release-stages"
-                ><strong>Beta</strong></a
-              >. Whilst we encourage you to test the update within your
-              applications, we do no recommend using this version in production
-              yet. Please follow the
-              <a href="./MIGRATION_GUIDE.md">migration guide</a> when updating
-              your application.
-            </p>
-          </blockquote>
           <p>
             <img
               src="https://img.shields.io/npm/v/@auth0/auth0-angular"
@@ -206,13 +193,13 @@
             <h3>Installation</h3>
           </a>
           <p>Using npm:</p>
-          <pre><code class="language-sh"><span class="hl-0">npm </span><span class="hl-1">install</span><span class="hl-0"> </span><span class="hl-1">@auth0/auth0-angular@beta</span>
+          <pre><code class="language-sh"><span class="hl-0">npm </span><span class="hl-1">install</span><span class="hl-0"> </span><span class="hl-1">@auth0/auth0-angular</span>
 </code></pre>
           <p>
             We also have <code>ng-add</code> support, so the library can also be
             installed using the Angular CLI:
           </p>
-          <pre><code class="language-sh"><span class="hl-0">ng </span><span class="hl-1">add</span><span class="hl-0"> </span><span class="hl-1">@auth0/auth0-angular@beta</span>
+          <pre><code class="language-sh"><span class="hl-0">ng </span><span class="hl-1">add</span><span class="hl-0"> </span><span class="hl-1">@auth0/auth0-angular</span>
 </code></pre>
 
           <a
@@ -313,7 +300,7 @@
             domain and client id, as well as the URL to which Auth0 should
             redirect back after succesful authentication:
           </p>
-          <pre><code class="language-ts"><span class="hl-2">import</span><span class="hl-0"> { </span><span class="hl-3">NgModule</span><span class="hl-0"> } </span><span class="hl-2">from</span><span class="hl-0"> </span><span class="hl-1">&#39;@angular/core&#39;</span><span class="hl-0">;</span><br/><span class="hl-2">import</span><span class="hl-0"> { </span><span class="hl-3">AuthModule</span><span class="hl-0"> } </span><span class="hl-2">from</span><span class="hl-0"> </span><span class="hl-1">&#39;@auth0/auth0-angular&#39;</span><span class="hl-0">;</span><br/><br/><span class="hl-0">@</span><span class="hl-4">NgModule</span><span class="hl-0">({</span><br/><span class="hl-0">  </span><span class="hl-5">// ...</span><br/><span class="hl-0">  </span><span class="hl-3">imports:</span><span class="hl-0"> [</span><br/><span class="hl-0">    </span><span class="hl-3">AuthModule</span><span class="hl-0">.</span><span class="hl-4">forRoot</span><span class="hl-0">({</span><br/><span class="hl-0">      </span><span class="hl-3">domain:</span><span class="hl-0"> </span><span class="hl-1">&#39;YOUR_AUTH0_DOMAIN&#39;</span><span class="hl-0">,</span><br/><span class="hl-0">      </span><span class="hl-3">clientId:</span><span class="hl-0"> </span><span class="hl-1">&#39;YOUR_AUTH0_CLIENT_ID&#39;</span><span class="hl-0">,</span><br/><span class="hl-0">      </span><span class="hl-3">authorizationParams:</span><span class="hl-0"> {</span><br/><span class="hl-0">        </span><span class="hl-3">redirect_uri:</span><span class="hl-0"> </span><span class="hl-3">window</span><span class="hl-0">.</span><span class="hl-3">location</span><span class="hl-0">.</span><span class="hl-3">origin</span><br/><span class="hl-0">      }</span><br/><span class="hl-0">    }),</span><br/><span class="hl-0">  ],</span><br/><span class="hl-0">  </span><span class="hl-5">// ...</span><br/><span class="hl-0">})</span><br/><span class="hl-2">export</span><span class="hl-0"> </span><span class="hl-6">class</span><span class="hl-0"> </span><span class="hl-7">AppModule</span><span class="hl-0"> {}</span>
+          <pre><code class="language-ts"><span class="hl-2">import</span><span class="hl-0"> { </span><span class="hl-3">NgModule</span><span class="hl-0"> } </span><span class="hl-2">from</span><span class="hl-0"> </span><span class="hl-1">&#39;@angular/core&#39;</span><span class="hl-0">;</span><br/><span class="hl-2">import</span><span class="hl-0"> { </span><span class="hl-3">AuthModule</span><span class="hl-0"> } </span><span class="hl-2">from</span><span class="hl-0"> </span><span class="hl-1">&#39;@auth0/auth0-angular&#39;</span><span class="hl-0">;</span><br/><br/><span class="hl-0">@</span><span class="hl-4">NgModule</span><span class="hl-0">({</span><br/><span class="hl-0">  </span><span class="hl-5">// ...</span><br/><span class="hl-0">  </span><span class="hl-3">imports:</span><span class="hl-0"> [</span><br/><span class="hl-0">    </span><span class="hl-3">AuthModule</span><span class="hl-0">.</span><span class="hl-4">forRoot</span><span class="hl-0">({</span><br/><span class="hl-0">      </span><span class="hl-3">domain:</span><span class="hl-0"> </span><span class="hl-1">&#39;YOUR_AUTH0_DOMAIN&#39;</span><span class="hl-0">,</span><br/><span class="hl-0">      </span><span class="hl-3">clientId:</span><span class="hl-0"> </span><span class="hl-1">&#39;YOUR_AUTH0_CLIENT_ID&#39;</span><span class="hl-0">,</span><br/><span class="hl-0">      </span><span class="hl-3">authorizationParams:</span><span class="hl-0"> {</span><br/><span class="hl-0">        </span><span class="hl-3">redirect_uri:</span><span class="hl-0"> </span><span class="hl-3">window</span><span class="hl-0">.</span><span class="hl-3">location</span><span class="hl-0">.</span><span class="hl-3">origin</span><span class="hl-0">,</span><br/><span class="hl-0">      },</span><br/><span class="hl-0">    }),</span><br/><span class="hl-0">  ],</span><br/><span class="hl-0">  </span><span class="hl-5">// ...</span><br/><span class="hl-0">})</span><br/><span class="hl-2">export</span><span class="hl-0"> </span><span class="hl-6">class</span><span class="hl-0"> </span><span class="hl-7">AppModule</span><span class="hl-0"> {}</span>
 </code></pre>
 
           <a
@@ -375,7 +362,7 @@
             root URL of your application after authentication. This can be
             configured by setting the
             <a
-              href="https://auth0.github.io/auth0-angular/interfaces/auth_config.AuthConfig.html#redirectUri"
+              href="https://auth0.github.io/auth0-angular/interfaces/AuthorizationParams.html#redirect_uri"
               >redirectUri</a
             >
             option.
@@ -401,14 +388,14 @@
           <ul>
             <li>
               <a
-                href="https://auth0.github.io/auth0-angular/classes/auth_service.AuthService.html"
+                href="https://auth0.github.io/auth0-angular/classes/AuthService.html"
                 >AuthService</a
               >
               - service used to interact with the SDK.
             </li>
             <li>
               <a
-                href="https://auth0.github.io/auth0-angular/interfaces/auth_config.AuthConfig.html"
+                href="https://auth0.github.io/auth0-angular/interfaces/AuthConfig.html"
                 >AuthConfig</a
               >
               - used to configure the SDK.
@@ -884,6 +871,51 @@
                 >Auth<wbr />Config</a
               >
             </li>
+            <li class="tsd-kind-interface tsd-is-external">
+              <a
+                href="interfaces/AuthorizationParams.html"
+                class="tsd-index-link"
+                ><svg
+                  class="tsd-kind-icon"
+                  width="24"
+                  height="24"
+                  viewBox="0 0 24 24"
+                >
+                  <use href="#icon-256-path"></use>
+                  <use href="#icon-256-text"></use></svg
+                >Authorization<wbr />Params</a
+              >
+            </li>
+            <li class="tsd-kind-interface tsd-is-external">
+              <a
+                href="interfaces/GetTokenSilentlyOptions.html"
+                class="tsd-index-link"
+                ><svg
+                  class="tsd-kind-icon"
+                  width="24"
+                  height="24"
+                  viewBox="0 0 24 24"
+                >
+                  <use href="#icon-256-path"></use>
+                  <use href="#icon-256-text"></use></svg
+                >Get<wbr />Token<wbr />Silently<wbr />Options</a
+              >
+            </li>
+            <li class="tsd-kind-interface tsd-is-external">
+              <a
+                href="interfaces/GetTokenWithPopupOptions.html"
+                class="tsd-index-link"
+                ><svg
+                  class="tsd-kind-icon"
+                  width="24"
+                  height="24"
+                  viewBox="0 0 24 24"
+                >
+                  <use href="#icon-256-path"></use>
+                  <use href="#icon-256-text"></use></svg
+                >Get<wbr />Token<wbr />With<wbr />Popup<wbr />Options</a
+              >
+            </li>
             <li class="tsd-kind-interface">
               <a
                 href="interfaces/HttpInterceptorConfig.html"
@@ -951,6 +983,34 @@
                   <use href="#icon-256-path"></use>
                   <use href="#icon-256-text"></use></svg
                 >Logout<wbr />Options</a
+              >
+            </li>
+            <li class="tsd-kind-interface tsd-is-external">
+              <a
+                href="interfaces/PopupConfigOptions.html"
+                class="tsd-index-link"
+                ><svg
+                  class="tsd-kind-icon"
+                  width="24"
+                  height="24"
+                  viewBox="0 0 24 24"
+                >
+                  <use href="#icon-256-path"></use>
+                  <use href="#icon-256-text"></use></svg
+                >Popup<wbr />Config<wbr />Options</a
+              >
+            </li>
+            <li class="tsd-kind-interface tsd-is-external">
+              <a href="interfaces/PopupLoginOptions.html" class="tsd-index-link"
+                ><svg
+                  class="tsd-kind-icon"
+                  width="24"
+                  height="24"
+                  viewBox="0 0 24 24"
+                >
+                  <use href="#icon-256-path"></use>
+                  <use href="#icon-256-text"></use></svg
+                >Popup<wbr />Login<wbr />Options</a
               >
             </li>
             <li class="tsd-kind-interface">

--- a/docs/interfaces/AppState.html
+++ b/docs/interfaces/AppState.html
@@ -104,7 +104,7 @@
             <li>
               Defined in
               <a
-                href="https://github.com/auth0/auth0-angular/blob/560b670/projects/auth0-angular/src/lib/auth.config.ts#L142"
+                href="https://github.com/auth0/auth0-angular/blob/014575f/projects/auth0-angular/src/lib/auth.config.ts#L142"
                 >projects/auth0-angular/src/lib/auth.config.ts:142</a
               >
             </li>
@@ -216,7 +216,7 @@
                 <li>
                   Defined in
                   <a
-                    href="https://github.com/auth0/auth0-angular/blob/560b670/projects/auth0-angular/src/lib/auth.config.ts#L147"
+                    href="https://github.com/auth0/auth0-angular/blob/014575f/projects/auth0-angular/src/lib/auth.config.ts#L147"
                     >projects/auth0-angular/src/lib/auth.config.ts:147</a
                   >
                 </li>

--- a/docs/interfaces/AuthConfig.html
+++ b/docs/interfaces/AuthConfig.html
@@ -100,7 +100,7 @@
             <li>
               Defined in
               <a
-                href="https://github.com/auth0/auth0-angular/blob/560b670/projects/auth0-angular/src/lib/auth.config.ts#L107"
+                href="https://github.com/auth0/auth0-angular/blob/014575f/projects/auth0-angular/src/lib/auth.config.ts#L107"
                 >projects/auth0-angular/src/lib/auth.config.ts:107</a
               >
             </li>
@@ -587,7 +587,12 @@
               authorization<wbr />Params<span class="tsd-signature-symbol"
                 >?:</span
               >
-              <span class="tsd-signature-type">AuthorizationParams</span>
+              <a
+                href="AuthorizationParams.html"
+                class="tsd-signature-type"
+                data-tsd-kind="Interface"
+                >AuthorizationParams</a
+              >
             </div>
             <div class="tsd-comment tsd-typography">
               <p>
@@ -936,7 +941,7 @@
                 <li>
                   Defined in
                   <a
-                    href="https://github.com/auth0/auth0-angular/blob/560b670/projects/auth0-angular/src/lib/auth.config.ts#L136"
+                    href="https://github.com/auth0/auth0-angular/blob/014575f/projects/auth0-angular/src/lib/auth.config.ts#L136"
                     >projects/auth0-angular/src/lib/auth.config.ts:136</a
                   >
                 </li>
@@ -988,7 +993,7 @@
                 <li>
                   Defined in
                   <a
-                    href="https://github.com/auth0/auth0-angular/blob/560b670/projects/auth0-angular/src/lib/auth.config.ts#L130"
+                    href="https://github.com/auth0/auth0-angular/blob/014575f/projects/auth0-angular/src/lib/auth.config.ts#L130"
                     >projects/auth0-angular/src/lib/auth.config.ts:130</a
                   >
                 </li>
@@ -1382,7 +1387,7 @@
                 <li>
                   Defined in
                   <a
-                    href="https://github.com/auth0/auth0-angular/blob/560b670/projects/auth0-angular/src/lib/auth.config.ts#L124"
+                    href="https://github.com/auth0/auth0-angular/blob/014575f/projects/auth0-angular/src/lib/auth.config.ts#L124"
                     >projects/auth0-angular/src/lib/auth.config.ts:124</a
                   >
                 </li>

--- a/docs/interfaces/AuthorizationParams.html
+++ b/docs/interfaces/AuthorizationParams.html
@@ -1,0 +1,1433 @@
+<!DOCTYPE html>
+<html class="default" lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta http-equiv="x-ua-compatible" content="IE=edge" />
+    <title>AuthorizationParams | @auth0/auth0-angular</title>
+    <meta name="description" content="Documentation for @auth0/auth0-angular" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <link rel="stylesheet" href="../assets/style.css" />
+    <link rel="stylesheet" href="../assets/highlight.css" />
+    <script async src="../assets/search.js" id="search-script"></script>
+  </head>
+  <body>
+    <script>
+      document.documentElement.dataset.theme =
+        localStorage.getItem('tsd-theme') || 'os';
+    </script>
+    <header class="tsd-page-toolbar">
+      <div class="tsd-toolbar-contents container">
+        <div class="table-cell" id="tsd-search" data-base="..">
+          <div class="field">
+            <label
+              for="tsd-search-field"
+              class="tsd-widget tsd-toolbar-icon search no-caption"
+              ><svg width="16" height="16" viewBox="0 0 16 16" fill="none">
+                <path
+                  d="M15.7824 13.833L12.6666 10.7177C12.5259 10.5771 12.3353 10.499 12.1353 10.499H11.6259C12.4884 9.39596 13.001 8.00859 13.001 6.49937C13.001 2.90909 10.0914 0 6.50048 0C2.90959 0 0 2.90909 0 6.49937C0 10.0896 2.90959 12.9987 6.50048 12.9987C8.00996 12.9987 9.39756 12.4863 10.5008 11.6239V12.1332C10.5008 12.3332 10.5789 12.5238 10.7195 12.6644L13.8354 15.7797C14.1292 16.0734 14.6042 16.0734 14.8948 15.7797L15.7793 14.8954C16.0731 14.6017 16.0731 14.1267 15.7824 13.833ZM6.50048 10.499C4.29094 10.499 2.50018 8.71165 2.50018 6.49937C2.50018 4.29021 4.28781 2.49976 6.50048 2.49976C8.71001 2.49976 10.5008 4.28708 10.5008 6.49937C10.5008 8.70852 8.71314 10.499 6.50048 10.499Z"
+                  fill="var(--color-text)"
+                ></path></svg></label
+            ><input type="text" id="tsd-search-field" aria-label="Search" />
+          </div>
+          <div class="field">
+            <div id="tsd-toolbar-links"></div>
+          </div>
+          <ul class="results">
+            <li class="state loading">Preparing search index...</li>
+            <li class="state failure">The search index is not available</li>
+          </ul>
+          <a href="../index.html" class="title">@auth0/auth0-angular</a>
+        </div>
+        <div class="table-cell" id="tsd-widgets">
+          <a
+            href="#"
+            class="tsd-widget tsd-toolbar-icon menu no-caption"
+            data-toggle="menu"
+            aria-label="Menu"
+            ><svg width="16" height="16" viewBox="0 0 16 16" fill="none">
+              <rect
+                x="1"
+                y="3"
+                width="14"
+                height="2"
+                fill="var(--color-text)"
+              ></rect>
+              <rect
+                x="1"
+                y="7"
+                width="14"
+                height="2"
+                fill="var(--color-text)"
+              ></rect>
+              <rect
+                x="1"
+                y="11"
+                width="14"
+                height="2"
+                fill="var(--color-text)"
+              ></rect></svg
+          ></a>
+        </div>
+      </div>
+    </header>
+    <div class="container container-main">
+      <div class="col-8 col-content">
+        <div class="tsd-page-title">
+          <ul class="tsd-breadcrumb">
+            <li><a href="../modules.html">@auth0/auth0-angular</a></li>
+            <li><a href="AuthorizationParams.html">AuthorizationParams</a></li>
+          </ul>
+          <h1>Interface AuthorizationParams</h1>
+        </div>
+        <section class="tsd-panel tsd-hierarchy">
+          <h4>Hierarchy</h4>
+          <ul class="tsd-hierarchy">
+            <li><span class="target">AuthorizationParams</span></li>
+          </ul>
+        </section>
+        <section class="tsd-panel tsd-kind-interface tsd-is-external">
+          <h4 class="tsd-before-signature">Indexable</h4>
+          <div class="tsd-signature">
+            <span class="tsd-signature-symbol">[</span>key:
+            <span class="tsd-signature-type">string</span
+            ><span class="tsd-signature-symbol">]: </span
+            ><span class="tsd-signature-type">any</span>
+          </div>
+        </section>
+        <aside class="tsd-sources">
+          <ul>
+            <li>
+              Defined in
+              node_modules/@auth0/auth0-spa-js/dist/typings/global.d.ts:2
+            </li>
+          </ul>
+        </aside>
+        <section class="tsd-panel-group tsd-index-group">
+          <section class="tsd-panel tsd-index-panel">
+            <details class="tsd-index-content tsd-index-accordion" open>
+              <summary class="tsd-accordion-summary tsd-index-summary">
+                <h5
+                  class="tsd-index-heading uppercase"
+                  role="button"
+                  aria-expanded="false"
+                  tabindex="0"
+                >
+                  <svg width="16" height="16" viewBox="0 0 16 16" fill="none">
+                    <path
+                      d="M1.5 5.50969L8 11.6609L14.5 5.50969L12.5466 3.66086L8 7.96494L3.45341 3.66086L1.5 5.50969Z"
+                      fill="var(--color-text)"
+                    ></path>
+                  </svg>
+                  Index
+                </h5>
+              </summary>
+              <div class="tsd-accordion-details">
+                <section class="tsd-index-section">
+                  <h3 class="tsd-index-heading">Properties</h3>
+                  <div class="tsd-index-list">
+                    <a
+                      href="AuthorizationParams.html#acr_values"
+                      class="tsd-index-link tsd-kind-property tsd-parent-kind-interface tsd-is-external"
+                      ><svg
+                        class="tsd-kind-icon"
+                        width="24"
+                        height="24"
+                        viewBox="0 0 24 24"
+                      >
+                        <rect
+                          fill="var(--color-icon-background)"
+                          stroke="#FF984D"
+                          stroke-width="1.5"
+                          x="1"
+                          y="1"
+                          width="22"
+                          height="22"
+                          rx="12"
+                          id="icon-1024-path"
+                        ></rect>
+                        <path
+                          d="M9.354 16V7.24H12.174C12.99 7.24 13.638 7.476 14.118 7.948C14.606 8.412 14.85 9.036 14.85 9.82C14.85 10.604 14.606 11.232 14.118 11.704C13.638 12.168 12.99 12.4 12.174 12.4H10.434V16H9.354ZM10.434 11.428H12.174C12.646 11.428 13.022 11.284 13.302 10.996C13.59 10.7 13.734 10.308 13.734 9.82C13.734 9.324 13.59 8.932 13.302 8.644C13.022 8.356 12.646 8.212 12.174 8.212H10.434V11.428Z"
+                          fill="var(--color-text)"
+                          id="icon-1024-text"
+                        ></path></svg
+                      ><span>acr_<wbr />values?</span></a
+                    >
+                    <a
+                      href="AuthorizationParams.html#audience"
+                      class="tsd-index-link tsd-kind-property tsd-parent-kind-interface tsd-is-external"
+                      ><svg
+                        class="tsd-kind-icon"
+                        width="24"
+                        height="24"
+                        viewBox="0 0 24 24"
+                      >
+                        <use href="#icon-1024-path"></use>
+                        <use href="#icon-1024-text"></use></svg
+                      ><span>audience?</span></a
+                    >
+                    <a
+                      href="AuthorizationParams.html#connection"
+                      class="tsd-index-link tsd-kind-property tsd-parent-kind-interface tsd-is-external"
+                      ><svg
+                        class="tsd-kind-icon"
+                        width="24"
+                        height="24"
+                        viewBox="0 0 24 24"
+                      >
+                        <use href="#icon-1024-path"></use>
+                        <use href="#icon-1024-text"></use></svg
+                      ><span>connection?</span></a
+                    >
+                    <a
+                      href="AuthorizationParams.html#display"
+                      class="tsd-index-link tsd-kind-property tsd-parent-kind-interface tsd-is-external"
+                      ><svg
+                        class="tsd-kind-icon"
+                        width="24"
+                        height="24"
+                        viewBox="0 0 24 24"
+                      >
+                        <use href="#icon-1024-path"></use>
+                        <use href="#icon-1024-text"></use></svg
+                      ><span>display?</span></a
+                    >
+                    <a
+                      href="AuthorizationParams.html#id_token_hint"
+                      class="tsd-index-link tsd-kind-property tsd-parent-kind-interface tsd-is-external"
+                      ><svg
+                        class="tsd-kind-icon"
+                        width="24"
+                        height="24"
+                        viewBox="0 0 24 24"
+                      >
+                        <use href="#icon-1024-path"></use>
+                        <use href="#icon-1024-text"></use></svg
+                      ><span>id_<wbr />token_<wbr />hint?</span></a
+                    >
+                    <a
+                      href="AuthorizationParams.html#invitation"
+                      class="tsd-index-link tsd-kind-property tsd-parent-kind-interface tsd-is-external"
+                      ><svg
+                        class="tsd-kind-icon"
+                        width="24"
+                        height="24"
+                        viewBox="0 0 24 24"
+                      >
+                        <use href="#icon-1024-path"></use>
+                        <use href="#icon-1024-text"></use></svg
+                      ><span>invitation?</span></a
+                    >
+                    <a
+                      href="AuthorizationParams.html#login_hint"
+                      class="tsd-index-link tsd-kind-property tsd-parent-kind-interface tsd-is-external"
+                      ><svg
+                        class="tsd-kind-icon"
+                        width="24"
+                        height="24"
+                        viewBox="0 0 24 24"
+                      >
+                        <use href="#icon-1024-path"></use>
+                        <use href="#icon-1024-text"></use></svg
+                      ><span>login_<wbr />hint?</span></a
+                    >
+                    <a
+                      href="AuthorizationParams.html#max_age"
+                      class="tsd-index-link tsd-kind-property tsd-parent-kind-interface tsd-is-external"
+                      ><svg
+                        class="tsd-kind-icon"
+                        width="24"
+                        height="24"
+                        viewBox="0 0 24 24"
+                      >
+                        <use href="#icon-1024-path"></use>
+                        <use href="#icon-1024-text"></use></svg
+                      ><span>max_<wbr />age?</span></a
+                    >
+                    <a
+                      href="AuthorizationParams.html#organization"
+                      class="tsd-index-link tsd-kind-property tsd-parent-kind-interface tsd-is-external"
+                      ><svg
+                        class="tsd-kind-icon"
+                        width="24"
+                        height="24"
+                        viewBox="0 0 24 24"
+                      >
+                        <use href="#icon-1024-path"></use>
+                        <use href="#icon-1024-text"></use></svg
+                      ><span>organization?</span></a
+                    >
+                    <a
+                      href="AuthorizationParams.html#prompt"
+                      class="tsd-index-link tsd-kind-property tsd-parent-kind-interface tsd-is-external"
+                      ><svg
+                        class="tsd-kind-icon"
+                        width="24"
+                        height="24"
+                        viewBox="0 0 24 24"
+                      >
+                        <use href="#icon-1024-path"></use>
+                        <use href="#icon-1024-text"></use></svg
+                      ><span>prompt?</span></a
+                    >
+                    <a
+                      href="AuthorizationParams.html#redirect_uri"
+                      class="tsd-index-link tsd-kind-property tsd-parent-kind-interface tsd-is-external"
+                      ><svg
+                        class="tsd-kind-icon"
+                        width="24"
+                        height="24"
+                        viewBox="0 0 24 24"
+                      >
+                        <use href="#icon-1024-path"></use>
+                        <use href="#icon-1024-text"></use></svg
+                      ><span>redirect_<wbr />uri?</span></a
+                    >
+                    <a
+                      href="AuthorizationParams.html#scope"
+                      class="tsd-index-link tsd-kind-property tsd-parent-kind-interface tsd-is-external"
+                      ><svg
+                        class="tsd-kind-icon"
+                        width="24"
+                        height="24"
+                        viewBox="0 0 24 24"
+                      >
+                        <use href="#icon-1024-path"></use>
+                        <use href="#icon-1024-text"></use></svg
+                      ><span>scope?</span></a
+                    >
+                    <a
+                      href="AuthorizationParams.html#screen_hint"
+                      class="tsd-index-link tsd-kind-property tsd-parent-kind-interface tsd-is-external"
+                      ><svg
+                        class="tsd-kind-icon"
+                        width="24"
+                        height="24"
+                        viewBox="0 0 24 24"
+                      >
+                        <use href="#icon-1024-path"></use>
+                        <use href="#icon-1024-text"></use></svg
+                      ><span>screen_<wbr />hint?</span></a
+                    >
+                    <a
+                      href="AuthorizationParams.html#ui_locales"
+                      class="tsd-index-link tsd-kind-property tsd-parent-kind-interface tsd-is-external"
+                      ><svg
+                        class="tsd-kind-icon"
+                        width="24"
+                        height="24"
+                        viewBox="0 0 24 24"
+                      >
+                        <use href="#icon-1024-path"></use>
+                        <use href="#icon-1024-text"></use></svg
+                      ><span>ui_<wbr />locales?</span></a
+                    >
+                  </div>
+                </section>
+              </div>
+            </details>
+          </section>
+        </section>
+        <section class="tsd-panel-group tsd-member-group">
+          <h2>Properties</h2>
+          <section
+            class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-interface tsd-is-external"
+          >
+            <a id="acr_values" class="tsd-anchor"></a>
+            <h3 class="tsd-anchor-link">
+              <code class="tsd-tag ts-flagOptional">Optional</code>
+              <span>acr_<wbr />values</span
+              ><a
+                href="#acr_values"
+                aria-label="Permalink"
+                class="tsd-anchor-icon"
+                ><svg
+                  class="icon icon-tabler icon-tabler-link"
+                  viewBox="0 0 24 24"
+                  stroke-width="2"
+                  stroke="currentColor"
+                  fill="none"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                >
+                  <path
+                    stroke="none"
+                    d="M0 0h24v24H0z"
+                    fill="none"
+                    id="icon-anchor-a"
+                  ></path>
+                  <path
+                    d="M10 14a3.5 3.5 0 0 0 5 0l4 -4a3.5 3.5 0 0 0 -5 -5l-.5 .5"
+                    id="icon-anchor-b"
+                  ></path>
+                  <path
+                    d="M14 10a3.5 3.5 0 0 0 -5 0l-4 4a3.5 3.5 0 0 0 5 5l.5 -.5"
+                    id="icon-anchor-c"
+                  ></path></svg
+              ></a>
+            </h3>
+            <div class="tsd-signature">
+              acr_<wbr />values<span class="tsd-signature-symbol">?:</span>
+              <span class="tsd-signature-type">string</span>
+            </div>
+            <aside class="tsd-sources">
+              <ul>
+                <li>
+                  Defined in
+                  node_modules/@auth0/auth0-spa-js/dist/typings/global.d.ts:48
+                </li>
+              </ul>
+            </aside>
+          </section>
+          <section
+            class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-interface tsd-is-external"
+          >
+            <a id="audience" class="tsd-anchor"></a>
+            <h3 class="tsd-anchor-link">
+              <code class="tsd-tag ts-flagOptional">Optional</code>
+              <span>audience</span
+              ><a
+                href="#audience"
+                aria-label="Permalink"
+                class="tsd-anchor-icon"
+                ><svg
+                  class="icon icon-tabler icon-tabler-link"
+                  viewBox="0 0 24 24"
+                  stroke-width="2"
+                  stroke="currentColor"
+                  fill="none"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                >
+                  <use href="#icon-anchor-a"></use>
+                  <use href="#icon-anchor-b"></use>
+                  <use href="#icon-anchor-c"></use></svg
+              ></a>
+            </h3>
+            <div class="tsd-signature">
+              audience<span class="tsd-signature-symbol">?:</span>
+              <span class="tsd-signature-type">string</span>
+            </div>
+            <div class="tsd-comment tsd-typography">
+              <p>The default audience to be used for requesting API access.</p>
+            </div>
+            <aside class="tsd-sources">
+              <ul>
+                <li>
+                  Defined in
+                  node_modules/@auth0/auth0-spa-js/dist/typings/global.d.ts:61
+                </li>
+              </ul>
+            </aside>
+          </section>
+          <section
+            class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-interface tsd-is-external"
+          >
+            <a id="connection" class="tsd-anchor"></a>
+            <h3 class="tsd-anchor-link">
+              <code class="tsd-tag ts-flagOptional">Optional</code>
+              <span>connection</span
+              ><a
+                href="#connection"
+                aria-label="Permalink"
+                class="tsd-anchor-icon"
+                ><svg
+                  class="icon icon-tabler icon-tabler-link"
+                  viewBox="0 0 24 24"
+                  stroke-width="2"
+                  stroke="currentColor"
+                  fill="none"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                >
+                  <use href="#icon-anchor-a"></use>
+                  <use href="#icon-anchor-b"></use>
+                  <use href="#icon-anchor-c"></use></svg
+              ></a>
+            </h3>
+            <div class="tsd-signature">
+              connection<span class="tsd-signature-symbol">?:</span>
+              <span class="tsd-signature-type">string</span>
+            </div>
+            <div class="tsd-comment tsd-typography">
+              <p>
+                The name of the connection configured for your application. If
+                null, it will redirect to the Auth0 Login Page and show the
+                Login Widget.
+              </p>
+            </div>
+            <aside class="tsd-sources">
+              <ul>
+                <li>
+                  Defined in
+                  node_modules/@auth0/auth0-spa-js/dist/typings/global.d.ts:67
+                </li>
+              </ul>
+            </aside>
+          </section>
+          <section
+            class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-interface tsd-is-external"
+          >
+            <a id="display" class="tsd-anchor"></a>
+            <h3 class="tsd-anchor-link">
+              <code class="tsd-tag ts-flagOptional">Optional</code>
+              <span>display</span
+              ><a href="#display" aria-label="Permalink" class="tsd-anchor-icon"
+                ><svg
+                  class="icon icon-tabler icon-tabler-link"
+                  viewBox="0 0 24 24"
+                  stroke-width="2"
+                  stroke="currentColor"
+                  fill="none"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                >
+                  <use href="#icon-anchor-a"></use>
+                  <use href="#icon-anchor-b"></use>
+                  <use href="#icon-anchor-c"></use></svg
+              ></a>
+            </h3>
+            <div class="tsd-signature">
+              display<span class="tsd-signature-symbol">?:</span>
+              <span class="tsd-signature-type">&quot;page&quot;</span
+              ><span class="tsd-signature-symbol"> | </span
+              ><span class="tsd-signature-type">&quot;popup&quot;</span
+              ><span class="tsd-signature-symbol"> | </span
+              ><span class="tsd-signature-type">&quot;touch&quot;</span
+              ><span class="tsd-signature-symbol"> | </span
+              ><span class="tsd-signature-type">&quot;wap&quot;</span>
+            </div>
+            <div class="tsd-comment tsd-typography">
+              <ul>
+                <li>
+                  <code>&#39;page&#39;</code>: displays the UI with a full page
+                  view
+                </li>
+                <li>
+                  <code>&#39;popup&#39;</code>: displays the UI with a popup
+                  window
+                </li>
+                <li>
+                  <code>&#39;touch&#39;</code>: displays the UI in a way that
+                  leverages a touch interface
+                </li>
+                <li>
+                  <code>&#39;wap&#39;</code>: displays the UI with a
+                  &quot;feature phone&quot; type interface
+                </li>
+              </ul>
+            </div>
+            <aside class="tsd-sources">
+              <ul>
+                <li>
+                  Defined in
+                  node_modules/@auth0/auth0-spa-js/dist/typings/global.d.ts:9
+                </li>
+              </ul>
+            </aside>
+          </section>
+          <section
+            class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-interface tsd-is-external"
+          >
+            <a id="id_token_hint" class="tsd-anchor"></a>
+            <h3 class="tsd-anchor-link">
+              <code class="tsd-tag ts-flagOptional">Optional</code>
+              <span>id_<wbr />token_<wbr />hint</span
+              ><a
+                href="#id_token_hint"
+                aria-label="Permalink"
+                class="tsd-anchor-icon"
+                ><svg
+                  class="icon icon-tabler icon-tabler-link"
+                  viewBox="0 0 24 24"
+                  stroke-width="2"
+                  stroke="currentColor"
+                  fill="none"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                >
+                  <use href="#icon-anchor-a"></use>
+                  <use href="#icon-anchor-b"></use>
+                  <use href="#icon-anchor-c"></use></svg
+              ></a>
+            </h3>
+            <div class="tsd-signature">
+              id_<wbr />token_<wbr />hint<span class="tsd-signature-symbol"
+                >?:</span
+              >
+              <span class="tsd-signature-type">string</span>
+            </div>
+            <div class="tsd-comment tsd-typography">
+              <p>Previously issued ID Token.</p>
+            </div>
+            <aside class="tsd-sources">
+              <ul>
+                <li>
+                  Defined in
+                  node_modules/@auth0/auth0-spa-js/dist/typings/global.d.ts:31
+                </li>
+              </ul>
+            </aside>
+          </section>
+          <section
+            class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-interface tsd-is-external"
+          >
+            <a id="invitation" class="tsd-anchor"></a>
+            <h3 class="tsd-anchor-link">
+              <code class="tsd-tag ts-flagOptional">Optional</code>
+              <span>invitation</span
+              ><a
+                href="#invitation"
+                aria-label="Permalink"
+                class="tsd-anchor-icon"
+                ><svg
+                  class="icon icon-tabler icon-tabler-link"
+                  viewBox="0 0 24 24"
+                  stroke-width="2"
+                  stroke="currentColor"
+                  fill="none"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                >
+                  <use href="#icon-anchor-a"></use>
+                  <use href="#icon-anchor-b"></use>
+                  <use href="#icon-anchor-c"></use></svg
+              ></a>
+            </h3>
+            <div class="tsd-signature">
+              invitation<span class="tsd-signature-symbol">?:</span>
+              <span class="tsd-signature-type">string</span>
+            </div>
+            <div class="tsd-comment tsd-typography">
+              <p>
+                The Id of an invitation to accept. This is available from the
+                user invitation URL that is given when participating in a user
+                invitation flow.
+              </p>
+            </div>
+            <aside class="tsd-sources">
+              <ul>
+                <li>
+                  Defined in
+                  node_modules/@auth0/auth0-spa-js/dist/typings/global.d.ts:78
+                </li>
+              </ul>
+            </aside>
+          </section>
+          <section
+            class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-interface tsd-is-external"
+          >
+            <a id="login_hint" class="tsd-anchor"></a>
+            <h3 class="tsd-anchor-link">
+              <code class="tsd-tag ts-flagOptional">Optional</code>
+              <span>login_<wbr />hint</span
+              ><a
+                href="#login_hint"
+                aria-label="Permalink"
+                class="tsd-anchor-icon"
+                ><svg
+                  class="icon icon-tabler icon-tabler-link"
+                  viewBox="0 0 24 24"
+                  stroke-width="2"
+                  stroke="currentColor"
+                  fill="none"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                >
+                  <use href="#icon-anchor-a"></use>
+                  <use href="#icon-anchor-b"></use>
+                  <use href="#icon-anchor-c"></use></svg
+              ></a>
+            </h3>
+            <div class="tsd-signature">
+              login_<wbr />hint<span class="tsd-signature-symbol">?:</span>
+              <span class="tsd-signature-type">string</span>
+            </div>
+            <div class="tsd-comment tsd-typography">
+              <p>
+                The user&#39;s email address or other identifier. When your app
+                knows which user is trying to authenticate, you can provide this
+                parameter to pre-fill the email box or select the right session
+                for sign-in.
+              </p>
+              <p>This currently only affects the classic Lock experience.</p>
+            </div>
+            <aside class="tsd-sources">
+              <ul>
+                <li>
+                  Defined in
+                  node_modules/@auth0/auth0-spa-js/dist/typings/global.d.ts:47
+                </li>
+              </ul>
+            </aside>
+          </section>
+          <section
+            class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-interface tsd-is-external"
+          >
+            <a id="max_age" class="tsd-anchor"></a>
+            <h3 class="tsd-anchor-link">
+              <code class="tsd-tag ts-flagOptional">Optional</code>
+              <span>max_<wbr />age</span
+              ><a href="#max_age" aria-label="Permalink" class="tsd-anchor-icon"
+                ><svg
+                  class="icon icon-tabler icon-tabler-link"
+                  viewBox="0 0 24 24"
+                  stroke-width="2"
+                  stroke="currentColor"
+                  fill="none"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                >
+                  <use href="#icon-anchor-a"></use>
+                  <use href="#icon-anchor-b"></use>
+                  <use href="#icon-anchor-c"></use></svg
+              ></a>
+            </h3>
+            <div class="tsd-signature">
+              max_<wbr />age<span class="tsd-signature-symbol">?:</span>
+              <span class="tsd-signature-type">string</span
+              ><span class="tsd-signature-symbol"> | </span
+              ><span class="tsd-signature-type">number</span>
+            </div>
+            <div class="tsd-comment tsd-typography">
+              <p>
+                Maximum allowable elapsed time (in seconds) since
+                authentication. If the last time the user authenticated is
+                greater than this value, the user must be reauthenticated.
+              </p>
+            </div>
+            <aside class="tsd-sources">
+              <ul>
+                <li>
+                  Defined in
+                  node_modules/@auth0/auth0-spa-js/dist/typings/global.d.ts:22
+                </li>
+              </ul>
+            </aside>
+          </section>
+          <section
+            class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-interface tsd-is-external"
+          >
+            <a id="organization" class="tsd-anchor"></a>
+            <h3 class="tsd-anchor-link">
+              <code class="tsd-tag ts-flagOptional">Optional</code>
+              <span>organization</span
+              ><a
+                href="#organization"
+                aria-label="Permalink"
+                class="tsd-anchor-icon"
+                ><svg
+                  class="icon icon-tabler icon-tabler-link"
+                  viewBox="0 0 24 24"
+                  stroke-width="2"
+                  stroke="currentColor"
+                  fill="none"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                >
+                  <use href="#icon-anchor-a"></use>
+                  <use href="#icon-anchor-b"></use>
+                  <use href="#icon-anchor-c"></use></svg
+              ></a>
+            </h3>
+            <div class="tsd-signature">
+              organization<span class="tsd-signature-symbol">?:</span>
+              <span class="tsd-signature-type">string</span>
+            </div>
+            <div class="tsd-comment tsd-typography">
+              <p>The Id of an organization to log in to.</p>
+              <p>
+                This will specify an <code>organization</code> parameter in your
+                user&#39;s login request and will add a step to validate the
+                <code>org_id</code> claim in your user&#39;s ID Token.
+              </p>
+            </div>
+            <aside class="tsd-sources">
+              <ul>
+                <li>
+                  Defined in
+                  node_modules/@auth0/auth0-spa-js/dist/typings/global.d.ts:74
+                </li>
+              </ul>
+            </aside>
+          </section>
+          <section
+            class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-interface tsd-is-external"
+          >
+            <a id="prompt" class="tsd-anchor"></a>
+            <h3 class="tsd-anchor-link">
+              <code class="tsd-tag ts-flagOptional">Optional</code>
+              <span>prompt</span
+              ><a href="#prompt" aria-label="Permalink" class="tsd-anchor-icon"
+                ><svg
+                  class="icon icon-tabler icon-tabler-link"
+                  viewBox="0 0 24 24"
+                  stroke-width="2"
+                  stroke="currentColor"
+                  fill="none"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                >
+                  <use href="#icon-anchor-a"></use>
+                  <use href="#icon-anchor-b"></use>
+                  <use href="#icon-anchor-c"></use></svg
+              ></a>
+            </h3>
+            <div class="tsd-signature">
+              prompt<span class="tsd-signature-symbol">?:</span>
+              <span class="tsd-signature-type">&quot;none&quot;</span
+              ><span class="tsd-signature-symbol"> | </span
+              ><span class="tsd-signature-type">&quot;login&quot;</span
+              ><span class="tsd-signature-symbol"> | </span
+              ><span class="tsd-signature-type">&quot;consent&quot;</span
+              ><span class="tsd-signature-symbol"> | </span
+              ><span class="tsd-signature-type"
+                >&quot;select_account&quot;</span
+              >
+            </div>
+            <div class="tsd-comment tsd-typography">
+              <ul>
+                <li>
+                  <code>&#39;none&#39;</code>: do not prompt user for login or
+                  consent on reauthentication
+                </li>
+                <li>
+                  <code>&#39;login&#39;</code>: prompt user for reauthentication
+                </li>
+                <li>
+                  <code>&#39;consent&#39;</code>: prompt user for consent before
+                  processing request
+                </li>
+                <li>
+                  <code>&#39;select_account&#39;</code>: prompt user to select
+                  an account
+                </li>
+              </ul>
+            </div>
+            <aside class="tsd-sources">
+              <ul>
+                <li>
+                  Defined in
+                  node_modules/@auth0/auth0-spa-js/dist/typings/global.d.ts:16
+                </li>
+              </ul>
+            </aside>
+          </section>
+          <section
+            class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-interface tsd-is-external"
+          >
+            <a id="redirect_uri" class="tsd-anchor"></a>
+            <h3 class="tsd-anchor-link">
+              <code class="tsd-tag ts-flagOptional">Optional</code>
+              <span>redirect_<wbr />uri</span
+              ><a
+                href="#redirect_uri"
+                aria-label="Permalink"
+                class="tsd-anchor-icon"
+                ><svg
+                  class="icon icon-tabler icon-tabler-link"
+                  viewBox="0 0 24 24"
+                  stroke-width="2"
+                  stroke="currentColor"
+                  fill="none"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                >
+                  <use href="#icon-anchor-a"></use>
+                  <use href="#icon-anchor-b"></use>
+                  <use href="#icon-anchor-c"></use></svg
+              ></a>
+            </h3>
+            <div class="tsd-signature">
+              redirect_<wbr />uri<span class="tsd-signature-symbol">?:</span>
+              <span class="tsd-signature-type">string</span>
+            </div>
+            <div class="tsd-comment tsd-typography">
+              <p>
+                The default URL where Auth0 will redirect your browser to with
+                the authentication result. It must be whitelisted in the
+                &quot;Allowed Callback URLs&quot; field in your Auth0
+                Application&#39;s settings. If not provided here, it should be
+                provided in the other methods that provide authentication.
+              </p>
+            </div>
+            <aside class="tsd-sources">
+              <ul>
+                <li>
+                  Defined in
+                  node_modules/@auth0/auth0-spa-js/dist/typings/global.d.ts:86
+                </li>
+              </ul>
+            </aside>
+          </section>
+          <section
+            class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-interface tsd-is-external"
+          >
+            <a id="scope" class="tsd-anchor"></a>
+            <h3 class="tsd-anchor-link">
+              <code class="tsd-tag ts-flagOptional">Optional</code>
+              <span>scope</span
+              ><a href="#scope" aria-label="Permalink" class="tsd-anchor-icon"
+                ><svg
+                  class="icon icon-tabler icon-tabler-link"
+                  viewBox="0 0 24 24"
+                  stroke-width="2"
+                  stroke="currentColor"
+                  fill="none"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                >
+                  <use href="#icon-anchor-a"></use>
+                  <use href="#icon-anchor-b"></use>
+                  <use href="#icon-anchor-c"></use></svg
+              ></a>
+            </h3>
+            <div class="tsd-signature">
+              scope<span class="tsd-signature-symbol">?:</span>
+              <span class="tsd-signature-type">string</span>
+            </div>
+            <div class="tsd-comment tsd-typography">
+              <p>The default scope to be used on authentication requests.</p>
+              <p>
+                This defaults to <code>profile email</code> if not set. If you
+                are setting extra scopes and require <code>profile</code> and
+                <code>email</code> to be included then you must include them in
+                the provided scope.
+              </p>
+              <p>
+                Note: The <code>openid</code> scope is
+                <strong>always applied</strong> regardless of this setting.
+              </p>
+            </div>
+            <aside class="tsd-sources">
+              <ul>
+                <li>
+                  Defined in
+                  node_modules/@auth0/auth0-spa-js/dist/typings/global.d.ts:57
+                </li>
+              </ul>
+            </aside>
+          </section>
+          <section
+            class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-interface tsd-is-external"
+          >
+            <a id="screen_hint" class="tsd-anchor"></a>
+            <h3 class="tsd-anchor-link">
+              <code class="tsd-tag ts-flagOptional">Optional</code>
+              <span>screen_<wbr />hint</span
+              ><a
+                href="#screen_hint"
+                aria-label="Permalink"
+                class="tsd-anchor-icon"
+                ><svg
+                  class="icon icon-tabler icon-tabler-link"
+                  viewBox="0 0 24 24"
+                  stroke-width="2"
+                  stroke="currentColor"
+                  fill="none"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                >
+                  <use href="#icon-anchor-a"></use>
+                  <use href="#icon-anchor-b"></use>
+                  <use href="#icon-anchor-c"></use></svg
+              ></a>
+            </h3>
+            <div class="tsd-signature">
+              screen_<wbr />hint<span class="tsd-signature-symbol">?:</span>
+              <span class="tsd-signature-type">string</span>
+            </div>
+            <div class="tsd-comment tsd-typography">
+              <p>
+                Provides a hint to Auth0 as to what flow should be displayed.
+                The default behavior is to show a login page but you can
+                override this by passing &#39;signup&#39; to show the signup
+                page instead.
+              </p>
+              <p>This only affects the New Universal Login Experience.</p>
+            </div>
+            <aside class="tsd-sources">
+              <ul>
+                <li>
+                  Defined in
+                  node_modules/@auth0/auth0-spa-js/dist/typings/global.d.ts:39
+                </li>
+              </ul>
+            </aside>
+          </section>
+          <section
+            class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-interface tsd-is-external"
+          >
+            <a id="ui_locales" class="tsd-anchor"></a>
+            <h3 class="tsd-anchor-link">
+              <code class="tsd-tag ts-flagOptional">Optional</code>
+              <span>ui_<wbr />locales</span
+              ><a
+                href="#ui_locales"
+                aria-label="Permalink"
+                class="tsd-anchor-icon"
+                ><svg
+                  class="icon icon-tabler icon-tabler-link"
+                  viewBox="0 0 24 24"
+                  stroke-width="2"
+                  stroke="currentColor"
+                  fill="none"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                >
+                  <use href="#icon-anchor-a"></use>
+                  <use href="#icon-anchor-b"></use>
+                  <use href="#icon-anchor-c"></use></svg
+              ></a>
+            </h3>
+            <div class="tsd-signature">
+              ui_<wbr />locales<span class="tsd-signature-symbol">?:</span>
+              <span class="tsd-signature-type">string</span>
+            </div>
+            <div class="tsd-comment tsd-typography">
+              <p>
+                The space-separated list of language tags, ordered by
+                preference. For example: <code>&#39;fr-CA fr en&#39;</code>.
+              </p>
+            </div>
+            <aside class="tsd-sources">
+              <ul>
+                <li>
+                  Defined in
+                  node_modules/@auth0/auth0-spa-js/dist/typings/global.d.ts:27
+                </li>
+              </ul>
+            </aside>
+          </section>
+        </section>
+      </div>
+      <div class="col-4 col-menu menu-sticky-wrap menu-highlight">
+        <div class="tsd-navigation settings">
+          <details class="tsd-index-accordion">
+            <summary class="tsd-accordion-summary">
+              <h3>
+                <svg width="20" height="20" viewBox="0 0 24 24" fill="none">
+                  <path
+                    d="M4.93896 8.531L12 15.591L19.061 8.531L16.939 6.409L12 11.349L7.06098 6.409L4.93896 8.531Z"
+                    fill="var(--color-text)"
+                  ></path>
+                </svg>
+                Settings
+              </h3>
+            </summary>
+            <div class="tsd-accordion-details">
+              <div class="tsd-filter-visibility">
+                <h4 class="uppercase">Member Visibility</h4>
+                <form>
+                  <ul id="tsd-filter-options">
+                    <li class="tsd-filter-item">
+                      <label class="tsd-filter-input"
+                        ><input
+                          type="checkbox"
+                          id="tsd-filter-protected"
+                          name="protected"
+                        /><svg
+                          width="32"
+                          height="32"
+                          viewBox="0 0 32 32"
+                          aria-hidden="true"
+                        >
+                          <rect
+                            class="tsd-checkbox-background"
+                            width="30"
+                            height="30"
+                            x="1"
+                            y="1"
+                            rx="6"
+                            fill="none"
+                          ></rect>
+                          <path
+                            class="tsd-checkbox-checkmark"
+                            d="M8.35422 16.8214L13.2143 21.75L24.6458 10.25"
+                            stroke="none"
+                            stroke-width="3.5"
+                            stroke-linejoin="round"
+                            fill="none"
+                          ></path></svg
+                        ><span>Protected</span></label
+                      >
+                    </li>
+                    <li class="tsd-filter-item">
+                      <label class="tsd-filter-input"
+                        ><input
+                          type="checkbox"
+                          id="tsd-filter-inherited"
+                          name="inherited"
+                          checked
+                        /><svg
+                          width="32"
+                          height="32"
+                          viewBox="0 0 32 32"
+                          aria-hidden="true"
+                        >
+                          <rect
+                            class="tsd-checkbox-background"
+                            width="30"
+                            height="30"
+                            x="1"
+                            y="1"
+                            rx="6"
+                            fill="none"
+                          ></rect>
+                          <path
+                            class="tsd-checkbox-checkmark"
+                            d="M8.35422 16.8214L13.2143 21.75L24.6458 10.25"
+                            stroke="none"
+                            stroke-width="3.5"
+                            stroke-linejoin="round"
+                            fill="none"
+                          ></path></svg
+                        ><span>Inherited</span></label
+                      >
+                    </li>
+                    <li class="tsd-filter-item">
+                      <label class="tsd-filter-input"
+                        ><input
+                          type="checkbox"
+                          id="tsd-filter-external"
+                          name="external"
+                          checked
+                        /><svg
+                          width="32"
+                          height="32"
+                          viewBox="0 0 32 32"
+                          aria-hidden="true"
+                        >
+                          <rect
+                            class="tsd-checkbox-background"
+                            width="30"
+                            height="30"
+                            x="1"
+                            y="1"
+                            rx="6"
+                            fill="none"
+                          ></rect>
+                          <path
+                            class="tsd-checkbox-checkmark"
+                            d="M8.35422 16.8214L13.2143 21.75L24.6458 10.25"
+                            stroke="none"
+                            stroke-width="3.5"
+                            stroke-linejoin="round"
+                            fill="none"
+                          ></path></svg
+                        ><span>External</span></label
+                      >
+                    </li>
+                  </ul>
+                </form>
+              </div>
+              <div class="tsd-theme-toggle">
+                <h4 class="uppercase">Theme</h4>
+                <select id="theme">
+                  <option value="os">OS</option>
+                  <option value="light">Light</option>
+                  <option value="dark">Dark</option>
+                </select>
+              </div>
+            </div>
+          </details>
+        </div>
+        <nav class="tsd-navigation primary">
+          <details class="tsd-index-accordion" open>
+            <summary class="tsd-accordion-summary">
+              <h3>
+                <svg width="20" height="20" viewBox="0 0 24 24" fill="none">
+                  <path
+                    d="M4.93896 8.531L12 15.591L19.061 8.531L16.939 6.409L12 11.349L7.06098 6.409L4.93896 8.531Z"
+                    fill="var(--color-text)"
+                  ></path>
+                </svg>
+                Modules
+              </h3>
+            </summary>
+            <div class="tsd-accordion-details">
+              <ul>
+                <li>
+                  <a href="../modules.html">@auth0/auth0-<wbr />angular</a>
+                  <ul></ul>
+                </li>
+              </ul>
+            </div>
+          </details>
+        </nav>
+        <nav class="tsd-navigation secondary menu-sticky">
+          <ul>
+            <li class="current tsd-kind-interface tsd-is-external">
+              <a href="AuthorizationParams.html" class="tsd-index-link"
+                ><svg
+                  class="tsd-kind-icon"
+                  width="24"
+                  height="24"
+                  viewBox="0 0 24 24"
+                >
+                  <rect
+                    fill="var(--color-icon-background)"
+                    stroke="var(--color-ts-interface)"
+                    stroke-width="1.5"
+                    x="1"
+                    y="1"
+                    width="22"
+                    height="22"
+                    rx="6"
+                    id="icon-256-path"
+                  ></rect>
+                  <path
+                    d="M9.51 16V15.016H11.298V8.224H9.51V7.24H14.19V8.224H12.402V15.016H14.19V16H9.51Z"
+                    fill="var(--color-text)"
+                    id="icon-256-text"
+                  ></path></svg
+                ><span>Authorization<wbr />Params</span></a
+              >
+              <ul>
+                <li
+                  class="tsd-kind-property tsd-parent-kind-interface tsd-is-external"
+                >
+                  <a
+                    href="AuthorizationParams.html#acr_values"
+                    class="tsd-index-link"
+                    ><svg
+                      class="tsd-kind-icon"
+                      width="24"
+                      height="24"
+                      viewBox="0 0 24 24"
+                    >
+                      <use href="#icon-1024-path"></use>
+                      <use href="#icon-1024-text"></use></svg
+                    >acr_<wbr />values?</a
+                  >
+                </li>
+                <li
+                  class="tsd-kind-property tsd-parent-kind-interface tsd-is-external"
+                >
+                  <a
+                    href="AuthorizationParams.html#audience"
+                    class="tsd-index-link"
+                    ><svg
+                      class="tsd-kind-icon"
+                      width="24"
+                      height="24"
+                      viewBox="0 0 24 24"
+                    >
+                      <use href="#icon-1024-path"></use>
+                      <use href="#icon-1024-text"></use></svg
+                    >audience?</a
+                  >
+                </li>
+                <li
+                  class="tsd-kind-property tsd-parent-kind-interface tsd-is-external"
+                >
+                  <a
+                    href="AuthorizationParams.html#connection"
+                    class="tsd-index-link"
+                    ><svg
+                      class="tsd-kind-icon"
+                      width="24"
+                      height="24"
+                      viewBox="0 0 24 24"
+                    >
+                      <use href="#icon-1024-path"></use>
+                      <use href="#icon-1024-text"></use></svg
+                    >connection?</a
+                  >
+                </li>
+                <li
+                  class="tsd-kind-property tsd-parent-kind-interface tsd-is-external"
+                >
+                  <a
+                    href="AuthorizationParams.html#display"
+                    class="tsd-index-link"
+                    ><svg
+                      class="tsd-kind-icon"
+                      width="24"
+                      height="24"
+                      viewBox="0 0 24 24"
+                    >
+                      <use href="#icon-1024-path"></use>
+                      <use href="#icon-1024-text"></use></svg
+                    >display?</a
+                  >
+                </li>
+                <li
+                  class="tsd-kind-property tsd-parent-kind-interface tsd-is-external"
+                >
+                  <a
+                    href="AuthorizationParams.html#id_token_hint"
+                    class="tsd-index-link"
+                    ><svg
+                      class="tsd-kind-icon"
+                      width="24"
+                      height="24"
+                      viewBox="0 0 24 24"
+                    >
+                      <use href="#icon-1024-path"></use>
+                      <use href="#icon-1024-text"></use></svg
+                    >id_<wbr />token_<wbr />hint?</a
+                  >
+                </li>
+                <li
+                  class="tsd-kind-property tsd-parent-kind-interface tsd-is-external"
+                >
+                  <a
+                    href="AuthorizationParams.html#invitation"
+                    class="tsd-index-link"
+                    ><svg
+                      class="tsd-kind-icon"
+                      width="24"
+                      height="24"
+                      viewBox="0 0 24 24"
+                    >
+                      <use href="#icon-1024-path"></use>
+                      <use href="#icon-1024-text"></use></svg
+                    >invitation?</a
+                  >
+                </li>
+                <li
+                  class="tsd-kind-property tsd-parent-kind-interface tsd-is-external"
+                >
+                  <a
+                    href="AuthorizationParams.html#login_hint"
+                    class="tsd-index-link"
+                    ><svg
+                      class="tsd-kind-icon"
+                      width="24"
+                      height="24"
+                      viewBox="0 0 24 24"
+                    >
+                      <use href="#icon-1024-path"></use>
+                      <use href="#icon-1024-text"></use></svg
+                    >login_<wbr />hint?</a
+                  >
+                </li>
+                <li
+                  class="tsd-kind-property tsd-parent-kind-interface tsd-is-external"
+                >
+                  <a
+                    href="AuthorizationParams.html#max_age"
+                    class="tsd-index-link"
+                    ><svg
+                      class="tsd-kind-icon"
+                      width="24"
+                      height="24"
+                      viewBox="0 0 24 24"
+                    >
+                      <use href="#icon-1024-path"></use>
+                      <use href="#icon-1024-text"></use></svg
+                    >max_<wbr />age?</a
+                  >
+                </li>
+                <li
+                  class="tsd-kind-property tsd-parent-kind-interface tsd-is-external"
+                >
+                  <a
+                    href="AuthorizationParams.html#organization"
+                    class="tsd-index-link"
+                    ><svg
+                      class="tsd-kind-icon"
+                      width="24"
+                      height="24"
+                      viewBox="0 0 24 24"
+                    >
+                      <use href="#icon-1024-path"></use>
+                      <use href="#icon-1024-text"></use></svg
+                    >organization?</a
+                  >
+                </li>
+                <li
+                  class="tsd-kind-property tsd-parent-kind-interface tsd-is-external"
+                >
+                  <a
+                    href="AuthorizationParams.html#prompt"
+                    class="tsd-index-link"
+                    ><svg
+                      class="tsd-kind-icon"
+                      width="24"
+                      height="24"
+                      viewBox="0 0 24 24"
+                    >
+                      <use href="#icon-1024-path"></use>
+                      <use href="#icon-1024-text"></use></svg
+                    >prompt?</a
+                  >
+                </li>
+                <li
+                  class="tsd-kind-property tsd-parent-kind-interface tsd-is-external"
+                >
+                  <a
+                    href="AuthorizationParams.html#redirect_uri"
+                    class="tsd-index-link"
+                    ><svg
+                      class="tsd-kind-icon"
+                      width="24"
+                      height="24"
+                      viewBox="0 0 24 24"
+                    >
+                      <use href="#icon-1024-path"></use>
+                      <use href="#icon-1024-text"></use></svg
+                    >redirect_<wbr />uri?</a
+                  >
+                </li>
+                <li
+                  class="tsd-kind-property tsd-parent-kind-interface tsd-is-external"
+                >
+                  <a
+                    href="AuthorizationParams.html#scope"
+                    class="tsd-index-link"
+                    ><svg
+                      class="tsd-kind-icon"
+                      width="24"
+                      height="24"
+                      viewBox="0 0 24 24"
+                    >
+                      <use href="#icon-1024-path"></use>
+                      <use href="#icon-1024-text"></use></svg
+                    >scope?</a
+                  >
+                </li>
+                <li
+                  class="tsd-kind-property tsd-parent-kind-interface tsd-is-external"
+                >
+                  <a
+                    href="AuthorizationParams.html#screen_hint"
+                    class="tsd-index-link"
+                    ><svg
+                      class="tsd-kind-icon"
+                      width="24"
+                      height="24"
+                      viewBox="0 0 24 24"
+                    >
+                      <use href="#icon-1024-path"></use>
+                      <use href="#icon-1024-text"></use></svg
+                    >screen_<wbr />hint?</a
+                  >
+                </li>
+                <li
+                  class="tsd-kind-property tsd-parent-kind-interface tsd-is-external"
+                >
+                  <a
+                    href="AuthorizationParams.html#ui_locales"
+                    class="tsd-index-link"
+                    ><svg
+                      class="tsd-kind-icon"
+                      width="24"
+                      height="24"
+                      viewBox="0 0 24 24"
+                    >
+                      <use href="#icon-1024-path"></use>
+                      <use href="#icon-1024-text"></use></svg
+                    >ui_<wbr />locales?</a
+                  >
+                </li>
+              </ul>
+            </li>
+          </ul>
+        </nav>
+      </div>
+    </div>
+    <div class="overlay"></div>
+    <script src="../assets/main.js"></script>
+  </body>
+</html>

--- a/docs/interfaces/GetTokenSilentlyOptions.html
+++ b/docs/interfaces/GetTokenSilentlyOptions.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8" />
     <meta http-equiv="x-ua-compatible" content="IE=edge" />
-    <title>AuthHttpInterceptor | @auth0/auth0-angular</title>
+    <title>GetTokenSilentlyOptions | @auth0/auth0-angular</title>
     <meta name="description" content="Documentation for @auth0/auth0-angular" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <link rel="stylesheet" href="../assets/style.css" />
@@ -75,30 +75,23 @@
         <div class="tsd-page-title">
           <ul class="tsd-breadcrumb">
             <li><a href="../modules.html">@auth0/auth0-angular</a></li>
-            <li><a href="AuthHttpInterceptor.html">AuthHttpInterceptor</a></li>
+            <li>
+              <a href="GetTokenSilentlyOptions.html">GetTokenSilentlyOptions</a>
+            </li>
           </ul>
-          <h1>Class AuthHttpInterceptor</h1>
+          <h1>Interface GetTokenSilentlyOptions</h1>
         </div>
         <section class="tsd-panel tsd-hierarchy">
           <h4>Hierarchy</h4>
           <ul class="tsd-hierarchy">
-            <li><span class="target">AuthHttpInterceptor</span></li>
-          </ul>
-        </section>
-        <section class="tsd-panel">
-          <h4>Implements</h4>
-          <ul class="tsd-hierarchy">
-            <li><span class="tsd-signature-type">HttpInterceptor</span></li>
+            <li><span class="target">GetTokenSilentlyOptions</span></li>
           </ul>
         </section>
         <aside class="tsd-sources">
           <ul>
             <li>
               Defined in
-              <a
-                href="https://github.com/auth0/auth0-angular/blob/014575f/projects/auth0-angular/src/lib/auth.interceptor.ts#L39"
-                >projects/auth0-angular/src/lib/auth.interceptor.ts:39</a
-              >
+              node_modules/@auth0/auth0-spa-js/dist/typings/global.d.ts:303
             </li>
           </ul>
         </aside>
@@ -123,11 +116,11 @@
               </summary>
               <div class="tsd-accordion-details">
                 <section class="tsd-index-section">
-                  <h3 class="tsd-index-heading">Constructors</h3>
+                  <h3 class="tsd-index-heading">Properties</h3>
                   <div class="tsd-index-list">
                     <a
-                      href="AuthHttpInterceptor.html#constructor"
-                      class="tsd-index-link tsd-kind-constructor tsd-parent-kind-class"
+                      href="GetTokenSilentlyOptions.html#authorizationParams"
+                      class="tsd-index-link tsd-kind-property tsd-parent-kind-interface tsd-is-external"
                       ><svg
                         class="tsd-kind-icon"
                         width="24"
@@ -136,53 +129,60 @@
                       >
                         <rect
                           fill="var(--color-icon-background)"
-                          stroke="#4D7FFF"
+                          stroke="#FF984D"
                           stroke-width="1.5"
                           x="1"
                           y="1"
                           width="22"
                           height="22"
                           rx="12"
-                          id="icon-512-path"
+                          id="icon-1024-path"
                         ></rect>
                         <path
-                          d="M11.898 16.1201C11.098 16.1201 10.466 15.8961 10.002 15.4481C9.53803 15.0001 9.30603 14.3841 9.30603 13.6001V9.64012C9.30603 8.85612 9.53803 8.24012 10.002 7.79212C10.466 7.34412 11.098 7.12012 11.898 7.12012C12.682 7.12012 13.306 7.34812 13.77 7.80412C14.234 8.25212 14.466 8.86412 14.466 9.64012H13.386C13.386 9.14412 13.254 8.76412 12.99 8.50012C12.734 8.22812 12.37 8.09212 11.898 8.09212C11.426 8.09212 11.054 8.22412 10.782 8.48812C10.518 8.75212 10.386 9.13212 10.386 9.62812V13.6001C10.386 14.0961 10.518 14.4801 10.782 14.7521C11.054 15.0161 11.426 15.1481 11.898 15.1481C12.37 15.1481 12.734 15.0161 12.99 14.7521C13.254 14.4801 13.386 14.0961 13.386 13.6001H14.466C14.466 14.3761 14.234 14.9921 13.77 15.4481C13.306 15.8961 12.682 16.1201 11.898 16.1201Z"
+                          d="M9.354 16V7.24H12.174C12.99 7.24 13.638 7.476 14.118 7.948C14.606 8.412 14.85 9.036 14.85 9.82C14.85 10.604 14.606 11.232 14.118 11.704C13.638 12.168 12.99 12.4 12.174 12.4H10.434V16H9.354ZM10.434 11.428H12.174C12.646 11.428 13.022 11.284 13.302 10.996C13.59 10.7 13.734 10.308 13.734 9.82C13.734 9.324 13.59 8.932 13.302 8.644C13.022 8.356 12.646 8.212 12.174 8.212H10.434V11.428Z"
                           fill="var(--color-text)"
-                          id="icon-512-text"
+                          id="icon-1024-text"
                         ></path></svg
-                      ><span>constructor</span></a
+                      ><span>authorization<wbr />Params?</span></a
                     >
-                  </div>
-                </section>
-                <section class="tsd-index-section">
-                  <h3 class="tsd-index-heading">Methods</h3>
-                  <div class="tsd-index-list">
                     <a
-                      href="AuthHttpInterceptor.html#intercept"
-                      class="tsd-index-link tsd-kind-method tsd-parent-kind-class"
+                      href="GetTokenSilentlyOptions.html#cacheMode"
+                      class="tsd-index-link tsd-kind-property tsd-parent-kind-interface tsd-is-external"
                       ><svg
                         class="tsd-kind-icon"
                         width="24"
                         height="24"
                         viewBox="0 0 24 24"
                       >
-                        <rect
-                          fill="var(--color-icon-background)"
-                          stroke="#FF4DB8"
-                          stroke-width="1.5"
-                          x="1"
-                          y="1"
-                          width="22"
-                          height="22"
-                          rx="12"
-                          id="icon-2048-path"
-                        ></rect>
-                        <path
-                          d="M9.162 16V7.24H10.578L11.514 10.072C11.602 10.328 11.674 10.584 11.73 10.84C11.794 11.088 11.842 11.28 11.874 11.416C11.906 11.28 11.954 11.088 12.018 10.84C12.082 10.584 12.154 10.324 12.234 10.06L13.122 7.24H14.538V16H13.482V12.82C13.482 12.468 13.49 12.068 13.506 11.62C13.53 11.172 13.558 10.716 13.59 10.252C13.622 9.78 13.654 9.332 13.686 8.908C13.726 8.476 13.762 8.1 13.794 7.78L12.366 12.16H11.334L9.894 7.78C9.934 8.092 9.97 8.456 10.002 8.872C10.042 9.28 10.078 9.716 10.11 10.18C10.142 10.636 10.166 11.092 10.182 11.548C10.206 12.004 10.218 12.428 10.218 12.82V16H9.162Z"
-                          fill="var(--color-text)"
-                          id="icon-2048-text"
-                        ></path></svg
-                      ><span>intercept</span></a
+                        <use href="#icon-1024-path"></use>
+                        <use href="#icon-1024-text"></use></svg
+                      ><span>cache<wbr />Mode?</span></a
+                    >
+                    <a
+                      href="GetTokenSilentlyOptions.html#detailedResponse"
+                      class="tsd-index-link tsd-kind-property tsd-parent-kind-interface tsd-is-external"
+                      ><svg
+                        class="tsd-kind-icon"
+                        width="24"
+                        height="24"
+                        viewBox="0 0 24 24"
+                      >
+                        <use href="#icon-1024-path"></use>
+                        <use href="#icon-1024-text"></use></svg
+                      ><span>detailed<wbr />Response?</span></a
+                    >
+                    <a
+                      href="GetTokenSilentlyOptions.html#timeoutInSeconds"
+                      class="tsd-index-link tsd-kind-property tsd-parent-kind-interface tsd-is-external"
+                      ><svg
+                        class="tsd-kind-icon"
+                        width="24"
+                        height="24"
+                        viewBox="0 0 24 24"
+                      >
+                        <use href="#icon-1024-path"></use>
+                        <use href="#icon-1024-text"></use></svg
+                      ><span>timeout<wbr />In<wbr />Seconds?</span></a
                     >
                   </div>
                 </section>
@@ -191,15 +191,16 @@
           </section>
         </section>
         <section class="tsd-panel-group tsd-member-group">
-          <h2>Constructors</h2>
+          <h2>Properties</h2>
           <section
-            class="tsd-panel tsd-member tsd-kind-constructor tsd-parent-kind-class"
+            class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-interface tsd-is-external"
           >
-            <a id="constructor" class="tsd-anchor"></a>
+            <a id="authorizationParams" class="tsd-anchor"></a>
             <h3 class="tsd-anchor-link">
-              <span>constructor</span
+              <code class="tsd-tag ts-flagOptional">Optional</code>
+              <span>authorization<wbr />Params</span
               ><a
-                href="#constructor"
+                href="#authorizationParams"
                 aria-label="Permalink"
                 class="tsd-anchor-icon"
                 ><svg
@@ -227,153 +228,110 @@
                   ></path></svg
               ></a>
             </h3>
-            <ul
-              class="tsd-signatures tsd-kind-constructor tsd-parent-kind-class"
-            >
-              <li
-                class="tsd-signature tsd-anchor-link"
-                id="constructor.new_AuthHttpInterceptor"
+            <div class="tsd-signature">
+              authorization<wbr />Params<span class="tsd-signature-symbol"
+                >?:</span
               >
-                new <wbr />Auth<wbr />Http<wbr />Interceptor<span
-                  class="tsd-signature-symbol"
-                  >(</span
-                >configFactory<span class="tsd-signature-symbol">: </span
-                ><a
-                  href="AuthClientConfig.html"
-                  class="tsd-signature-type"
-                  data-tsd-kind="Class"
-                  >AuthClientConfig</a
-                >, auth0Client<span class="tsd-signature-symbol">: </span
-                ><span class="tsd-signature-type">Auth0Client</span>,
-                authState<span class="tsd-signature-symbol">: </span
-                ><a
-                  href="AuthState.html"
-                  class="tsd-signature-type"
-                  data-tsd-kind="Class"
-                  >AuthState</a
-                >, authService<span class="tsd-signature-symbol">: </span
-                ><a
-                  href="AuthService.html"
-                  class="tsd-signature-type"
-                  data-tsd-kind="Class"
-                  >AuthService</a
-                ><span class="tsd-signature-symbol">&lt;</span
-                ><a
-                  href="../interfaces/AppState.html"
-                  class="tsd-signature-type"
-                  data-tsd-kind="Interface"
-                  >AppState</a
-                ><span class="tsd-signature-symbol">&gt;</span
-                ><span class="tsd-signature-symbol">)</span
-                ><span class="tsd-signature-symbol">: </span
-                ><a
-                  href="AuthHttpInterceptor.html"
-                  class="tsd-signature-type"
-                  data-tsd-kind="Class"
-                  >AuthHttpInterceptor</a
-                ><a
-                  href="#constructor.new_AuthHttpInterceptor"
-                  aria-label="Permalink"
-                  class="tsd-anchor-icon"
-                  ><svg
-                    class="icon icon-tabler icon-tabler-link"
-                    viewBox="0 0 24 24"
-                    stroke-width="2"
-                    stroke="currentColor"
-                    fill="none"
-                    stroke-linecap="round"
-                    stroke-linejoin="round"
-                  >
-                    <use href="#icon-anchor-a"></use>
-                    <use href="#icon-anchor-b"></use>
-                    <use href="#icon-anchor-c"></use></svg
-                ></a>
-              </li>
-              <li class="tsd-description">
-                <div class="tsd-parameters">
-                  <h4 class="tsd-parameters-title">Parameters</h4>
-                  <ul class="tsd-parameter-list">
-                    <li>
-                      <h5>
-                        configFactory:
-                        <a
-                          href="AuthClientConfig.html"
-                          class="tsd-signature-type"
-                          data-tsd-kind="Class"
-                          >AuthClientConfig</a
-                        >
-                      </h5>
-                    </li>
-                    <li>
-                      <h5>
-                        auth0Client:
-                        <span class="tsd-signature-type">Auth0Client</span>
-                      </h5>
-                    </li>
-                    <li>
-                      <h5>
-                        authState:
-                        <a
-                          href="AuthState.html"
-                          class="tsd-signature-type"
-                          data-tsd-kind="Class"
-                          >AuthState</a
-                        >
-                      </h5>
-                    </li>
-                    <li>
-                      <h5>
-                        authService:
-                        <a
-                          href="AuthService.html"
-                          class="tsd-signature-type"
-                          data-tsd-kind="Class"
-                          >AuthService</a
-                        ><span class="tsd-signature-symbol">&lt;</span
-                        ><a
-                          href="../interfaces/AppState.html"
-                          class="tsd-signature-type"
-                          data-tsd-kind="Interface"
-                          >AppState</a
-                        ><span class="tsd-signature-symbol">&gt;</span>
-                      </h5>
-                    </li>
-                  </ul>
-                </div>
-                <h4 class="tsd-returns-title">
-                  Returns
-                  <a
-                    href="AuthHttpInterceptor.html"
-                    class="tsd-signature-type"
-                    data-tsd-kind="Class"
-                    >AuthHttpInterceptor</a
-                  >
-                </h4>
-                <aside class="tsd-sources">
-                  <ul>
-                    <li>
-                      Defined in
-                      <a
-                        href="https://github.com/auth0/auth0-angular/blob/014575f/projects/auth0-angular/src/lib/auth.interceptor.ts#L40"
-                        >projects/auth0-angular/src/lib/auth.interceptor.ts:40</a
-                      >
-                    </li>
-                  </ul>
-                </aside>
-              </li>
-            </ul>
+              <span class="tsd-signature-symbol">{ </span><br /><span>    </span
+              >audience<span class="tsd-signature-symbol">?: </span
+              ><span class="tsd-signature-type">string</span
+              ><span class="tsd-signature-symbol">; </span><br /><span
+                >    </span
+              >redirect_uri<span class="tsd-signature-symbol">?: </span
+              ><span class="tsd-signature-type">string</span
+              ><span class="tsd-signature-symbol">; </span><br /><span
+                >    </span
+              >scope<span class="tsd-signature-symbol">?: </span
+              ><span class="tsd-signature-type">string</span
+              ><span class="tsd-signature-symbol">; </span><br /><span
+                >    </span
+              >[key: <span class="tsd-signature-type">string</span>]<span
+                class="tsd-signature-symbol"
+                >: </span
+              ><span class="tsd-signature-type">any</span
+              ><span class="tsd-signature-symbol">; </span><br /><span
+                class="tsd-signature-symbol"
+                >}</span
+              >
+            </div>
+            <div class="tsd-comment tsd-typography">
+              <p>
+                Parameters that will be sent back to Auth0 as part of a request.
+              </p>
+            </div>
+            <div class="tsd-type-declaration">
+              <h4>Type declaration</h4>
+              <ul class="tsd-parameters">
+                <li class="tsd-parameter-index-signature">
+                  <h5>
+                    <span class="tsd-signature-symbol">[</span>key:
+                    <span class="tsd-signature-type">string</span
+                    ><span class="tsd-signature-symbol">]: </span
+                    ><span class="tsd-signature-type">any</span>
+                  </h5>
+                </li>
+                <li class="tsd-parameter">
+                  <h5>
+                    <code class="tsd-tag ts-flagOptional">Optional</code>
+                    audience<span class="tsd-signature-symbol">?: </span
+                    ><span class="tsd-signature-type">string</span>
+                  </h5>
+                  <div class="tsd-comment tsd-typography">
+                    <p>
+                      The audience that was used in the authentication request
+                    </p>
+                  </div>
+                </li>
+                <li class="tsd-parameter">
+                  <h5>
+                    <code class="tsd-tag ts-flagOptional">Optional</code>
+                    redirect_<wbr />uri<span class="tsd-signature-symbol"
+                      >?: </span
+                    ><span class="tsd-signature-type">string</span>
+                  </h5>
+                  <div class="tsd-comment tsd-typography">
+                    <p>
+                      There&#39;s no actual redirect when getting a token
+                      silently, but, according to the spec, a
+                      <code>redirect_uri</code> param is required. Auth0 uses
+                      this parameter to validate that the current
+                      <code>origin</code> matches the <code>redirect_uri</code>
+                      <code>origin</code> when sending the response. It must be
+                      whitelisted in the &quot;Allowed Web Origins&quot; in your
+                      Auth0 Application&#39;s settings.
+                    </p>
+                  </div>
+                </li>
+                <li class="tsd-parameter">
+                  <h5>
+                    <code class="tsd-tag ts-flagOptional">Optional</code>
+                    scope<span class="tsd-signature-symbol">?: </span
+                    ><span class="tsd-signature-type">string</span>
+                  </h5>
+                  <div class="tsd-comment tsd-typography">
+                    <p>The scope that was used in the authentication request</p>
+                  </div>
+                </li>
+              </ul>
+            </div>
+            <aside class="tsd-sources">
+              <ul>
+                <li>
+                  Defined in
+                  node_modules/@auth0/auth0-spa-js/dist/typings/global.d.ts:314
+                </li>
+              </ul>
+            </aside>
           </section>
-        </section>
-        <section class="tsd-panel-group tsd-member-group">
-          <h2>Methods</h2>
           <section
-            class="tsd-panel tsd-member tsd-kind-method tsd-parent-kind-class"
+            class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-interface tsd-is-external"
           >
-            <a id="intercept" class="tsd-anchor"></a>
+            <a id="cacheMode" class="tsd-anchor"></a>
             <h3 class="tsd-anchor-link">
-              <span>intercept</span
+              <code class="tsd-tag ts-flagOptional">Optional</code>
+              <span>cache<wbr />Mode</span
               ><a
-                href="#intercept"
+                href="#cacheMode"
                 aria-label="Permalink"
                 class="tsd-anchor-icon"
                 ><svg
@@ -390,91 +348,127 @@
                   <use href="#icon-anchor-c"></use></svg
               ></a>
             </h3>
-            <ul class="tsd-signatures tsd-kind-method tsd-parent-kind-class">
-              <li
-                class="tsd-signature tsd-anchor-link"
-                id="intercept.intercept-1"
+            <div class="tsd-signature">
+              cache<wbr />Mode<span class="tsd-signature-symbol">?:</span>
+              <span class="tsd-signature-type">&quot;on&quot;</span
+              ><span class="tsd-signature-symbol"> | </span
+              ><span class="tsd-signature-type">&quot;off&quot;</span
+              ><span class="tsd-signature-symbol"> | </span
+              ><span class="tsd-signature-type">&quot;cache-only&quot;</span>
+            </div>
+            <div class="tsd-comment tsd-typography">
+              <p>
+                When <code>off</code>, ignores the cache and always sends a
+                request to Auth0. When <code>cache-only</code>, only reads from
+                the cache and never sends a request to Auth0. Defaults to
+                <code>on</code>, where it both reads from the cache and sends a
+                request to Auth0 as needed.
+              </p>
+            </div>
+            <aside class="tsd-sources">
+              <ul>
+                <li>
+                  Defined in
+                  node_modules/@auth0/auth0-spa-js/dist/typings/global.d.ts:310
+                </li>
+              </ul>
+            </aside>
+          </section>
+          <section
+            class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-interface tsd-is-external"
+          >
+            <a id="detailedResponse" class="tsd-anchor"></a>
+            <h3 class="tsd-anchor-link">
+              <code class="tsd-tag ts-flagOptional">Optional</code>
+              <span>detailed<wbr />Response</span
+              ><a
+                href="#detailedResponse"
+                aria-label="Permalink"
+                class="tsd-anchor-icon"
+                ><svg
+                  class="icon icon-tabler icon-tabler-link"
+                  viewBox="0 0 24 24"
+                  stroke-width="2"
+                  stroke="currentColor"
+                  fill="none"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                >
+                  <use href="#icon-anchor-a"></use>
+                  <use href="#icon-anchor-b"></use>
+                  <use href="#icon-anchor-c"></use></svg
+              ></a>
+            </h3>
+            <div class="tsd-signature">
+              detailed<wbr />Response<span class="tsd-signature-symbol"
+                >?:</span
               >
-                intercept<span class="tsd-signature-symbol">(</span>req<span
-                  class="tsd-signature-symbol"
-                  >: </span
-                ><span class="tsd-signature-type">HttpRequest</span
-                ><span class="tsd-signature-symbol">&lt;</span
-                ><span class="tsd-signature-type">any</span
-                ><span class="tsd-signature-symbol">&gt;</span>, next<span
-                  class="tsd-signature-symbol"
-                  >: </span
-                ><span class="tsd-signature-type">HttpHandler</span
-                ><span class="tsd-signature-symbol">)</span
-                ><span class="tsd-signature-symbol">: </span
-                ><span class="tsd-signature-type">Observable</span
-                ><span class="tsd-signature-symbol">&lt;</span
-                ><span class="tsd-signature-type">HttpEvent</span
-                ><span class="tsd-signature-symbol">&lt;</span
-                ><span class="tsd-signature-type">any</span
-                ><span class="tsd-signature-symbol">&gt;</span
-                ><span class="tsd-signature-symbol">&gt;</span
-                ><a
-                  href="#intercept.intercept-1"
-                  aria-label="Permalink"
-                  class="tsd-anchor-icon"
-                  ><svg
-                    class="icon icon-tabler icon-tabler-link"
-                    viewBox="0 0 24 24"
-                    stroke-width="2"
-                    stroke="currentColor"
-                    fill="none"
-                    stroke-linecap="round"
-                    stroke-linejoin="round"
-                  >
-                    <use href="#icon-anchor-a"></use>
-                    <use href="#icon-anchor-b"></use>
-                    <use href="#icon-anchor-c"></use></svg
-                ></a>
-              </li>
-              <li class="tsd-description">
-                <div class="tsd-parameters">
-                  <h4 class="tsd-parameters-title">Parameters</h4>
-                  <ul class="tsd-parameter-list">
-                    <li>
-                      <h5>
-                        req: <span class="tsd-signature-type">HttpRequest</span
-                        ><span class="tsd-signature-symbol">&lt;</span
-                        ><span class="tsd-signature-type">any</span
-                        ><span class="tsd-signature-symbol">&gt;</span>
-                      </h5>
-                    </li>
-                    <li>
-                      <h5>
-                        next:
-                        <span class="tsd-signature-type">HttpHandler</span>
-                      </h5>
-                    </li>
-                  </ul>
-                </div>
-                <h4 class="tsd-returns-title">
-                  Returns <span class="tsd-signature-type">Observable</span
-                  ><span class="tsd-signature-symbol">&lt;</span
-                  ><span class="tsd-signature-type">HttpEvent</span
-                  ><span class="tsd-signature-symbol">&lt;</span
-                  ><span class="tsd-signature-type">any</span
-                  ><span class="tsd-signature-symbol">&gt;</span
-                  ><span class="tsd-signature-symbol">&gt;</span>
-                </h4>
-                <aside class="tsd-sources">
-                  <p>Implementation of HttpInterceptor.intercept</p>
-                  <ul>
-                    <li>
-                      Defined in
-                      <a
-                        href="https://github.com/auth0/auth0-angular/blob/014575f/projects/auth0-angular/src/lib/auth.interceptor.ts#L47"
-                        >projects/auth0-angular/src/lib/auth.interceptor.ts:47</a
-                      >
-                    </li>
-                  </ul>
-                </aside>
-              </li>
-            </ul>
+              <span class="tsd-signature-type">boolean</span>
+            </div>
+            <div class="tsd-comment tsd-typography">
+              <p>
+                If true, the full response from the /oauth/token endpoint (or
+                the cache, if the cache was used) is returned (minus
+                <code>refresh_token</code> if one was issued). Otherwise, just
+                the access token is returned.
+              </p>
+              <p>The default is <code>false</code>.</p>
+            </div>
+            <aside class="tsd-sources">
+              <ul>
+                <li>
+                  Defined in
+                  node_modules/@auth0/auth0-spa-js/dist/typings/global.d.ts:348
+                </li>
+              </ul>
+            </aside>
+          </section>
+          <section
+            class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-interface tsd-is-external"
+          >
+            <a id="timeoutInSeconds" class="tsd-anchor"></a>
+            <h3 class="tsd-anchor-link">
+              <code class="tsd-tag ts-flagOptional">Optional</code>
+              <span>timeout<wbr />In<wbr />Seconds</span
+              ><a
+                href="#timeoutInSeconds"
+                aria-label="Permalink"
+                class="tsd-anchor-icon"
+                ><svg
+                  class="icon icon-tabler icon-tabler-link"
+                  viewBox="0 0 24 24"
+                  stroke-width="2"
+                  stroke="currentColor"
+                  fill="none"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                >
+                  <use href="#icon-anchor-a"></use>
+                  <use href="#icon-anchor-b"></use>
+                  <use href="#icon-anchor-c"></use></svg
+              ></a>
+            </h3>
+            <div class="tsd-signature">
+              timeout<wbr />In<wbr />Seconds<span class="tsd-signature-symbol"
+                >?:</span
+              >
+              <span class="tsd-signature-type">number</span>
+            </div>
+            <div class="tsd-comment tsd-typography">
+              <p>
+                A maximum number of seconds to wait before declaring the
+                background /authorize call as failed for timeout Defaults to
+                60s.
+              </p>
+            </div>
+            <aside class="tsd-sources">
+              <ul>
+                <li>
+                  Defined in
+                  node_modules/@auth0/auth0-spa-js/dist/typings/global.d.ts:341
+                </li>
+              </ul>
+            </aside>
           </section>
         </section>
       </div>
@@ -634,8 +628,8 @@
         </nav>
         <nav class="tsd-navigation secondary menu-sticky">
           <ul>
-            <li class="current tsd-kind-class">
-              <a href="AuthHttpInterceptor.html" class="tsd-index-link"
+            <li class="current tsd-kind-interface tsd-is-external">
+              <a href="GetTokenSilentlyOptions.html" class="tsd-index-link"
                 ><svg
                   class="tsd-kind-icon"
                   width="24"
@@ -644,26 +638,28 @@
                 >
                   <rect
                     fill="var(--color-icon-background)"
-                    stroke="var(--color-ts-class)"
+                    stroke="var(--color-ts-interface)"
                     stroke-width="1.5"
                     x="1"
                     y="1"
                     width="22"
                     height="22"
                     rx="6"
-                    id="icon-128-path"
+                    id="icon-256-path"
                   ></rect>
                   <path
-                    d="M11.898 16.1201C11.098 16.1201 10.466 15.8961 10.002 15.4481C9.53803 15.0001 9.30603 14.3841 9.30603 13.6001V9.64012C9.30603 8.85612 9.53803 8.24012 10.002 7.79212C10.466 7.34412 11.098 7.12012 11.898 7.12012C12.682 7.12012 13.306 7.34812 13.77 7.80412C14.234 8.25212 14.466 8.86412 14.466 9.64012H13.386C13.386 9.14412 13.254 8.76412 12.99 8.50012C12.734 8.22812 12.37 8.09212 11.898 8.09212C11.426 8.09212 11.054 8.22412 10.782 8.48812C10.518 8.75212 10.386 9.13212 10.386 9.62812V13.6001C10.386 14.0961 10.518 14.4801 10.782 14.7521C11.054 15.0161 11.426 15.1481 11.898 15.1481C12.37 15.1481 12.734 15.0161 12.99 14.7521C13.254 14.4801 13.386 14.0961 13.386 13.6001H14.466C14.466 14.3761 14.234 14.9921 13.77 15.4481C13.306 15.8961 12.682 16.1201 11.898 16.1201Z"
+                    d="M9.51 16V15.016H11.298V8.224H9.51V7.24H14.19V8.224H12.402V15.016H14.19V16H9.51Z"
                     fill="var(--color-text)"
-                    id="icon-128-text"
+                    id="icon-256-text"
                   ></path></svg
-                ><span>Auth<wbr />Http<wbr />Interceptor</span></a
+                ><span>Get<wbr />Token<wbr />Silently<wbr />Options</span></a
               >
               <ul>
-                <li class="tsd-kind-constructor tsd-parent-kind-class">
+                <li
+                  class="tsd-kind-property tsd-parent-kind-interface tsd-is-external"
+                >
                   <a
-                    href="AuthHttpInterceptor.html#constructor"
+                    href="GetTokenSilentlyOptions.html#authorizationParams"
                     class="tsd-index-link"
                     ><svg
                       class="tsd-kind-icon"
@@ -671,14 +667,16 @@
                       height="24"
                       viewBox="0 0 24 24"
                     >
-                      <use href="#icon-512-path"></use>
-                      <use href="#icon-512-text"></use></svg
-                    >constructor</a
+                      <use href="#icon-1024-path"></use>
+                      <use href="#icon-1024-text"></use></svg
+                    >authorization<wbr />Params?</a
                   >
                 </li>
-                <li class="tsd-kind-method tsd-parent-kind-class">
+                <li
+                  class="tsd-kind-property tsd-parent-kind-interface tsd-is-external"
+                >
                   <a
-                    href="AuthHttpInterceptor.html#intercept"
+                    href="GetTokenSilentlyOptions.html#cacheMode"
                     class="tsd-index-link"
                     ><svg
                       class="tsd-kind-icon"
@@ -686,9 +684,43 @@
                       height="24"
                       viewBox="0 0 24 24"
                     >
-                      <use href="#icon-2048-path"></use>
-                      <use href="#icon-2048-text"></use></svg
-                    >intercept</a
+                      <use href="#icon-1024-path"></use>
+                      <use href="#icon-1024-text"></use></svg
+                    >cache<wbr />Mode?</a
+                  >
+                </li>
+                <li
+                  class="tsd-kind-property tsd-parent-kind-interface tsd-is-external"
+                >
+                  <a
+                    href="GetTokenSilentlyOptions.html#detailedResponse"
+                    class="tsd-index-link"
+                    ><svg
+                      class="tsd-kind-icon"
+                      width="24"
+                      height="24"
+                      viewBox="0 0 24 24"
+                    >
+                      <use href="#icon-1024-path"></use>
+                      <use href="#icon-1024-text"></use></svg
+                    >detailed<wbr />Response?</a
+                  >
+                </li>
+                <li
+                  class="tsd-kind-property tsd-parent-kind-interface tsd-is-external"
+                >
+                  <a
+                    href="GetTokenSilentlyOptions.html#timeoutInSeconds"
+                    class="tsd-index-link"
+                    ><svg
+                      class="tsd-kind-icon"
+                      width="24"
+                      height="24"
+                      viewBox="0 0 24 24"
+                    >
+                      <use href="#icon-1024-path"></use>
+                      <use href="#icon-1024-text"></use></svg
+                    >timeout<wbr />In<wbr />Seconds?</a
                   >
                 </li>
               </ul>

--- a/docs/interfaces/GetTokenWithPopupOptions.html
+++ b/docs/interfaces/GetTokenWithPopupOptions.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8" />
     <meta http-equiv="x-ua-compatible" content="IE=edge" />
-    <title>AuthHttpInterceptor | @auth0/auth0-angular</title>
+    <title>GetTokenWithPopupOptions | @auth0/auth0-angular</title>
     <meta name="description" content="Documentation for @auth0/auth0-angular" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <link rel="stylesheet" href="../assets/style.css" />
@@ -75,30 +75,35 @@
         <div class="tsd-page-title">
           <ul class="tsd-breadcrumb">
             <li><a href="../modules.html">@auth0/auth0-angular</a></li>
-            <li><a href="AuthHttpInterceptor.html">AuthHttpInterceptor</a></li>
+            <li>
+              <a href="GetTokenWithPopupOptions.html"
+                >GetTokenWithPopupOptions</a
+              >
+            </li>
           </ul>
-          <h1>Class AuthHttpInterceptor</h1>
+          <h1>Interface GetTokenWithPopupOptions</h1>
         </div>
         <section class="tsd-panel tsd-hierarchy">
           <h4>Hierarchy</h4>
           <ul class="tsd-hierarchy">
-            <li><span class="target">AuthHttpInterceptor</span></li>
-          </ul>
-        </section>
-        <section class="tsd-panel">
-          <h4>Implements</h4>
-          <ul class="tsd-hierarchy">
-            <li><span class="tsd-signature-type">HttpInterceptor</span></li>
+            <li>
+              <a
+                href="PopupLoginOptions.html"
+                class="tsd-signature-type"
+                data-tsd-kind="Interface"
+                >PopupLoginOptions</a
+              >
+              <ul class="tsd-hierarchy">
+                <li><span class="target">GetTokenWithPopupOptions</span></li>
+              </ul>
+            </li>
           </ul>
         </section>
         <aside class="tsd-sources">
           <ul>
             <li>
               Defined in
-              <a
-                href="https://github.com/auth0/auth0-angular/blob/014575f/projects/auth0-angular/src/lib/auth.interceptor.ts#L39"
-                >projects/auth0-angular/src/lib/auth.interceptor.ts:39</a
-              >
+              node_modules/@auth0/auth0-spa-js/dist/typings/global.d.ts:350
             </li>
           </ul>
         </aside>
@@ -123,11 +128,11 @@
               </summary>
               <div class="tsd-accordion-details">
                 <section class="tsd-index-section">
-                  <h3 class="tsd-index-heading">Constructors</h3>
+                  <h3 class="tsd-index-heading">Properties</h3>
                   <div class="tsd-index-list">
                     <a
-                      href="AuthHttpInterceptor.html#constructor"
-                      class="tsd-index-link tsd-kind-constructor tsd-parent-kind-class"
+                      href="GetTokenWithPopupOptions.html#authorizationParams"
+                      class="tsd-index-link tsd-kind-property tsd-parent-kind-interface tsd-is-inherited tsd-is-external"
                       ><svg
                         class="tsd-kind-icon"
                         width="24"
@@ -136,53 +141,34 @@
                       >
                         <rect
                           fill="var(--color-icon-background)"
-                          stroke="#4D7FFF"
+                          stroke="#FF984D"
                           stroke-width="1.5"
                           x="1"
                           y="1"
                           width="22"
                           height="22"
                           rx="12"
-                          id="icon-512-path"
+                          id="icon-1024-path"
                         ></rect>
                         <path
-                          d="M11.898 16.1201C11.098 16.1201 10.466 15.8961 10.002 15.4481C9.53803 15.0001 9.30603 14.3841 9.30603 13.6001V9.64012C9.30603 8.85612 9.53803 8.24012 10.002 7.79212C10.466 7.34412 11.098 7.12012 11.898 7.12012C12.682 7.12012 13.306 7.34812 13.77 7.80412C14.234 8.25212 14.466 8.86412 14.466 9.64012H13.386C13.386 9.14412 13.254 8.76412 12.99 8.50012C12.734 8.22812 12.37 8.09212 11.898 8.09212C11.426 8.09212 11.054 8.22412 10.782 8.48812C10.518 8.75212 10.386 9.13212 10.386 9.62812V13.6001C10.386 14.0961 10.518 14.4801 10.782 14.7521C11.054 15.0161 11.426 15.1481 11.898 15.1481C12.37 15.1481 12.734 15.0161 12.99 14.7521C13.254 14.4801 13.386 14.0961 13.386 13.6001H14.466C14.466 14.3761 14.234 14.9921 13.77 15.4481C13.306 15.8961 12.682 16.1201 11.898 16.1201Z"
+                          d="M9.354 16V7.24H12.174C12.99 7.24 13.638 7.476 14.118 7.948C14.606 8.412 14.85 9.036 14.85 9.82C14.85 10.604 14.606 11.232 14.118 11.704C13.638 12.168 12.99 12.4 12.174 12.4H10.434V16H9.354ZM10.434 11.428H12.174C12.646 11.428 13.022 11.284 13.302 10.996C13.59 10.7 13.734 10.308 13.734 9.82C13.734 9.324 13.59 8.932 13.302 8.644C13.022 8.356 12.646 8.212 12.174 8.212H10.434V11.428Z"
                           fill="var(--color-text)"
-                          id="icon-512-text"
+                          id="icon-1024-text"
                         ></path></svg
-                      ><span>constructor</span></a
+                      ><span>authorization<wbr />Params?</span></a
                     >
-                  </div>
-                </section>
-                <section class="tsd-index-section">
-                  <h3 class="tsd-index-heading">Methods</h3>
-                  <div class="tsd-index-list">
                     <a
-                      href="AuthHttpInterceptor.html#intercept"
-                      class="tsd-index-link tsd-kind-method tsd-parent-kind-class"
+                      href="GetTokenWithPopupOptions.html#cacheMode"
+                      class="tsd-index-link tsd-kind-property tsd-parent-kind-interface tsd-is-external"
                       ><svg
                         class="tsd-kind-icon"
                         width="24"
                         height="24"
                         viewBox="0 0 24 24"
                       >
-                        <rect
-                          fill="var(--color-icon-background)"
-                          stroke="#FF4DB8"
-                          stroke-width="1.5"
-                          x="1"
-                          y="1"
-                          width="22"
-                          height="22"
-                          rx="12"
-                          id="icon-2048-path"
-                        ></rect>
-                        <path
-                          d="M9.162 16V7.24H10.578L11.514 10.072C11.602 10.328 11.674 10.584 11.73 10.84C11.794 11.088 11.842 11.28 11.874 11.416C11.906 11.28 11.954 11.088 12.018 10.84C12.082 10.584 12.154 10.324 12.234 10.06L13.122 7.24H14.538V16H13.482V12.82C13.482 12.468 13.49 12.068 13.506 11.62C13.53 11.172 13.558 10.716 13.59 10.252C13.622 9.78 13.654 9.332 13.686 8.908C13.726 8.476 13.762 8.1 13.794 7.78L12.366 12.16H11.334L9.894 7.78C9.934 8.092 9.97 8.456 10.002 8.872C10.042 9.28 10.078 9.716 10.11 10.18C10.142 10.636 10.166 11.092 10.182 11.548C10.206 12.004 10.218 12.428 10.218 12.82V16H9.162Z"
-                          fill="var(--color-text)"
-                          id="icon-2048-text"
-                        ></path></svg
-                      ><span>intercept</span></a
+                        <use href="#icon-1024-path"></use>
+                        <use href="#icon-1024-text"></use></svg
+                      ><span>cache<wbr />Mode?</span></a
                     >
                   </div>
                 </section>
@@ -191,15 +177,16 @@
           </section>
         </section>
         <section class="tsd-panel-group tsd-member-group">
-          <h2>Constructors</h2>
+          <h2>Properties</h2>
           <section
-            class="tsd-panel tsd-member tsd-kind-constructor tsd-parent-kind-class"
+            class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-interface tsd-is-inherited tsd-is-external"
           >
-            <a id="constructor" class="tsd-anchor"></a>
+            <a id="authorizationParams" class="tsd-anchor"></a>
             <h3 class="tsd-anchor-link">
-              <span>constructor</span
+              <code class="tsd-tag ts-flagOptional">Optional</code>
+              <span>authorization<wbr />Params</span
               ><a
-                href="#constructor"
+                href="#authorizationParams"
                 aria-label="Permalink"
                 class="tsd-anchor-icon"
                 ><svg
@@ -227,153 +214,49 @@
                   ></path></svg
               ></a>
             </h3>
-            <ul
-              class="tsd-signatures tsd-kind-constructor tsd-parent-kind-class"
-            >
-              <li
-                class="tsd-signature tsd-anchor-link"
-                id="constructor.new_AuthHttpInterceptor"
+            <div class="tsd-signature">
+              authorization<wbr />Params<span class="tsd-signature-symbol"
+                >?:</span
               >
-                new <wbr />Auth<wbr />Http<wbr />Interceptor<span
-                  class="tsd-signature-symbol"
-                  >(</span
-                >configFactory<span class="tsd-signature-symbol">: </span
-                ><a
-                  href="AuthClientConfig.html"
-                  class="tsd-signature-type"
-                  data-tsd-kind="Class"
-                  >AuthClientConfig</a
-                >, auth0Client<span class="tsd-signature-symbol">: </span
-                ><span class="tsd-signature-type">Auth0Client</span>,
-                authState<span class="tsd-signature-symbol">: </span
-                ><a
-                  href="AuthState.html"
-                  class="tsd-signature-type"
-                  data-tsd-kind="Class"
-                  >AuthState</a
-                >, authService<span class="tsd-signature-symbol">: </span
-                ><a
-                  href="AuthService.html"
-                  class="tsd-signature-type"
-                  data-tsd-kind="Class"
-                  >AuthService</a
-                ><span class="tsd-signature-symbol">&lt;</span
-                ><a
-                  href="../interfaces/AppState.html"
-                  class="tsd-signature-type"
-                  data-tsd-kind="Interface"
-                  >AppState</a
-                ><span class="tsd-signature-symbol">&gt;</span
-                ><span class="tsd-signature-symbol">)</span
-                ><span class="tsd-signature-symbol">: </span
-                ><a
-                  href="AuthHttpInterceptor.html"
-                  class="tsd-signature-type"
-                  data-tsd-kind="Class"
-                  >AuthHttpInterceptor</a
-                ><a
-                  href="#constructor.new_AuthHttpInterceptor"
-                  aria-label="Permalink"
-                  class="tsd-anchor-icon"
-                  ><svg
-                    class="icon icon-tabler icon-tabler-link"
-                    viewBox="0 0 24 24"
-                    stroke-width="2"
-                    stroke="currentColor"
-                    fill="none"
-                    stroke-linecap="round"
-                    stroke-linejoin="round"
-                  >
-                    <use href="#icon-anchor-a"></use>
-                    <use href="#icon-anchor-b"></use>
-                    <use href="#icon-anchor-c"></use></svg
-                ></a>
-              </li>
-              <li class="tsd-description">
-                <div class="tsd-parameters">
-                  <h4 class="tsd-parameters-title">Parameters</h4>
-                  <ul class="tsd-parameter-list">
-                    <li>
-                      <h5>
-                        configFactory:
-                        <a
-                          href="AuthClientConfig.html"
-                          class="tsd-signature-type"
-                          data-tsd-kind="Class"
-                          >AuthClientConfig</a
-                        >
-                      </h5>
-                    </li>
-                    <li>
-                      <h5>
-                        auth0Client:
-                        <span class="tsd-signature-type">Auth0Client</span>
-                      </h5>
-                    </li>
-                    <li>
-                      <h5>
-                        authState:
-                        <a
-                          href="AuthState.html"
-                          class="tsd-signature-type"
-                          data-tsd-kind="Class"
-                          >AuthState</a
-                        >
-                      </h5>
-                    </li>
-                    <li>
-                      <h5>
-                        authService:
-                        <a
-                          href="AuthService.html"
-                          class="tsd-signature-type"
-                          data-tsd-kind="Class"
-                          >AuthService</a
-                        ><span class="tsd-signature-symbol">&lt;</span
-                        ><a
-                          href="../interfaces/AppState.html"
-                          class="tsd-signature-type"
-                          data-tsd-kind="Interface"
-                          >AppState</a
-                        ><span class="tsd-signature-symbol">&gt;</span>
-                      </h5>
-                    </li>
-                  </ul>
-                </div>
-                <h4 class="tsd-returns-title">
-                  Returns
-                  <a
-                    href="AuthHttpInterceptor.html"
-                    class="tsd-signature-type"
-                    data-tsd-kind="Class"
-                    >AuthHttpInterceptor</a
-                  >
-                </h4>
-                <aside class="tsd-sources">
-                  <ul>
-                    <li>
-                      Defined in
-                      <a
-                        href="https://github.com/auth0/auth0-angular/blob/014575f/projects/auth0-angular/src/lib/auth.interceptor.ts#L40"
-                        >projects/auth0-angular/src/lib/auth.interceptor.ts:40</a
-                      >
-                    </li>
-                  </ul>
-                </aside>
-              </li>
-            </ul>
+              <a
+                href="AuthorizationParams.html"
+                class="tsd-signature-type"
+                data-tsd-kind="Interface"
+                >AuthorizationParams</a
+              >
+            </div>
+            <div class="tsd-comment tsd-typography">
+              <p>
+                URL parameters that will be sent back to the Authorization
+                Server. This can be known parameters defined by Auth0 or custom
+                parameters that you define.
+              </p>
+            </div>
+            <aside class="tsd-sources">
+              <p>
+                Inherited from
+                <a href="PopupLoginOptions.html">PopupLoginOptions</a>.<a
+                  href="PopupLoginOptions.html#authorizationParams"
+                  >authorizationParams</a
+                >
+              </p>
+              <ul>
+                <li>
+                  Defined in
+                  node_modules/@auth0/auth0-spa-js/dist/typings/global.d.ts:98
+                </li>
+              </ul>
+            </aside>
           </section>
-        </section>
-        <section class="tsd-panel-group tsd-member-group">
-          <h2>Methods</h2>
           <section
-            class="tsd-panel tsd-member tsd-kind-method tsd-parent-kind-class"
+            class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-interface tsd-is-external"
           >
-            <a id="intercept" class="tsd-anchor"></a>
+            <a id="cacheMode" class="tsd-anchor"></a>
             <h3 class="tsd-anchor-link">
-              <span>intercept</span
+              <code class="tsd-tag ts-flagOptional">Optional</code>
+              <span>cache<wbr />Mode</span
               ><a
-                href="#intercept"
+                href="#cacheMode"
                 aria-label="Permalink"
                 class="tsd-anchor-icon"
                 ><svg
@@ -390,91 +273,31 @@
                   <use href="#icon-anchor-c"></use></svg
               ></a>
             </h3>
-            <ul class="tsd-signatures tsd-kind-method tsd-parent-kind-class">
-              <li
-                class="tsd-signature tsd-anchor-link"
-                id="intercept.intercept-1"
-              >
-                intercept<span class="tsd-signature-symbol">(</span>req<span
-                  class="tsd-signature-symbol"
-                  >: </span
-                ><span class="tsd-signature-type">HttpRequest</span
-                ><span class="tsd-signature-symbol">&lt;</span
-                ><span class="tsd-signature-type">any</span
-                ><span class="tsd-signature-symbol">&gt;</span>, next<span
-                  class="tsd-signature-symbol"
-                  >: </span
-                ><span class="tsd-signature-type">HttpHandler</span
-                ><span class="tsd-signature-symbol">)</span
-                ><span class="tsd-signature-symbol">: </span
-                ><span class="tsd-signature-type">Observable</span
-                ><span class="tsd-signature-symbol">&lt;</span
-                ><span class="tsd-signature-type">HttpEvent</span
-                ><span class="tsd-signature-symbol">&lt;</span
-                ><span class="tsd-signature-type">any</span
-                ><span class="tsd-signature-symbol">&gt;</span
-                ><span class="tsd-signature-symbol">&gt;</span
-                ><a
-                  href="#intercept.intercept-1"
-                  aria-label="Permalink"
-                  class="tsd-anchor-icon"
-                  ><svg
-                    class="icon icon-tabler icon-tabler-link"
-                    viewBox="0 0 24 24"
-                    stroke-width="2"
-                    stroke="currentColor"
-                    fill="none"
-                    stroke-linecap="round"
-                    stroke-linejoin="round"
-                  >
-                    <use href="#icon-anchor-a"></use>
-                    <use href="#icon-anchor-b"></use>
-                    <use href="#icon-anchor-c"></use></svg
-                ></a>
-              </li>
-              <li class="tsd-description">
-                <div class="tsd-parameters">
-                  <h4 class="tsd-parameters-title">Parameters</h4>
-                  <ul class="tsd-parameter-list">
-                    <li>
-                      <h5>
-                        req: <span class="tsd-signature-type">HttpRequest</span
-                        ><span class="tsd-signature-symbol">&lt;</span
-                        ><span class="tsd-signature-type">any</span
-                        ><span class="tsd-signature-symbol">&gt;</span>
-                      </h5>
-                    </li>
-                    <li>
-                      <h5>
-                        next:
-                        <span class="tsd-signature-type">HttpHandler</span>
-                      </h5>
-                    </li>
-                  </ul>
-                </div>
-                <h4 class="tsd-returns-title">
-                  Returns <span class="tsd-signature-type">Observable</span
-                  ><span class="tsd-signature-symbol">&lt;</span
-                  ><span class="tsd-signature-type">HttpEvent</span
-                  ><span class="tsd-signature-symbol">&lt;</span
-                  ><span class="tsd-signature-type">any</span
-                  ><span class="tsd-signature-symbol">&gt;</span
-                  ><span class="tsd-signature-symbol">&gt;</span>
-                </h4>
-                <aside class="tsd-sources">
-                  <p>Implementation of HttpInterceptor.intercept</p>
-                  <ul>
-                    <li>
-                      Defined in
-                      <a
-                        href="https://github.com/auth0/auth0-angular/blob/014575f/projects/auth0-angular/src/lib/auth.interceptor.ts#L47"
-                        >projects/auth0-angular/src/lib/auth.interceptor.ts:47</a
-                      >
-                    </li>
-                  </ul>
-                </aside>
-              </li>
-            </ul>
+            <div class="tsd-signature">
+              cache<wbr />Mode<span class="tsd-signature-symbol">?:</span>
+              <span class="tsd-signature-type">&quot;on&quot;</span
+              ><span class="tsd-signature-symbol"> | </span
+              ><span class="tsd-signature-type">&quot;off&quot;</span
+              ><span class="tsd-signature-symbol"> | </span
+              ><span class="tsd-signature-type">&quot;cache-only&quot;</span>
+            </div>
+            <div class="tsd-comment tsd-typography">
+              <p>
+                When <code>off</code>, ignores the cache and always sends a
+                request to Auth0. When <code>cache-only</code>, only reads from
+                the cache and never sends a request to Auth0. Defaults to
+                <code>on</code>, where it both reads from the cache and sends a
+                request to Auth0 as needed.
+              </p>
+            </div>
+            <aside class="tsd-sources">
+              <ul>
+                <li>
+                  Defined in
+                  node_modules/@auth0/auth0-spa-js/dist/typings/global.d.ts:356
+                </li>
+              </ul>
+            </aside>
           </section>
         </section>
       </div>
@@ -634,8 +457,8 @@
         </nav>
         <nav class="tsd-navigation secondary menu-sticky">
           <ul>
-            <li class="current tsd-kind-class">
-              <a href="AuthHttpInterceptor.html" class="tsd-index-link"
+            <li class="current tsd-kind-interface tsd-is-external">
+              <a href="GetTokenWithPopupOptions.html" class="tsd-index-link"
                 ><svg
                   class="tsd-kind-icon"
                   width="24"
@@ -644,26 +467,30 @@
                 >
                   <rect
                     fill="var(--color-icon-background)"
-                    stroke="var(--color-ts-class)"
+                    stroke="var(--color-ts-interface)"
                     stroke-width="1.5"
                     x="1"
                     y="1"
                     width="22"
                     height="22"
                     rx="6"
-                    id="icon-128-path"
+                    id="icon-256-path"
                   ></rect>
                   <path
-                    d="M11.898 16.1201C11.098 16.1201 10.466 15.8961 10.002 15.4481C9.53803 15.0001 9.30603 14.3841 9.30603 13.6001V9.64012C9.30603 8.85612 9.53803 8.24012 10.002 7.79212C10.466 7.34412 11.098 7.12012 11.898 7.12012C12.682 7.12012 13.306 7.34812 13.77 7.80412C14.234 8.25212 14.466 8.86412 14.466 9.64012H13.386C13.386 9.14412 13.254 8.76412 12.99 8.50012C12.734 8.22812 12.37 8.09212 11.898 8.09212C11.426 8.09212 11.054 8.22412 10.782 8.48812C10.518 8.75212 10.386 9.13212 10.386 9.62812V13.6001C10.386 14.0961 10.518 14.4801 10.782 14.7521C11.054 15.0161 11.426 15.1481 11.898 15.1481C12.37 15.1481 12.734 15.0161 12.99 14.7521C13.254 14.4801 13.386 14.0961 13.386 13.6001H14.466C14.466 14.3761 14.234 14.9921 13.77 15.4481C13.306 15.8961 12.682 16.1201 11.898 16.1201Z"
+                    d="M9.51 16V15.016H11.298V8.224H9.51V7.24H14.19V8.224H12.402V15.016H14.19V16H9.51Z"
                     fill="var(--color-text)"
-                    id="icon-128-text"
+                    id="icon-256-text"
                   ></path></svg
-                ><span>Auth<wbr />Http<wbr />Interceptor</span></a
+                ><span
+                  >Get<wbr />Token<wbr />With<wbr />Popup<wbr />Options</span
+                ></a
               >
               <ul>
-                <li class="tsd-kind-constructor tsd-parent-kind-class">
+                <li
+                  class="tsd-kind-property tsd-parent-kind-interface tsd-is-inherited tsd-is-external"
+                >
                   <a
-                    href="AuthHttpInterceptor.html#constructor"
+                    href="GetTokenWithPopupOptions.html#authorizationParams"
                     class="tsd-index-link"
                     ><svg
                       class="tsd-kind-icon"
@@ -671,14 +498,16 @@
                       height="24"
                       viewBox="0 0 24 24"
                     >
-                      <use href="#icon-512-path"></use>
-                      <use href="#icon-512-text"></use></svg
-                    >constructor</a
+                      <use href="#icon-1024-path"></use>
+                      <use href="#icon-1024-text"></use></svg
+                    >authorization<wbr />Params?</a
                   >
                 </li>
-                <li class="tsd-kind-method tsd-parent-kind-class">
+                <li
+                  class="tsd-kind-property tsd-parent-kind-interface tsd-is-external"
+                >
                   <a
-                    href="AuthHttpInterceptor.html#intercept"
+                    href="GetTokenWithPopupOptions.html#cacheMode"
                     class="tsd-index-link"
                     ><svg
                       class="tsd-kind-icon"
@@ -686,9 +515,9 @@
                       height="24"
                       viewBox="0 0 24 24"
                     >
-                      <use href="#icon-2048-path"></use>
-                      <use href="#icon-2048-text"></use></svg
-                    >intercept</a
+                      <use href="#icon-1024-path"></use>
+                      <use href="#icon-1024-text"></use></svg
+                    >cache<wbr />Mode?</a
                   >
                 </li>
               </ul>

--- a/docs/interfaces/HttpInterceptorRouteConfig.html
+++ b/docs/interfaces/HttpInterceptorRouteConfig.html
@@ -99,7 +99,7 @@
             <li>
               Defined in
               <a
-                href="https://github.com/auth0/auth0-angular/blob/560b670/projects/auth0-angular/src/lib/auth.config.ts#L51"
+                href="https://github.com/auth0/auth0-angular/blob/014575f/projects/auth0-angular/src/lib/auth.config.ts#L51"
                 >projects/auth0-angular/src/lib/auth.config.ts:51</a
               >
             </li>
@@ -270,7 +270,7 @@
                 <li>
                   Defined in
                   <a
-                    href="https://github.com/auth0/auth0-angular/blob/560b670/projects/auth0-angular/src/lib/auth.config.ts#L101"
+                    href="https://github.com/auth0/auth0-angular/blob/014575f/projects/auth0-angular/src/lib/auth.config.ts#L101"
                     >projects/auth0-angular/src/lib/auth.config.ts:101</a
                   >
                 </li>
@@ -319,7 +319,7 @@
                 <li>
                   Defined in
                   <a
-                    href="https://github.com/auth0/auth0-angular/blob/560b670/projects/auth0-angular/src/lib/auth.config.ts#L94"
+                    href="https://github.com/auth0/auth0-angular/blob/014575f/projects/auth0-angular/src/lib/auth.config.ts#L94"
                     >projects/auth0-angular/src/lib/auth.config.ts:94</a
                   >
                 </li>
@@ -353,7 +353,12 @@
             </h3>
             <div class="tsd-signature">
               token<wbr />Options<span class="tsd-signature-symbol">?:</span>
-              <span class="tsd-signature-type">GetTokenSilentlyOptions</span>
+              <a
+                href="GetTokenSilentlyOptions.html"
+                class="tsd-signature-type"
+                data-tsd-kind="Interface"
+                >GetTokenSilentlyOptions</a
+              >
             </div>
             <div class="tsd-comment tsd-typography">
               <p>
@@ -366,7 +371,7 @@
                 <li>
                   Defined in
                   <a
-                    href="https://github.com/auth0/auth0-angular/blob/560b670/projects/auth0-angular/src/lib/auth.config.ts#L85"
+                    href="https://github.com/auth0/auth0-angular/blob/014575f/projects/auth0-angular/src/lib/auth.config.ts#L85"
                     >projects/auth0-angular/src/lib/auth.config.ts:85</a
                   >
                 </li>
@@ -430,7 +435,7 @@
                 <li>
                   Defined in
                   <a
-                    href="https://github.com/auth0/auth0-angular/blob/560b670/projects/auth0-angular/src/lib/auth.config.ts#L67"
+                    href="https://github.com/auth0/auth0-angular/blob/014575f/projects/auth0-angular/src/lib/auth.config.ts#L67"
                     >projects/auth0-angular/src/lib/auth.config.ts:67</a
                   >
                 </li>
@@ -534,7 +539,7 @@
                 <li>
                   Defined in
                   <a
-                    href="https://github.com/auth0/auth0-angular/blob/560b670/projects/auth0-angular/src/lib/auth.config.ts#L79"
+                    href="https://github.com/auth0/auth0-angular/blob/014575f/projects/auth0-angular/src/lib/auth.config.ts#L79"
                     >projects/auth0-angular/src/lib/auth.config.ts:79</a
                   >
                 </li>

--- a/docs/interfaces/LogoutOptions.html
+++ b/docs/interfaces/LogoutOptions.html
@@ -100,7 +100,7 @@
             <li>
               Defined in
               <a
-                href="https://github.com/auth0/auth0-angular/blob/560b670/projects/auth0-angular/src/lib/interfaces.ts#L7"
+                href="https://github.com/auth0/auth0-angular/blob/014575f/projects/auth0-angular/src/lib/interfaces.ts#L7"
                 >projects/auth0-angular/src/lib/interfaces.ts:7</a
               >
             </li>

--- a/docs/interfaces/PopupConfigOptions.html
+++ b/docs/interfaces/PopupConfigOptions.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8" />
     <meta http-equiv="x-ua-compatible" content="IE=edge" />
-    <title>HttpInterceptorConfig | @auth0/auth0-angular</title>
+    <title>PopupConfigOptions | @auth0/auth0-angular</title>
     <meta name="description" content="Documentation for @auth0/auth0-angular" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <link rel="stylesheet" href="../assets/style.css" />
@@ -75,31 +75,21 @@
         <div class="tsd-page-title">
           <ul class="tsd-breadcrumb">
             <li><a href="../modules.html">@auth0/auth0-angular</a></li>
-            <li>
-              <a href="HttpInterceptorConfig.html">HttpInterceptorConfig</a>
-            </li>
+            <li><a href="PopupConfigOptions.html">PopupConfigOptions</a></li>
           </ul>
-          <h1>Interface HttpInterceptorConfig</h1>
+          <h1>Interface PopupConfigOptions</h1>
         </div>
-        <section class="tsd-panel tsd-comment">
-          <div class="tsd-comment tsd-typography">
-            <p>Configuration for the HttpInterceptor</p>
-          </div>
-        </section>
         <section class="tsd-panel tsd-hierarchy">
           <h4>Hierarchy</h4>
           <ul class="tsd-hierarchy">
-            <li><span class="target">HttpInterceptorConfig</span></li>
+            <li><span class="target">PopupConfigOptions</span></li>
           </ul>
         </section>
         <aside class="tsd-sources">
           <ul>
             <li>
               Defined in
-              <a
-                href="https://github.com/auth0/auth0-angular/blob/014575f/projects/auth0-angular/src/lib/auth.config.ts#L44"
-                >projects/auth0-angular/src/lib/auth.config.ts:44</a
-              >
+              node_modules/@auth0/auth0-spa-js/dist/typings/global.d.ts:290
             </li>
           </ul>
         </aside>
@@ -127,8 +117,8 @@
                   <h3 class="tsd-index-heading">Properties</h3>
                   <div class="tsd-index-list">
                     <a
-                      href="HttpInterceptorConfig.html#allowedList"
-                      class="tsd-index-link tsd-kind-property tsd-parent-kind-interface"
+                      href="PopupConfigOptions.html#popup"
+                      class="tsd-index-link tsd-kind-property tsd-parent-kind-interface tsd-is-external"
                       ><svg
                         class="tsd-kind-icon"
                         width="24"
@@ -151,7 +141,20 @@
                           fill="var(--color-text)"
                           id="icon-1024-text"
                         ></path></svg
-                      ><span>allowed<wbr />List</span></a
+                      ><span>popup?</span></a
+                    >
+                    <a
+                      href="PopupConfigOptions.html#timeoutInSeconds"
+                      class="tsd-index-link tsd-kind-property tsd-parent-kind-interface tsd-is-external"
+                      ><svg
+                        class="tsd-kind-icon"
+                        width="24"
+                        height="24"
+                        viewBox="0 0 24 24"
+                      >
+                        <use href="#icon-1024-path"></use>
+                        <use href="#icon-1024-text"></use></svg
+                      ><span>timeout<wbr />In<wbr />Seconds?</span></a
                     >
                   </div>
                 </section>
@@ -162,15 +165,13 @@
         <section class="tsd-panel-group tsd-member-group">
           <h2>Properties</h2>
           <section
-            class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-interface"
+            class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-interface tsd-is-external"
           >
-            <a id="allowedList" class="tsd-anchor"></a>
+            <a id="popup" class="tsd-anchor"></a>
             <h3 class="tsd-anchor-link">
-              <span>allowed<wbr />List</span
-              ><a
-                href="#allowedList"
-                aria-label="Permalink"
-                class="tsd-anchor-icon"
+              <code class="tsd-tag ts-flagOptional">Optional</code>
+              <span>popup</span
+              ><a href="#popup" aria-label="Permalink" class="tsd-anchor-icon"
                 ><svg
                   class="icon icon-tabler icon-tabler-link"
                   viewBox="0 0 24 24"
@@ -197,22 +198,68 @@
               ></a>
             </h3>
             <div class="tsd-signature">
-              allowed<wbr />List<span class="tsd-signature-symbol">:</span>
-              <a
-                href="../types/ApiRouteDefinition.html"
-                class="tsd-signature-type"
-                data-tsd-kind="Type alias"
-                >ApiRouteDefinition</a
-              ><span class="tsd-signature-symbol">[]</span>
+              popup<span class="tsd-signature-symbol">?:</span>
+              <span class="tsd-signature-type">any</span>
+            </div>
+            <div class="tsd-comment tsd-typography">
+              <p>
+                Accepts an already-created popup window to use. If not
+                specified, the SDK will create its own. This may be useful for
+                platforms like iOS that have security restrictions around when
+                popups can be invoked (e.g. from a user click event)
+              </p>
             </div>
             <aside class="tsd-sources">
               <ul>
                 <li>
                   Defined in
-                  <a
-                    href="https://github.com/auth0/auth0-angular/blob/014575f/projects/auth0-angular/src/lib/auth.config.ts#L45"
-                    >projects/auth0-angular/src/lib/auth.config.ts:45</a
-                  >
+                  node_modules/@auth0/auth0-spa-js/dist/typings/global.d.ts:301
+                </li>
+              </ul>
+            </aside>
+          </section>
+          <section
+            class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-interface tsd-is-external"
+          >
+            <a id="timeoutInSeconds" class="tsd-anchor"></a>
+            <h3 class="tsd-anchor-link">
+              <code class="tsd-tag ts-flagOptional">Optional</code>
+              <span>timeout<wbr />In<wbr />Seconds</span
+              ><a
+                href="#timeoutInSeconds"
+                aria-label="Permalink"
+                class="tsd-anchor-icon"
+                ><svg
+                  class="icon icon-tabler icon-tabler-link"
+                  viewBox="0 0 24 24"
+                  stroke-width="2"
+                  stroke="currentColor"
+                  fill="none"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                >
+                  <use href="#icon-anchor-a"></use>
+                  <use href="#icon-anchor-b"></use>
+                  <use href="#icon-anchor-c"></use></svg
+              ></a>
+            </h3>
+            <div class="tsd-signature">
+              timeout<wbr />In<wbr />Seconds<span class="tsd-signature-symbol"
+                >?:</span
+              >
+              <span class="tsd-signature-type">number</span>
+            </div>
+            <div class="tsd-comment tsd-typography">
+              <p>
+                The number of seconds to wait for a popup response before
+                throwing a timeout error. Defaults to 60s
+              </p>
+            </div>
+            <aside class="tsd-sources">
+              <ul>
+                <li>
+                  Defined in
+                  node_modules/@auth0/auth0-spa-js/dist/typings/global.d.ts:295
                 </li>
               </ul>
             </aside>
@@ -375,8 +422,8 @@
         </nav>
         <nav class="tsd-navigation secondary menu-sticky">
           <ul>
-            <li class="current tsd-kind-interface">
-              <a href="HttpInterceptorConfig.html" class="tsd-index-link"
+            <li class="current tsd-kind-interface tsd-is-external">
+              <a href="PopupConfigOptions.html" class="tsd-index-link"
                 ><svg
                   class="tsd-kind-icon"
                   width="24"
@@ -399,12 +446,29 @@
                     fill="var(--color-text)"
                     id="icon-256-text"
                   ></path></svg
-                ><span>Http<wbr />Interceptor<wbr />Config</span></a
+                ><span>Popup<wbr />Config<wbr />Options</span></a
               >
               <ul>
-                <li class="tsd-kind-property tsd-parent-kind-interface">
+                <li
+                  class="tsd-kind-property tsd-parent-kind-interface tsd-is-external"
+                >
+                  <a href="PopupConfigOptions.html#popup" class="tsd-index-link"
+                    ><svg
+                      class="tsd-kind-icon"
+                      width="24"
+                      height="24"
+                      viewBox="0 0 24 24"
+                    >
+                      <use href="#icon-1024-path"></use>
+                      <use href="#icon-1024-text"></use></svg
+                    >popup?</a
+                  >
+                </li>
+                <li
+                  class="tsd-kind-property tsd-parent-kind-interface tsd-is-external"
+                >
                   <a
-                    href="HttpInterceptorConfig.html#allowedList"
+                    href="PopupConfigOptions.html#timeoutInSeconds"
                     class="tsd-index-link"
                     ><svg
                       class="tsd-kind-icon"
@@ -414,7 +478,7 @@
                     >
                       <use href="#icon-1024-path"></use>
                       <use href="#icon-1024-text"></use></svg
-                    >allowed<wbr />List</a
+                    >timeout<wbr />In<wbr />Seconds?</a
                   >
                 </li>
               </ul>

--- a/docs/interfaces/PopupLoginOptions.html
+++ b/docs/interfaces/PopupLoginOptions.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8" />
     <meta http-equiv="x-ua-compatible" content="IE=edge" />
-    <title>HttpInterceptorConfig | @auth0/auth0-angular</title>
+    <title>PopupLoginOptions | @auth0/auth0-angular</title>
     <meta name="description" content="Documentation for @auth0/auth0-angular" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <link rel="stylesheet" href="../assets/style.css" />
@@ -75,31 +75,38 @@
         <div class="tsd-page-title">
           <ul class="tsd-breadcrumb">
             <li><a href="../modules.html">@auth0/auth0-angular</a></li>
-            <li>
-              <a href="HttpInterceptorConfig.html">HttpInterceptorConfig</a>
-            </li>
+            <li><a href="PopupLoginOptions.html">PopupLoginOptions</a></li>
           </ul>
-          <h1>Interface HttpInterceptorConfig</h1>
+          <h1>Interface PopupLoginOptions</h1>
         </div>
-        <section class="tsd-panel tsd-comment">
-          <div class="tsd-comment tsd-typography">
-            <p>Configuration for the HttpInterceptor</p>
-          </div>
-        </section>
         <section class="tsd-panel tsd-hierarchy">
           <h4>Hierarchy</h4>
           <ul class="tsd-hierarchy">
-            <li><span class="target">HttpInterceptorConfig</span></li>
+            <li>
+              <span class="tsd-signature-type">BaseLoginOptions</span>
+              <ul class="tsd-hierarchy">
+                <li>
+                  <span class="target">PopupLoginOptions</span>
+                  <ul class="tsd-hierarchy">
+                    <li>
+                      <a
+                        href="GetTokenWithPopupOptions.html"
+                        class="tsd-signature-type"
+                        data-tsd-kind="Interface"
+                        >GetTokenWithPopupOptions</a
+                      >
+                    </li>
+                  </ul>
+                </li>
+              </ul>
+            </li>
           </ul>
         </section>
         <aside class="tsd-sources">
           <ul>
             <li>
               Defined in
-              <a
-                href="https://github.com/auth0/auth0-angular/blob/014575f/projects/auth0-angular/src/lib/auth.config.ts#L44"
-                >projects/auth0-angular/src/lib/auth.config.ts:44</a
-              >
+              node_modules/@auth0/auth0-spa-js/dist/typings/global.d.ts:288
             </li>
           </ul>
         </aside>
@@ -127,8 +134,8 @@
                   <h3 class="tsd-index-heading">Properties</h3>
                   <div class="tsd-index-list">
                     <a
-                      href="HttpInterceptorConfig.html#allowedList"
-                      class="tsd-index-link tsd-kind-property tsd-parent-kind-interface"
+                      href="PopupLoginOptions.html#authorizationParams"
+                      class="tsd-index-link tsd-kind-property tsd-parent-kind-interface tsd-is-inherited tsd-is-external"
                       ><svg
                         class="tsd-kind-icon"
                         width="24"
@@ -151,7 +158,7 @@
                           fill="var(--color-text)"
                           id="icon-1024-text"
                         ></path></svg
-                      ><span>allowed<wbr />List</span></a
+                      ><span>authorization<wbr />Params?</span></a
                     >
                   </div>
                 </section>
@@ -162,13 +169,14 @@
         <section class="tsd-panel-group tsd-member-group">
           <h2>Properties</h2>
           <section
-            class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-interface"
+            class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-interface tsd-is-inherited tsd-is-external"
           >
-            <a id="allowedList" class="tsd-anchor"></a>
+            <a id="authorizationParams" class="tsd-anchor"></a>
             <h3 class="tsd-anchor-link">
-              <span>allowed<wbr />List</span
+              <code class="tsd-tag ts-flagOptional">Optional</code>
+              <span>authorization<wbr />Params</span
               ><a
-                href="#allowedList"
+                href="#authorizationParams"
                 aria-label="Permalink"
                 class="tsd-anchor-icon"
                 ><svg
@@ -197,22 +205,29 @@
               ></a>
             </h3>
             <div class="tsd-signature">
-              allowed<wbr />List<span class="tsd-signature-symbol">:</span>
+              authorization<wbr />Params<span class="tsd-signature-symbol"
+                >?:</span
+              >
               <a
-                href="../types/ApiRouteDefinition.html"
+                href="AuthorizationParams.html"
                 class="tsd-signature-type"
-                data-tsd-kind="Type alias"
-                >ApiRouteDefinition</a
-              ><span class="tsd-signature-symbol">[]</span>
+                data-tsd-kind="Interface"
+                >AuthorizationParams</a
+              >
+            </div>
+            <div class="tsd-comment tsd-typography">
+              <p>
+                URL parameters that will be sent back to the Authorization
+                Server. This can be known parameters defined by Auth0 or custom
+                parameters that you define.
+              </p>
             </div>
             <aside class="tsd-sources">
+              <p>Inherited from BaseLoginOptions.authorizationParams</p>
               <ul>
                 <li>
                   Defined in
-                  <a
-                    href="https://github.com/auth0/auth0-angular/blob/014575f/projects/auth0-angular/src/lib/auth.config.ts#L45"
-                    >projects/auth0-angular/src/lib/auth.config.ts:45</a
-                  >
+                  node_modules/@auth0/auth0-spa-js/dist/typings/global.d.ts:98
                 </li>
               </ul>
             </aside>
@@ -375,8 +390,8 @@
         </nav>
         <nav class="tsd-navigation secondary menu-sticky">
           <ul>
-            <li class="current tsd-kind-interface">
-              <a href="HttpInterceptorConfig.html" class="tsd-index-link"
+            <li class="current tsd-kind-interface tsd-is-external">
+              <a href="PopupLoginOptions.html" class="tsd-index-link"
                 ><svg
                   class="tsd-kind-icon"
                   width="24"
@@ -399,12 +414,14 @@
                     fill="var(--color-text)"
                     id="icon-256-text"
                   ></path></svg
-                ><span>Http<wbr />Interceptor<wbr />Config</span></a
+                ><span>Popup<wbr />Login<wbr />Options</span></a
               >
               <ul>
-                <li class="tsd-kind-property tsd-parent-kind-interface">
+                <li
+                  class="tsd-kind-property tsd-parent-kind-interface tsd-is-inherited tsd-is-external"
+                >
                   <a
-                    href="HttpInterceptorConfig.html#allowedList"
+                    href="PopupLoginOptions.html#authorizationParams"
                     class="tsd-index-link"
                     ><svg
                       class="tsd-kind-icon"
@@ -414,7 +431,7 @@
                     >
                       <use href="#icon-1024-path"></use>
                       <use href="#icon-1024-text"></use></svg
-                    >allowed<wbr />List</a
+                    >authorization<wbr />Params?</a
                   >
                 </li>
               </ul>

--- a/docs/interfaces/RedirectLoginOptions.html
+++ b/docs/interfaces/RedirectLoginOptions.html
@@ -114,7 +114,7 @@
             <li>
               Defined in
               <a
-                href="https://github.com/auth0/auth0-angular/blob/560b670/projects/auth0-angular/src/lib/interfaces.ts#L4"
+                href="https://github.com/auth0/auth0-angular/blob/014575f/projects/auth0-angular/src/lib/interfaces.ts#L4"
                 >projects/auth0-angular/src/lib/interfaces.ts:4</a
               >
             </li>
@@ -301,7 +301,12 @@
               authorization<wbr />Params<span class="tsd-signature-symbol"
                 >?:</span
               >
-              <span class="tsd-signature-type">AuthorizationParams</span>
+              <a
+                href="AuthorizationParams.html"
+                class="tsd-signature-type"
+                data-tsd-kind="Interface"
+                >AuthorizationParams</a
+              >
             </div>
             <div class="tsd-comment tsd-typography">
               <p>

--- a/docs/modules.html
+++ b/docs/modules.html
@@ -303,6 +303,47 @@
                   ><span>Auth<wbr />Config</span></a
                 >
                 <a
+                  href="interfaces/AuthorizationParams.html"
+                  class="tsd-index-link tsd-kind-interface tsd-is-external"
+                  ><svg
+                    class="tsd-kind-icon"
+                    width="24"
+                    height="24"
+                    viewBox="0 0 24 24"
+                  >
+                    <use href="#icon-256-path"></use>
+                    <use href="#icon-256-text"></use></svg
+                  ><span>Authorization<wbr />Params</span></a
+                >
+                <a
+                  href="interfaces/GetTokenSilentlyOptions.html"
+                  class="tsd-index-link tsd-kind-interface tsd-is-external"
+                  ><svg
+                    class="tsd-kind-icon"
+                    width="24"
+                    height="24"
+                    viewBox="0 0 24 24"
+                  >
+                    <use href="#icon-256-path"></use>
+                    <use href="#icon-256-text"></use></svg
+                  ><span>Get<wbr />Token<wbr />Silently<wbr />Options</span></a
+                >
+                <a
+                  href="interfaces/GetTokenWithPopupOptions.html"
+                  class="tsd-index-link tsd-kind-interface tsd-is-external"
+                  ><svg
+                    class="tsd-kind-icon"
+                    width="24"
+                    height="24"
+                    viewBox="0 0 24 24"
+                  >
+                    <use href="#icon-256-path"></use>
+                    <use href="#icon-256-text"></use></svg
+                  ><span
+                    >Get<wbr />Token<wbr />With<wbr />Popup<wbr />Options</span
+                  ></a
+                >
+                <a
                   href="interfaces/HttpInterceptorConfig.html"
                   class="tsd-index-link tsd-kind-interface"
                   ><svg
@@ -368,6 +409,32 @@
                     <use href="#icon-256-path"></use>
                     <use href="#icon-256-text"></use></svg
                   ><span>Logout<wbr />Options</span></a
+                >
+                <a
+                  href="interfaces/PopupConfigOptions.html"
+                  class="tsd-index-link tsd-kind-interface tsd-is-external"
+                  ><svg
+                    class="tsd-kind-icon"
+                    width="24"
+                    height="24"
+                    viewBox="0 0 24 24"
+                  >
+                    <use href="#icon-256-path"></use>
+                    <use href="#icon-256-text"></use></svg
+                  ><span>Popup<wbr />Config<wbr />Options</span></a
+                >
+                <a
+                  href="interfaces/PopupLoginOptions.html"
+                  class="tsd-index-link tsd-kind-interface tsd-is-external"
+                  ><svg
+                    class="tsd-kind-icon"
+                    width="24"
+                    height="24"
+                    viewBox="0 0 24 24"
+                  >
+                    <use href="#icon-256-path"></use>
+                    <use href="#icon-256-text"></use></svg
+                  ><span>Popup<wbr />Login<wbr />Options</span></a
                 >
                 <a
                   href="interfaces/RedirectLoginOptions.html"
@@ -836,6 +903,51 @@
                 >Auth<wbr />Config</a
               >
             </li>
+            <li class="tsd-kind-interface tsd-is-external">
+              <a
+                href="interfaces/AuthorizationParams.html"
+                class="tsd-index-link"
+                ><svg
+                  class="tsd-kind-icon"
+                  width="24"
+                  height="24"
+                  viewBox="0 0 24 24"
+                >
+                  <use href="#icon-256-path"></use>
+                  <use href="#icon-256-text"></use></svg
+                >Authorization<wbr />Params</a
+              >
+            </li>
+            <li class="tsd-kind-interface tsd-is-external">
+              <a
+                href="interfaces/GetTokenSilentlyOptions.html"
+                class="tsd-index-link"
+                ><svg
+                  class="tsd-kind-icon"
+                  width="24"
+                  height="24"
+                  viewBox="0 0 24 24"
+                >
+                  <use href="#icon-256-path"></use>
+                  <use href="#icon-256-text"></use></svg
+                >Get<wbr />Token<wbr />Silently<wbr />Options</a
+              >
+            </li>
+            <li class="tsd-kind-interface tsd-is-external">
+              <a
+                href="interfaces/GetTokenWithPopupOptions.html"
+                class="tsd-index-link"
+                ><svg
+                  class="tsd-kind-icon"
+                  width="24"
+                  height="24"
+                  viewBox="0 0 24 24"
+                >
+                  <use href="#icon-256-path"></use>
+                  <use href="#icon-256-text"></use></svg
+                >Get<wbr />Token<wbr />With<wbr />Popup<wbr />Options</a
+              >
+            </li>
             <li class="tsd-kind-interface">
               <a
                 href="interfaces/HttpInterceptorConfig.html"
@@ -903,6 +1015,34 @@
                   <use href="#icon-256-path"></use>
                   <use href="#icon-256-text"></use></svg
                 >Logout<wbr />Options</a
+              >
+            </li>
+            <li class="tsd-kind-interface tsd-is-external">
+              <a
+                href="interfaces/PopupConfigOptions.html"
+                class="tsd-index-link"
+                ><svg
+                  class="tsd-kind-icon"
+                  width="24"
+                  height="24"
+                  viewBox="0 0 24 24"
+                >
+                  <use href="#icon-256-path"></use>
+                  <use href="#icon-256-text"></use></svg
+                >Popup<wbr />Config<wbr />Options</a
+              >
+            </li>
+            <li class="tsd-kind-interface tsd-is-external">
+              <a href="interfaces/PopupLoginOptions.html" class="tsd-index-link"
+                ><svg
+                  class="tsd-kind-icon"
+                  width="24"
+                  height="24"
+                  viewBox="0 0 24 24"
+                >
+                  <use href="#icon-256-path"></use>
+                  <use href="#icon-256-text"></use></svg
+                >Popup<wbr />Login<wbr />Options</a
               >
             </li>
             <li class="tsd-kind-interface">

--- a/docs/types/ApiRouteDefinition.html
+++ b/docs/types/ApiRouteDefinition.html
@@ -103,7 +103,7 @@
             <li>
               Defined in
               <a
-                href="https://github.com/auth0/auth0-angular/blob/560b670/projects/auth0-angular/src/lib/auth.config.ts#L28"
+                href="https://github.com/auth0/auth0-angular/blob/014575f/projects/auth0-angular/src/lib/auth.config.ts#L28"
                 >projects/auth0-angular/src/lib/auth.config.ts:28</a
               >
             </li>
@@ -481,6 +481,51 @@
                 >Auth<wbr />Config</a
               >
             </li>
+            <li class="tsd-kind-interface tsd-is-external">
+              <a
+                href="../interfaces/AuthorizationParams.html"
+                class="tsd-index-link"
+                ><svg
+                  class="tsd-kind-icon"
+                  width="24"
+                  height="24"
+                  viewBox="0 0 24 24"
+                >
+                  <use href="#icon-256-path"></use>
+                  <use href="#icon-256-text"></use></svg
+                >Authorization<wbr />Params</a
+              >
+            </li>
+            <li class="tsd-kind-interface tsd-is-external">
+              <a
+                href="../interfaces/GetTokenSilentlyOptions.html"
+                class="tsd-index-link"
+                ><svg
+                  class="tsd-kind-icon"
+                  width="24"
+                  height="24"
+                  viewBox="0 0 24 24"
+                >
+                  <use href="#icon-256-path"></use>
+                  <use href="#icon-256-text"></use></svg
+                >Get<wbr />Token<wbr />Silently<wbr />Options</a
+              >
+            </li>
+            <li class="tsd-kind-interface tsd-is-external">
+              <a
+                href="../interfaces/GetTokenWithPopupOptions.html"
+                class="tsd-index-link"
+                ><svg
+                  class="tsd-kind-icon"
+                  width="24"
+                  height="24"
+                  viewBox="0 0 24 24"
+                >
+                  <use href="#icon-256-path"></use>
+                  <use href="#icon-256-text"></use></svg
+                >Get<wbr />Token<wbr />With<wbr />Popup<wbr />Options</a
+              >
+            </li>
             <li class="tsd-kind-interface">
               <a
                 href="../interfaces/HttpInterceptorConfig.html"
@@ -548,6 +593,36 @@
                   <use href="#icon-256-path"></use>
                   <use href="#icon-256-text"></use></svg
                 >Logout<wbr />Options</a
+              >
+            </li>
+            <li class="tsd-kind-interface tsd-is-external">
+              <a
+                href="../interfaces/PopupConfigOptions.html"
+                class="tsd-index-link"
+                ><svg
+                  class="tsd-kind-icon"
+                  width="24"
+                  height="24"
+                  viewBox="0 0 24 24"
+                >
+                  <use href="#icon-256-path"></use>
+                  <use href="#icon-256-text"></use></svg
+                >Popup<wbr />Config<wbr />Options</a
+              >
+            </li>
+            <li class="tsd-kind-interface tsd-is-external">
+              <a
+                href="../interfaces/PopupLoginOptions.html"
+                class="tsd-index-link"
+                ><svg
+                  class="tsd-kind-icon"
+                  width="24"
+                  height="24"
+                  viewBox="0 0 24 24"
+                >
+                  <use href="#icon-256-path"></use>
+                  <use href="#icon-256-text"></use></svg
+                >Popup<wbr />Login<wbr />Options</a
               >
             </li>
             <li class="tsd-kind-interface">

--- a/docs/types/Cacheable.html
+++ b/docs/types/Cacheable.html
@@ -465,6 +465,51 @@
                 >Auth<wbr />Config</a
               >
             </li>
+            <li class="tsd-kind-interface tsd-is-external">
+              <a
+                href="../interfaces/AuthorizationParams.html"
+                class="tsd-index-link"
+                ><svg
+                  class="tsd-kind-icon"
+                  width="24"
+                  height="24"
+                  viewBox="0 0 24 24"
+                >
+                  <use href="#icon-256-path"></use>
+                  <use href="#icon-256-text"></use></svg
+                >Authorization<wbr />Params</a
+              >
+            </li>
+            <li class="tsd-kind-interface tsd-is-external">
+              <a
+                href="../interfaces/GetTokenSilentlyOptions.html"
+                class="tsd-index-link"
+                ><svg
+                  class="tsd-kind-icon"
+                  width="24"
+                  height="24"
+                  viewBox="0 0 24 24"
+                >
+                  <use href="#icon-256-path"></use>
+                  <use href="#icon-256-text"></use></svg
+                >Get<wbr />Token<wbr />Silently<wbr />Options</a
+              >
+            </li>
+            <li class="tsd-kind-interface tsd-is-external">
+              <a
+                href="../interfaces/GetTokenWithPopupOptions.html"
+                class="tsd-index-link"
+                ><svg
+                  class="tsd-kind-icon"
+                  width="24"
+                  height="24"
+                  viewBox="0 0 24 24"
+                >
+                  <use href="#icon-256-path"></use>
+                  <use href="#icon-256-text"></use></svg
+                >Get<wbr />Token<wbr />With<wbr />Popup<wbr />Options</a
+              >
+            </li>
             <li class="tsd-kind-interface">
               <a
                 href="../interfaces/HttpInterceptorConfig.html"
@@ -532,6 +577,36 @@
                   <use href="#icon-256-path"></use>
                   <use href="#icon-256-text"></use></svg
                 >Logout<wbr />Options</a
+              >
+            </li>
+            <li class="tsd-kind-interface tsd-is-external">
+              <a
+                href="../interfaces/PopupConfigOptions.html"
+                class="tsd-index-link"
+                ><svg
+                  class="tsd-kind-icon"
+                  width="24"
+                  height="24"
+                  viewBox="0 0 24 24"
+                >
+                  <use href="#icon-256-path"></use>
+                  <use href="#icon-256-text"></use></svg
+                >Popup<wbr />Config<wbr />Options</a
+              >
+            </li>
+            <li class="tsd-kind-interface tsd-is-external">
+              <a
+                href="../interfaces/PopupLoginOptions.html"
+                class="tsd-index-link"
+                ><svg
+                  class="tsd-kind-icon"
+                  width="24"
+                  height="24"
+                  viewBox="0 0 24 24"
+                >
+                  <use href="#icon-256-path"></use>
+                  <use href="#icon-256-text"></use></svg
+                >Popup<wbr />Login<wbr />Options</a
               >
             </li>
             <li class="tsd-kind-interface">

--- a/docs/variables/Auth0ClientService.html
+++ b/docs/variables/Auth0ClientService.html
@@ -98,7 +98,7 @@
             <li>
               Defined in
               <a
-                href="https://github.com/auth0/auth0-angular/blob/560b670/projects/auth0-angular/src/lib/auth.client.ts#L29"
+                href="https://github.com/auth0/auth0-angular/blob/014575f/projects/auth0-angular/src/lib/auth.client.ts#L29"
                 >projects/auth0-angular/src/lib/auth.client.ts:29</a
               >
             </li>
@@ -476,6 +476,51 @@
                 >Auth<wbr />Config</a
               >
             </li>
+            <li class="tsd-kind-interface tsd-is-external">
+              <a
+                href="../interfaces/AuthorizationParams.html"
+                class="tsd-index-link"
+                ><svg
+                  class="tsd-kind-icon"
+                  width="24"
+                  height="24"
+                  viewBox="0 0 24 24"
+                >
+                  <use href="#icon-256-path"></use>
+                  <use href="#icon-256-text"></use></svg
+                >Authorization<wbr />Params</a
+              >
+            </li>
+            <li class="tsd-kind-interface tsd-is-external">
+              <a
+                href="../interfaces/GetTokenSilentlyOptions.html"
+                class="tsd-index-link"
+                ><svg
+                  class="tsd-kind-icon"
+                  width="24"
+                  height="24"
+                  viewBox="0 0 24 24"
+                >
+                  <use href="#icon-256-path"></use>
+                  <use href="#icon-256-text"></use></svg
+                >Get<wbr />Token<wbr />Silently<wbr />Options</a
+              >
+            </li>
+            <li class="tsd-kind-interface tsd-is-external">
+              <a
+                href="../interfaces/GetTokenWithPopupOptions.html"
+                class="tsd-index-link"
+                ><svg
+                  class="tsd-kind-icon"
+                  width="24"
+                  height="24"
+                  viewBox="0 0 24 24"
+                >
+                  <use href="#icon-256-path"></use>
+                  <use href="#icon-256-text"></use></svg
+                >Get<wbr />Token<wbr />With<wbr />Popup<wbr />Options</a
+              >
+            </li>
             <li class="tsd-kind-interface">
               <a
                 href="../interfaces/HttpInterceptorConfig.html"
@@ -543,6 +588,36 @@
                   <use href="#icon-256-path"></use>
                   <use href="#icon-256-text"></use></svg
                 >Logout<wbr />Options</a
+              >
+            </li>
+            <li class="tsd-kind-interface tsd-is-external">
+              <a
+                href="../interfaces/PopupConfigOptions.html"
+                class="tsd-index-link"
+                ><svg
+                  class="tsd-kind-icon"
+                  width="24"
+                  height="24"
+                  viewBox="0 0 24 24"
+                >
+                  <use href="#icon-256-path"></use>
+                  <use href="#icon-256-text"></use></svg
+                >Popup<wbr />Config<wbr />Options</a
+              >
+            </li>
+            <li class="tsd-kind-interface tsd-is-external">
+              <a
+                href="../interfaces/PopupLoginOptions.html"
+                class="tsd-index-link"
+                ><svg
+                  class="tsd-kind-icon"
+                  width="24"
+                  height="24"
+                  viewBox="0 0 24 24"
+                >
+                  <use href="#icon-256-path"></use>
+                  <use href="#icon-256-text"></use></svg
+                >Popup<wbr />Login<wbr />Options</a
               >
             </li>
             <li class="tsd-kind-interface">

--- a/docs/variables/AuthConfigService.html
+++ b/docs/variables/AuthConfigService.html
@@ -113,7 +113,7 @@
             <li>
               Defined in
               <a
-                href="https://github.com/auth0/auth0-angular/blob/560b670/projects/auth0-angular/src/lib/auth.config.ts#L235"
+                href="https://github.com/auth0/auth0-angular/blob/014575f/projects/auth0-angular/src/lib/auth.config.ts#L235"
                 >projects/auth0-angular/src/lib/auth.config.ts:235</a
               >
             </li>
@@ -491,6 +491,51 @@
                 >Auth<wbr />Config</a
               >
             </li>
+            <li class="tsd-kind-interface tsd-is-external">
+              <a
+                href="../interfaces/AuthorizationParams.html"
+                class="tsd-index-link"
+                ><svg
+                  class="tsd-kind-icon"
+                  width="24"
+                  height="24"
+                  viewBox="0 0 24 24"
+                >
+                  <use href="#icon-256-path"></use>
+                  <use href="#icon-256-text"></use></svg
+                >Authorization<wbr />Params</a
+              >
+            </li>
+            <li class="tsd-kind-interface tsd-is-external">
+              <a
+                href="../interfaces/GetTokenSilentlyOptions.html"
+                class="tsd-index-link"
+                ><svg
+                  class="tsd-kind-icon"
+                  width="24"
+                  height="24"
+                  viewBox="0 0 24 24"
+                >
+                  <use href="#icon-256-path"></use>
+                  <use href="#icon-256-text"></use></svg
+                >Get<wbr />Token<wbr />Silently<wbr />Options</a
+              >
+            </li>
+            <li class="tsd-kind-interface tsd-is-external">
+              <a
+                href="../interfaces/GetTokenWithPopupOptions.html"
+                class="tsd-index-link"
+                ><svg
+                  class="tsd-kind-icon"
+                  width="24"
+                  height="24"
+                  viewBox="0 0 24 24"
+                >
+                  <use href="#icon-256-path"></use>
+                  <use href="#icon-256-text"></use></svg
+                >Get<wbr />Token<wbr />With<wbr />Popup<wbr />Options</a
+              >
+            </li>
             <li class="tsd-kind-interface">
               <a
                 href="../interfaces/HttpInterceptorConfig.html"
@@ -558,6 +603,36 @@
                   <use href="#icon-256-path"></use>
                   <use href="#icon-256-text"></use></svg
                 >Logout<wbr />Options</a
+              >
+            </li>
+            <li class="tsd-kind-interface tsd-is-external">
+              <a
+                href="../interfaces/PopupConfigOptions.html"
+                class="tsd-index-link"
+                ><svg
+                  class="tsd-kind-icon"
+                  width="24"
+                  height="24"
+                  viewBox="0 0 24 24"
+                >
+                  <use href="#icon-256-path"></use>
+                  <use href="#icon-256-text"></use></svg
+                >Popup<wbr />Config<wbr />Options</a
+              >
+            </li>
+            <li class="tsd-kind-interface tsd-is-external">
+              <a
+                href="../interfaces/PopupLoginOptions.html"
+                class="tsd-index-link"
+                ><svg
+                  class="tsd-kind-icon"
+                  width="24"
+                  height="24"
+                  viewBox="0 0 24 24"
+                >
+                  <use href="#icon-256-path"></use>
+                  <use href="#icon-256-text"></use></svg
+                >Popup<wbr />Login<wbr />Options</a
               >
             </li>
             <li class="tsd-kind-interface">

--- a/projects/auth0-angular/src/public-api.ts
+++ b/projects/auth0-angular/src/public-api.ts
@@ -12,10 +12,15 @@ export * from './lib/auth.state';
 export * from './lib/interfaces';
 
 export {
+  AuthorizationParams,
+  PopupLoginOptions,
+  PopupConfigOptions,
+  GetTokenWithPopupOptions,
+  GetTokenSilentlyOptions,
   ICache,
   Cacheable,
   LocalStorageCache,
   InMemoryCache,
   IdToken,
-  User
+  User,
 } from '@auth0/auth0-spa-js';


### PR DESCRIPTION
### Description

This updates the links in the readme, and consequently then adds some types to be exported from spa-js so that the generated documentation includes pages for interfaces such as `AuthorizationParams` and `PopupLoginOptions` (and others)

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not the default branch
