### PR TITLE
Do not crash when getTokenSilently returns null

### DIFF
--- a/projects/auth0-angular/src/lib/auth.service.spec.ts
+++ b/projects/auth0-angular/src/lib/auth.service.spec.ts
@@ -776,6 +776,20 @@ describe('AuthService', () => {
         });
     });
 
+    it('should null when nothing in cache', (done) => {
+      ((auth0Client.getTokenSilently as unknown) as jest.SpyInstance).mockResolvedValue(
+        null
+      );
+
+      const service = createService();
+      service
+        .getAccessTokenSilently()
+        .subscribe((token) => {
+          expect(token).toBeNull();
+          done();
+        });
+    });
+
     it('should record errors in the error$ observable', (done) => {
       const errorObj = new Error('An error has occured');
 

--- a/projects/auth0-angular/src/lib/auth.service.ts
+++ b/projects/auth0-angular/src/lib/auth.service.ts
@@ -41,7 +41,8 @@ import { LogoutOptions, RedirectLoginOptions } from './interfaces';
   providedIn: 'root',
 })
 export class AuthService<TAppState extends AppState = AppState>
-  implements OnDestroy {
+  implements OnDestroy
+{
   private appStateSubject$ = new ReplaySubject<TAppState>(1);
 
   // https://stackoverflow.com/a/41177163
@@ -242,11 +243,13 @@ export class AuthService<TAppState extends AppState = AppState>
           ? client.getTokenSilently({ ...options, detailedResponse: true })
           : client.getTokenSilently(options)
       ),
-      tap((token) =>
-        this.authState.setAccessToken(
-          typeof token === 'string' ? token : token.access_token
-        )
-      ),
+      tap((token) => {
+        if (token) {
+          this.authState.setAccessToken(
+            typeof token === 'string' ? token : token.access_token
+          );
+        }
+      }),
       catchError((error) => {
         this.authState.setError(error);
         this.authState.refresh();


### PR DESCRIPTION
### Description

When nothing was found in the cache, the getAccessTokenSilently would crash.

### References

Closes #457 

### Testing

- [x] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not the default branch
