### PR TITLE
Ensure allowAnonymous works with missing_refresh_token

### DIFF
--- a/projects/auth0-angular/src/lib/auth.interceptor.spec.ts
+++ b/projects/auth0-angular/src/lib/auth.interceptor.spec.ts
@@ -165,7 +165,7 @@ describe('The Auth HTTP Interceptor', () => {
     it('pass through and do not have access tokens attached', fakeAsync(async (
       done: () => void
     ) => {
-      config.httpInterceptor = (null as unknown) as HttpInterceptorConfig;
+      config.httpInterceptor = null as unknown as HttpInterceptorConfig;
       await assertPassThruApiCallTo('https://my-api.com/api/public', done);
     }));
   });
@@ -310,9 +310,9 @@ describe('The Auth HTTP Interceptor', () => {
     it('does not execute HTTP call when not able to retrieve a token', fakeAsync(async (
       done: () => void
     ) => {
-      ((auth0Client.getTokenSilently as unknown) as jest.SpyInstance).mockReturnValue(
-        throwError({ error: 'login_required' })
-      );
+      (
+        auth0Client.getTokenSilently as unknown as jest.SpyInstance
+      ).mockReturnValue(throwError({ error: 'login_required' }));
 
       httpClient.request('get', 'https://my-api.com/api/calendar').subscribe({
         error: (err) => expect(err).toEqual({ error: 'login_required' }),
@@ -327,9 +327,19 @@ describe('The Auth HTTP Interceptor', () => {
     it('does execute HTTP call when not able to retrieve a token but allowAnonymous is set to true', fakeAsync(async (
       done: () => void
     ) => {
-      ((auth0Client.getTokenSilently as unknown) as jest.SpyInstance).mockReturnValue(
-        throwError({ error: 'login_required' })
-      );
+      (
+        auth0Client.getTokenSilently as unknown as jest.SpyInstance
+      ).mockReturnValue(throwError({ error: 'login_required' }));
+
+      await assertPassThruApiCallTo('https://my-api.com/api/orders', done);
+    }));
+
+    it('does execute HTTP call when missing_refresh_token but allowAnonymous is set to true', fakeAsync(async (
+      done: () => void
+    ) => {
+      (
+        auth0Client.getTokenSilently as unknown as jest.SpyInstance
+      ).mockReturnValue(throwError({ error: 'missing_refresh_token' }));
 
       await assertPassThruApiCallTo('https://my-api.com/api/orders', done);
     }));
@@ -337,9 +347,9 @@ describe('The Auth HTTP Interceptor', () => {
     it('emit error when not able to retrieve a token but allowAnonymous is set to false', fakeAsync(async (
       done: () => void
     ) => {
-      ((auth0Client.getTokenSilently as unknown) as jest.SpyInstance).mockRejectedValue(
-        { error: 'login_required' }
-      );
+      (
+        auth0Client.getTokenSilently as unknown as jest.SpyInstance
+      ).mockRejectedValue({ error: 'login_required' });
 
       httpClient.request('get', 'https://my-api.com/api/calendar').subscribe({
         error: (err) => expect(err).toEqual({ error: 'login_required' }),
@@ -354,9 +364,19 @@ describe('The Auth HTTP Interceptor', () => {
     }));
 
     it('does not emit error when not able to retrieve a token but allowAnonymous is set to true', fakeAsync(async () => {
-      ((auth0Client.getTokenSilently as unknown) as jest.SpyInstance).mockRejectedValue(
-        { error: 'login_required' }
-      );
+      (
+        auth0Client.getTokenSilently as unknown as jest.SpyInstance
+      ).mockRejectedValue({ error: 'login_required' });
+
+      await assertPassThruApiCallTo('https://my-api.com/api/orders', () => {
+        expect(authState.setError).not.toHaveBeenCalled();
+      });
+    }));
+
+    it('does not emit error when missing_refresh_token but allowAnonymous is set to true', fakeAsync(async () => {
+      (
+        auth0Client.getTokenSilently as unknown as jest.SpyInstance
+      ).mockRejectedValue({ error: 'missing_refresh_token' });
 
       await assertPassThruApiCallTo('https://my-api.com/api/orders', () => {
         expect(authState.setError).not.toHaveBeenCalled();

--- a/projects/auth0-angular/src/lib/auth.interceptor.ts
+++ b/projects/auth0-angular/src/lib/auth.interceptor.ts
@@ -31,9 +31,10 @@ import { Auth0ClientService } from './auth.client';
 import { AuthState } from './auth.state';
 import { AuthService } from './auth.service';
 
-const waitUntil = <TSignal>(signal$: Observable<TSignal>) => <TSource>(
-  source$: Observable<TSource>
-) => source$.pipe(mergeMap((value) => signal$.pipe(first(), mapTo(value))));
+const waitUntil =
+  <TSignal>(signal$: Observable<TSignal>) =>
+  <TSource>(source$: Observable<TSource>) =>
+    source$.pipe(mergeMap((value) => signal$.pipe(first(), mapTo(value))));
 
 @Injectable()
 export class AuthHttpInterceptor implements HttpInterceptor {
@@ -41,7 +42,7 @@ export class AuthHttpInterceptor implements HttpInterceptor {
     private configFactory: AuthClientConfig,
     @Inject(Auth0ClientService) private auth0Client: Auth0Client,
     private authState: AuthState,
-    private authService: AuthService,
+    private authService: AuthService
   ) {}
 
   intercept(
@@ -54,7 +55,7 @@ export class AuthHttpInterceptor implements HttpInterceptor {
     }
 
     const isLoaded$ = this.authService.isLoading$.pipe(
-      filter((isLoading) => !isLoading),
+      filter((isLoading) => !isLoading)
     );
 
     return this.findMatchingRoute(req, config.httpInterceptor).pipe(
@@ -207,7 +208,9 @@ export class AuthHttpInterceptor implements HttpInterceptor {
       !!route &&
       isHttpInterceptorRouteConfig(route) &&
       !!route.allowAnonymous &&
-      ['login_required', 'consent_required'].includes(err.error)
+      ['login_required', 'consent_required', 'missing_refresh_token'].includes(
+        err.error
+      )
     );
   }
 }


### PR DESCRIPTION
### Description

Currently, allowAnonymous does not work when the SDK throws a MissingRefreshToken Error. This PR ensures the absence of a refresh token still allows requests to go through when allowAnonymous is set to true.


### References

Closes #429 

### Testing

- [x] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not the default branch
