### PR TITLE
Ensure AuthConfigService is exported before AuthClientConfig

### DIFF
--- a/projects/auth0-angular/src/lib/auth.config.ts
+++ b/projects/auth0-angular/src/lib/auth.config.ts
@@ -194,6 +194,22 @@ export interface AppState {
  * ```
  *
  */
+
+/**
+ * Injection token for accessing configuration.
+ *
+ * @usageNotes
+ *
+ * Use the `Inject` decorator to access the configuration from a service or component:
+ *
+ * ```
+ * class MyService(@Inject(AuthConfigService) config: AuthConfig) {}
+ * ```
+ */
+export const AuthConfigService = new InjectionToken<AuthConfig>(
+  'auth0-angular.config'
+);
+
 @Injectable({ providedIn: 'root' })
 export class AuthClientConfig {
   private config?: AuthConfig;
@@ -220,18 +236,3 @@ export class AuthClientConfig {
     return this.config as AuthConfig;
   }
 }
-
-/**
- * Injection token for accessing configuration.
- *
- * @usageNotes
- *
- * Use the `Inject` decorator to access the configuration from a service or component:
- *
- * ```
- * class MyService(@Inject(AuthConfigService) config: AuthConfig) {}
- * ```
- */
-export const AuthConfigService = new InjectionToken<AuthConfig>(
-  'auth0-angular.config'
-);


### PR DESCRIPTION
### Description

Jest complains because of the order we export both AuthConfigService and AuthClientConfig.


### References

Closes #412 

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not the default branch
