### PR TITLE
Release v2.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Change Log
 
+## [v2.2.1](https://github.com/auth0/auth0-angular/tree/v2.2.1) (2023-07-24)
+
+[Full Changelog](https://github.com/auth0/auth0-angular/compare/v2.2.0...v2.2.1)
+
+**Fixed**
+
+- Do not crash when getTokenSilently returns null [\#458](https://github.com/auth0/auth0-angular/pull/458) ([frederikprijck](https://github.com/frederikprijck))
+
 ## [v2.2.0](https://github.com/auth0/auth0-angular/tree/v2.2.0) (2023-07-13)
 
 [Full Changelog](https://github.com/auth0/auth0-angular/compare/v2.1.0...v2.2.0)

--- a/docs/classes/Auth0ClientFactory.html
+++ b/docs/classes/Auth0ClientFactory.html
@@ -90,7 +90,7 @@
             <li>
               Defined in
               <a
-                href="https://github.com/auth0/auth0-angular/blob/585220b/projects/auth0-angular/src/lib/auth.client.ts#L6"
+                href="https://github.com/auth0/auth0-angular/blob/d11191f/projects/auth0-angular/src/lib/auth.client.ts#L6"
                 >projects/auth0-angular/src/lib/auth.client.ts:6</a
               >
             </li>
@@ -355,7 +355,7 @@
                     <li>
                       Defined in
                       <a
-                        href="https://github.com/auth0/auth0-angular/blob/585220b/projects/auth0-angular/src/lib/auth.client.ts#L7"
+                        href="https://github.com/auth0/auth0-angular/blob/d11191f/projects/auth0-angular/src/lib/auth.client.ts#L7"
                         >projects/auth0-angular/src/lib/auth.client.ts:7</a
                       >
                     </li>

--- a/docs/classes/AuthClientConfig.html
+++ b/docs/classes/AuthClientConfig.html
@@ -104,7 +104,7 @@
             <li>
               Defined in
               <a
-                href="https://github.com/auth0/auth0-angular/blob/585220b/projects/auth0-angular/src/lib/auth.config.ts#L213"
+                href="https://github.com/auth0/auth0-angular/blob/d11191f/projects/auth0-angular/src/lib/auth.config.ts#L213"
                 >projects/auth0-angular/src/lib/auth.config.ts:213</a
               >
             </li>
@@ -321,7 +321,7 @@
                     <li>
                       Defined in
                       <a
-                        href="https://github.com/auth0/auth0-angular/blob/585220b/projects/auth0-angular/src/lib/auth.config.ts#L216"
+                        href="https://github.com/auth0/auth0-angular/blob/d11191f/projects/auth0-angular/src/lib/auth.config.ts#L216"
                         >projects/auth0-angular/src/lib/auth.config.ts:216</a
                       >
                     </li>
@@ -403,7 +403,7 @@
                     <li>
                       Defined in
                       <a
-                        href="https://github.com/auth0/auth0-angular/blob/585220b/projects/auth0-angular/src/lib/auth.config.ts#L234"
+                        href="https://github.com/auth0/auth0-angular/blob/d11191f/projects/auth0-angular/src/lib/auth.config.ts#L234"
                         >projects/auth0-angular/src/lib/auth.config.ts:234</a
                       >
                     </li>
@@ -498,7 +498,7 @@
                     <li>
                       Defined in
                       <a
-                        href="https://github.com/auth0/auth0-angular/blob/585220b/projects/auth0-angular/src/lib/auth.config.ts#L227"
+                        href="https://github.com/auth0/auth0-angular/blob/d11191f/projects/auth0-angular/src/lib/auth.config.ts#L227"
                         >projects/auth0-angular/src/lib/auth.config.ts:227</a
                       >
                     </li>

--- a/docs/classes/AuthGuard.html
+++ b/docs/classes/AuthGuard.html
@@ -98,7 +98,7 @@
             <li>
               Defined in
               <a
-                href="https://github.com/auth0/auth0-angular/blob/585220b/projects/auth0-angular/src/lib/auth.guard.ts#L18"
+                href="https://github.com/auth0/auth0-angular/blob/d11191f/projects/auth0-angular/src/lib/auth.guard.ts#L18"
                 >projects/auth0-angular/src/lib/auth.guard.ts:18</a
               >
             </li>
@@ -339,7 +339,7 @@
                     <li>
                       Defined in
                       <a
-                        href="https://github.com/auth0/auth0-angular/blob/585220b/projects/auth0-angular/src/lib/auth.guard.ts#L19"
+                        href="https://github.com/auth0/auth0-angular/blob/d11191f/projects/auth0-angular/src/lib/auth.guard.ts#L19"
                         >projects/auth0-angular/src/lib/auth.guard.ts:19</a
                       >
                     </li>
@@ -443,7 +443,7 @@
                     <li>
                       Defined in
                       <a
-                        href="https://github.com/auth0/auth0-angular/blob/585220b/projects/auth0-angular/src/lib/auth.guard.ts#L25"
+                        href="https://github.com/auth0/auth0-angular/blob/d11191f/projects/auth0-angular/src/lib/auth.guard.ts#L25"
                         >projects/auth0-angular/src/lib/auth.guard.ts:25</a
                       >
                     </li>
@@ -545,7 +545,7 @@
                     <li>
                       Defined in
                       <a
-                        href="https://github.com/auth0/auth0-angular/blob/585220b/projects/auth0-angular/src/lib/auth.guard.ts#L32"
+                        href="https://github.com/auth0/auth0-angular/blob/d11191f/projects/auth0-angular/src/lib/auth.guard.ts#L32"
                         >projects/auth0-angular/src/lib/auth.guard.ts:32</a
                       >
                     </li>
@@ -638,7 +638,7 @@
                     <li>
                       Defined in
                       <a
-                        href="https://github.com/auth0/auth0-angular/blob/585220b/projects/auth0-angular/src/lib/auth.guard.ts#L21"
+                        href="https://github.com/auth0/auth0-angular/blob/d11191f/projects/auth0-angular/src/lib/auth.guard.ts#L21"
                         >projects/auth0-angular/src/lib/auth.guard.ts:21</a
                       >
                     </li>

--- a/docs/classes/AuthHttpInterceptor.html
+++ b/docs/classes/AuthHttpInterceptor.html
@@ -96,7 +96,7 @@
             <li>
               Defined in
               <a
-                href="https://github.com/auth0/auth0-angular/blob/585220b/projects/auth0-angular/src/lib/auth.interceptor.ts#L40"
+                href="https://github.com/auth0/auth0-angular/blob/d11191f/projects/auth0-angular/src/lib/auth.interceptor.ts#L40"
                 >projects/auth0-angular/src/lib/auth.interceptor.ts:40</a
               >
             </li>
@@ -354,7 +354,7 @@
                     <li>
                       Defined in
                       <a
-                        href="https://github.com/auth0/auth0-angular/blob/585220b/projects/auth0-angular/src/lib/auth.interceptor.ts#L41"
+                        href="https://github.com/auth0/auth0-angular/blob/d11191f/projects/auth0-angular/src/lib/auth.interceptor.ts#L41"
                         >projects/auth0-angular/src/lib/auth.interceptor.ts:41</a
                       >
                     </li>
@@ -467,7 +467,7 @@
                     <li>
                       Defined in
                       <a
-                        href="https://github.com/auth0/auth0-angular/blob/585220b/projects/auth0-angular/src/lib/auth.interceptor.ts#L48"
+                        href="https://github.com/auth0/auth0-angular/blob/d11191f/projects/auth0-angular/src/lib/auth.interceptor.ts#L48"
                         >projects/auth0-angular/src/lib/auth.interceptor.ts:48</a
                       >
                     </li>

--- a/docs/classes/AuthModule.html
+++ b/docs/classes/AuthModule.html
@@ -90,7 +90,7 @@
             <li>
               Defined in
               <a
-                href="https://github.com/auth0/auth0-angular/blob/585220b/projects/auth0-angular/src/lib/auth.module.ts#L8"
+                href="https://github.com/auth0/auth0-angular/blob/d11191f/projects/auth0-angular/src/lib/auth.module.ts#L8"
                 >projects/auth0-angular/src/lib/auth.module.ts:8</a
               >
             </li>
@@ -375,7 +375,7 @@
                     <li>
                       Defined in
                       <a
-                        href="https://github.com/auth0/auth0-angular/blob/585220b/projects/auth0-angular/src/lib/auth.module.ts#L15"
+                        href="https://github.com/auth0/auth0-angular/blob/d11191f/projects/auth0-angular/src/lib/auth.module.ts#L15"
                         >projects/auth0-angular/src/lib/auth.module.ts:15</a
                       >
                     </li>

--- a/docs/classes/AuthService.html
+++ b/docs/classes/AuthService.html
@@ -119,7 +119,7 @@
             <li>
               Defined in
               <a
-                href="https://github.com/auth0/auth0-angular/blob/585220b/projects/auth0-angular/src/lib/auth.service.ts#L43"
+                href="https://github.com/auth0/auth0-angular/blob/d11191f/projects/auth0-angular/src/lib/auth.service.ts#L43"
                 >projects/auth0-angular/src/lib/auth.service.ts:43</a
               >
             </li>
@@ -573,8 +573,8 @@
                     <li>
                       Defined in
                       <a
-                        href="https://github.com/auth0/auth0-angular/blob/585220b/projects/auth0-angular/src/lib/auth.service.ts#L81"
-                        >projects/auth0-angular/src/lib/auth.service.ts:81</a
+                        href="https://github.com/auth0/auth0-angular/blob/d11191f/projects/auth0-angular/src/lib/auth.service.ts#L82"
+                        >projects/auth0-angular/src/lib/auth.service.ts:82</a
                       >
                     </li>
                   </ul>
@@ -632,8 +632,8 @@
                 <li>
                   Defined in
                   <a
-                    href="https://github.com/auth0/auth0-angular/blob/585220b/projects/auth0-angular/src/lib/auth.service.ts#L79"
-                    >projects/auth0-angular/src/lib/auth.service.ts:79</a
+                    href="https://github.com/auth0/auth0-angular/blob/d11191f/projects/auth0-angular/src/lib/auth.service.ts#L80"
+                    >projects/auth0-angular/src/lib/auth.service.ts:80</a
                   >
                 </li>
               </ul>
@@ -680,8 +680,8 @@
                 <li>
                   Defined in
                   <a
-                    href="https://github.com/auth0/auth0-angular/blob/585220b/projects/auth0-angular/src/lib/auth.service.ts#L73"
-                    >projects/auth0-angular/src/lib/auth.service.ts:73</a
+                    href="https://github.com/auth0/auth0-angular/blob/d11191f/projects/auth0-angular/src/lib/auth.service.ts#L74"
+                    >projects/auth0-angular/src/lib/auth.service.ts:74</a
                   >
                 </li>
               </ul>
@@ -741,8 +741,8 @@
                 <li>
                   Defined in
                   <a
-                    href="https://github.com/auth0/auth0-angular/blob/585220b/projects/auth0-angular/src/lib/auth.service.ts#L68"
-                    >projects/auth0-angular/src/lib/auth.service.ts:68</a
+                    href="https://github.com/auth0/auth0-angular/blob/d11191f/projects/auth0-angular/src/lib/auth.service.ts#L69"
+                    >projects/auth0-angular/src/lib/auth.service.ts:69</a
                   >
                 </li>
               </ul>
@@ -794,8 +794,8 @@
                 <li>
                   Defined in
                   <a
-                    href="https://github.com/auth0/auth0-angular/blob/585220b/projects/auth0-angular/src/lib/auth.service.ts#L58"
-                    >projects/auth0-angular/src/lib/auth.service.ts:58</a
+                    href="https://github.com/auth0/auth0-angular/blob/d11191f/projects/auth0-angular/src/lib/auth.service.ts#L59"
+                    >projects/auth0-angular/src/lib/auth.service.ts:59</a
                   >
                 </li>
               </ul>
@@ -844,8 +844,8 @@
                 <li>
                   Defined in
                   <a
-                    href="https://github.com/auth0/auth0-angular/blob/585220b/projects/auth0-angular/src/lib/auth.service.ts#L52"
-                    >projects/auth0-angular/src/lib/auth.service.ts:52</a
+                    href="https://github.com/auth0/auth0-angular/blob/d11191f/projects/auth0-angular/src/lib/auth.service.ts#L53"
+                    >projects/auth0-angular/src/lib/auth.service.ts:53</a
                   >
                 </li>
               </ul>
@@ -900,8 +900,8 @@
                 <li>
                   Defined in
                   <a
-                    href="https://github.com/auth0/auth0-angular/blob/585220b/projects/auth0-angular/src/lib/auth.service.ts#L63"
-                    >projects/auth0-angular/src/lib/auth.service.ts:63</a
+                    href="https://github.com/auth0/auth0-angular/blob/d11191f/projects/auth0-angular/src/lib/auth.service.ts#L64"
+                    >projects/auth0-angular/src/lib/auth.service.ts:64</a
                   >
                 </li>
               </ul>
@@ -1028,8 +1028,8 @@
                     <li>
                       Defined in
                       <a
-                        href="https://github.com/auth0/auth0-angular/blob/585220b/projects/auth0-angular/src/lib/auth.service.ts#L198"
-                        >projects/auth0-angular/src/lib/auth.service.ts:198</a
+                        href="https://github.com/auth0/auth0-angular/blob/d11191f/projects/auth0-angular/src/lib/auth.service.ts#L199"
+                        >projects/auth0-angular/src/lib/auth.service.ts:199</a
                       >
                     </li>
                   </ul>
@@ -1107,8 +1107,8 @@
                     <li>
                       Defined in
                       <a
-                        href="https://github.com/auth0/auth0-angular/blob/585220b/projects/auth0-angular/src/lib/auth.service.ts#L207"
-                        >projects/auth0-angular/src/lib/auth.service.ts:207</a
+                        href="https://github.com/auth0/auth0-angular/blob/d11191f/projects/auth0-angular/src/lib/auth.service.ts#L208"
+                        >projects/auth0-angular/src/lib/auth.service.ts:208</a
                       >
                     </li>
                   </ul>
@@ -1223,8 +1223,8 @@
                     <li>
                       Defined in
                       <a
-                        href="https://github.com/auth0/auth0-angular/blob/585220b/projects/auth0-angular/src/lib/auth.service.ts#L270"
-                        >projects/auth0-angular/src/lib/auth.service.ts:270</a
+                        href="https://github.com/auth0/auth0-angular/blob/d11191f/projects/auth0-angular/src/lib/auth.service.ts#L273"
+                        >projects/auth0-angular/src/lib/auth.service.ts:273</a
                       >
                     </li>
                   </ul>
@@ -1345,8 +1345,8 @@
                     <li>
                       Defined in
                       <a
-                        href="https://github.com/auth0/auth0-angular/blob/585220b/projects/auth0-angular/src/lib/auth.service.ts#L302"
-                        >projects/auth0-angular/src/lib/auth.service.ts:302</a
+                        href="https://github.com/auth0/auth0-angular/blob/d11191f/projects/auth0-angular/src/lib/auth.service.ts#L305"
+                        >projects/auth0-angular/src/lib/auth.service.ts:305</a
                       >
                     </li>
                   </ul>
@@ -1485,8 +1485,8 @@
                     <li>
                       Defined in
                       <a
-                        href="https://github.com/auth0/auth0-angular/blob/585220b/projects/auth0-angular/src/lib/auth.service.ts#L157"
-                        >projects/auth0-angular/src/lib/auth.service.ts:157</a
+                        href="https://github.com/auth0/auth0-angular/blob/d11191f/projects/auth0-angular/src/lib/auth.service.ts#L158"
+                        >projects/auth0-angular/src/lib/auth.service.ts:158</a
                       >
                     </li>
                   </ul>
@@ -1607,8 +1607,8 @@
                     <li>
                       Defined in
                       <a
-                        href="https://github.com/auth0/auth0-angular/blob/585220b/projects/auth0-angular/src/lib/auth.service.ts#L134"
-                        >projects/auth0-angular/src/lib/auth.service.ts:134</a
+                        href="https://github.com/auth0/auth0-angular/blob/d11191f/projects/auth0-angular/src/lib/auth.service.ts#L135"
+                        >projects/auth0-angular/src/lib/auth.service.ts:135</a
                       >
                     </li>
                   </ul>
@@ -1721,8 +1721,8 @@
                     <li>
                       Defined in
                       <a
-                        href="https://github.com/auth0/auth0-angular/blob/585220b/projects/auth0-angular/src/lib/auth.service.ts#L183"
-                        >projects/auth0-angular/src/lib/auth.service.ts:183</a
+                        href="https://github.com/auth0/auth0-angular/blob/d11191f/projects/auth0-angular/src/lib/auth.service.ts#L184"
+                        >projects/auth0-angular/src/lib/auth.service.ts:184</a
                       >
                     </li>
                   </ul>
@@ -1795,8 +1795,8 @@
                     <li>
                       Defined in
                       <a
-                        href="https://github.com/auth0/auth0-angular/blob/585220b/projects/auth0-angular/src/lib/auth.service.ts#L117"
-                        >projects/auth0-angular/src/lib/auth.service.ts:117</a
+                        href="https://github.com/auth0/auth0-angular/blob/d11191f/projects/auth0-angular/src/lib/auth.service.ts#L118"
+                        >projects/auth0-angular/src/lib/auth.service.ts:118</a
                       >
                     </li>
                   </ul>

--- a/docs/classes/AuthState.html
+++ b/docs/classes/AuthState.html
@@ -95,7 +95,7 @@
             <li>
               Defined in
               <a
-                href="https://github.com/auth0/auth0-angular/blob/585220b/projects/auth0-angular/src/lib/auth.state.ts#L26"
+                href="https://github.com/auth0/auth0-angular/blob/d11191f/projects/auth0-angular/src/lib/auth.state.ts#L26"
                 >projects/auth0-angular/src/lib/auth.state.ts:26</a
               >
             </li>
@@ -411,7 +411,7 @@
                     <li>
                       Defined in
                       <a
-                        href="https://github.com/auth0/auth0-angular/blob/585220b/projects/auth0-angular/src/lib/auth.state.ts#L112"
+                        href="https://github.com/auth0/auth0-angular/blob/d11191f/projects/auth0-angular/src/lib/auth.state.ts#L112"
                         >projects/auth0-angular/src/lib/auth.state.ts:112</a
                       >
                     </li>
@@ -464,7 +464,7 @@
                 <li>
                   Defined in
                   <a
-                    href="https://github.com/auth0/auth0-angular/blob/585220b/projects/auth0-angular/src/lib/auth.state.ts#L110"
+                    href="https://github.com/auth0/auth0-angular/blob/d11191f/projects/auth0-angular/src/lib/auth.state.ts#L110"
                     >projects/auth0-angular/src/lib/auth.state.ts:110</a
                   >
                 </li>
@@ -525,7 +525,7 @@
                 <li>
                   Defined in
                   <a
-                    href="https://github.com/auth0/auth0-angular/blob/585220b/projects/auth0-angular/src/lib/auth.state.ts#L101"
+                    href="https://github.com/auth0/auth0-angular/blob/d11191f/projects/auth0-angular/src/lib/auth.state.ts#L101"
                     >projects/auth0-angular/src/lib/auth.state.ts:101</a
                   >
                 </li>
@@ -578,7 +578,7 @@
                 <li>
                   Defined in
                   <a
-                    href="https://github.com/auth0/auth0-angular/blob/585220b/projects/auth0-angular/src/lib/auth.state.ts#L83"
+                    href="https://github.com/auth0/auth0-angular/blob/d11191f/projects/auth0-angular/src/lib/auth.state.ts#L83"
                     >projects/auth0-angular/src/lib/auth.state.ts:83</a
                   >
                 </li>
@@ -628,7 +628,7 @@
                 <li>
                   Defined in
                   <a
-                    href="https://github.com/auth0/auth0-angular/blob/585220b/projects/auth0-angular/src/lib/auth.state.ts#L35"
+                    href="https://github.com/auth0/auth0-angular/blob/d11191f/projects/auth0-angular/src/lib/auth.state.ts#L35"
                     >projects/auth0-angular/src/lib/auth.state.ts:35</a
                   >
                 </li>
@@ -684,7 +684,7 @@
                 <li>
                   Defined in
                   <a
-                    href="https://github.com/auth0/auth0-angular/blob/585220b/projects/auth0-angular/src/lib/auth.state.ts#L91"
+                    href="https://github.com/auth0/auth0-angular/blob/d11191f/projects/auth0-angular/src/lib/auth.state.ts#L91"
                     >projects/auth0-angular/src/lib/auth.state.ts:91</a
                   >
                 </li>
@@ -756,7 +756,7 @@
                     <li>
                       Defined in
                       <a
-                        href="https://github.com/auth0/auth0-angular/blob/585220b/projects/auth0-angular/src/lib/auth.state.ts#L127"
+                        href="https://github.com/auth0/auth0-angular/blob/d11191f/projects/auth0-angular/src/lib/auth.state.ts#L127"
                         >projects/auth0-angular/src/lib/auth.state.ts:127</a
                       >
                     </li>
@@ -848,7 +848,7 @@
                     <li>
                       Defined in
                       <a
-                        href="https://github.com/auth0/auth0-angular/blob/585220b/projects/auth0-angular/src/lib/auth.state.ts#L136"
+                        href="https://github.com/auth0/auth0-angular/blob/d11191f/projects/auth0-angular/src/lib/auth.state.ts#L136"
                         >projects/auth0-angular/src/lib/auth.state.ts:136</a
                       >
                     </li>
@@ -935,7 +935,7 @@
                     <li>
                       Defined in
                       <a
-                        href="https://github.com/auth0/auth0-angular/blob/585220b/projects/auth0-angular/src/lib/auth.state.ts#L145"
+                        href="https://github.com/auth0/auth0-angular/blob/d11191f/projects/auth0-angular/src/lib/auth.state.ts#L145"
                         >projects/auth0-angular/src/lib/auth.state.ts:145</a
                       >
                     </li>
@@ -1024,7 +1024,7 @@
                     <li>
                       Defined in
                       <a
-                        href="https://github.com/auth0/auth0-angular/blob/585220b/projects/auth0-angular/src/lib/auth.state.ts#L119"
+                        href="https://github.com/auth0/auth0-angular/blob/d11191f/projects/auth0-angular/src/lib/auth.state.ts#L119"
                         >projects/auth0-angular/src/lib/auth.state.ts:119</a
                       >
                     </li>

--- a/docs/enums/HttpMethod.html
+++ b/docs/enums/HttpMethod.html
@@ -93,7 +93,7 @@
             <li>
               Defined in
               <a
-                href="https://github.com/auth0/auth0-angular/blob/585220b/projects/auth0-angular/src/lib/auth.config.ts#L13"
+                href="https://github.com/auth0/auth0-angular/blob/d11191f/projects/auth0-angular/src/lib/auth.config.ts#L13"
                 >projects/auth0-angular/src/lib/auth.config.ts:13</a
               >
             </li>
@@ -263,7 +263,7 @@
                 <li>
                   Defined in
                   <a
-                    href="https://github.com/auth0/auth0-angular/blob/585220b/projects/auth0-angular/src/lib/auth.config.ts#L18"
+                    href="https://github.com/auth0/auth0-angular/blob/d11191f/projects/auth0-angular/src/lib/auth.config.ts#L18"
                     >projects/auth0-angular/src/lib/auth.config.ts:18</a
                   >
                 </li>
@@ -300,7 +300,7 @@
                 <li>
                   Defined in
                   <a
-                    href="https://github.com/auth0/auth0-angular/blob/585220b/projects/auth0-angular/src/lib/auth.config.ts#L14"
+                    href="https://github.com/auth0/auth0-angular/blob/d11191f/projects/auth0-angular/src/lib/auth.config.ts#L14"
                     >projects/auth0-angular/src/lib/auth.config.ts:14</a
                   >
                 </li>
@@ -337,7 +337,7 @@
                 <li>
                   Defined in
                   <a
-                    href="https://github.com/auth0/auth0-angular/blob/585220b/projects/auth0-angular/src/lib/auth.config.ts#L19"
+                    href="https://github.com/auth0/auth0-angular/blob/d11191f/projects/auth0-angular/src/lib/auth.config.ts#L19"
                     >projects/auth0-angular/src/lib/auth.config.ts:19</a
                   >
                 </li>
@@ -374,7 +374,7 @@
                 <li>
                   Defined in
                   <a
-                    href="https://github.com/auth0/auth0-angular/blob/585220b/projects/auth0-angular/src/lib/auth.config.ts#L17"
+                    href="https://github.com/auth0/auth0-angular/blob/d11191f/projects/auth0-angular/src/lib/auth.config.ts#L17"
                     >projects/auth0-angular/src/lib/auth.config.ts:17</a
                   >
                 </li>
@@ -411,7 +411,7 @@
                 <li>
                   Defined in
                   <a
-                    href="https://github.com/auth0/auth0-angular/blob/585220b/projects/auth0-angular/src/lib/auth.config.ts#L15"
+                    href="https://github.com/auth0/auth0-angular/blob/d11191f/projects/auth0-angular/src/lib/auth.config.ts#L15"
                     >projects/auth0-angular/src/lib/auth.config.ts:15</a
                   >
                 </li>
@@ -448,7 +448,7 @@
                 <li>
                   Defined in
                   <a
-                    href="https://github.com/auth0/auth0-angular/blob/585220b/projects/auth0-angular/src/lib/auth.config.ts#L16"
+                    href="https://github.com/auth0/auth0-angular/blob/d11191f/projects/auth0-angular/src/lib/auth.config.ts#L16"
                     >projects/auth0-angular/src/lib/auth.config.ts:16</a
                   >
                 </li>

--- a/docs/functions/authGuardFn.html
+++ b/docs/functions/authGuardFn.html
@@ -180,7 +180,7 @@
                   <li>
                     Defined in
                     <a
-                      href="https://github.com/auth0/auth0-angular/blob/585220b/projects/auth0-angular/src/lib/functional.ts#L17"
+                      href="https://github.com/auth0/auth0-angular/blob/d11191f/projects/auth0-angular/src/lib/functional.ts#L17"
                       >projects/auth0-angular/src/lib/functional.ts:17</a
                     >
                   </li>

--- a/docs/functions/authHttpInterceptorFn.html
+++ b/docs/functions/authHttpInterceptorFn.html
@@ -280,7 +280,7 @@
                   <li>
                     Defined in
                     <a
-                      href="https://github.com/auth0/auth0-angular/blob/585220b/projects/auth0-angular/src/lib/functional.ts#L32"
+                      href="https://github.com/auth0/auth0-angular/blob/d11191f/projects/auth0-angular/src/lib/functional.ts#L32"
                       >projects/auth0-angular/src/lib/functional.ts:32</a
                     >
                   </li>

--- a/docs/functions/isHttpInterceptorRouteConfig.html
+++ b/docs/functions/isHttpInterceptorRouteConfig.html
@@ -177,7 +177,7 @@
                   <li>
                     Defined in
                     <a
-                      href="https://github.com/auth0/auth0-angular/blob/585220b/projects/auth0-angular/src/lib/auth.config.ts#L35"
+                      href="https://github.com/auth0/auth0-angular/blob/d11191f/projects/auth0-angular/src/lib/auth.config.ts#L35"
                       >projects/auth0-angular/src/lib/auth.config.ts:35</a
                     >
                   </li>

--- a/docs/functions/provideAuth0.html
+++ b/docs/functions/provideAuth0.html
@@ -167,7 +167,7 @@
                   <li>
                     Defined in
                     <a
-                      href="https://github.com/auth0/auth0-angular/blob/585220b/projects/auth0-angular/src/lib/provide.ts#L23"
+                      href="https://github.com/auth0/auth0-angular/blob/d11191f/projects/auth0-angular/src/lib/provide.ts#L23"
                       >projects/auth0-angular/src/lib/provide.ts:23</a
                     >
                   </li>

--- a/docs/interfaces/AppState.html
+++ b/docs/interfaces/AppState.html
@@ -104,7 +104,7 @@
             <li>
               Defined in
               <a
-                href="https://github.com/auth0/auth0-angular/blob/585220b/projects/auth0-angular/src/lib/auth.config.ts#L142"
+                href="https://github.com/auth0/auth0-angular/blob/d11191f/projects/auth0-angular/src/lib/auth.config.ts#L142"
                 >projects/auth0-angular/src/lib/auth.config.ts:142</a
               >
             </li>
@@ -216,7 +216,7 @@
                 <li>
                   Defined in
                   <a
-                    href="https://github.com/auth0/auth0-angular/blob/585220b/projects/auth0-angular/src/lib/auth.config.ts#L147"
+                    href="https://github.com/auth0/auth0-angular/blob/d11191f/projects/auth0-angular/src/lib/auth.config.ts#L147"
                     >projects/auth0-angular/src/lib/auth.config.ts:147</a
                   >
                 </li>

--- a/docs/interfaces/AuthConfig.html
+++ b/docs/interfaces/AuthConfig.html
@@ -100,7 +100,7 @@
             <li>
               Defined in
               <a
-                href="https://github.com/auth0/auth0-angular/blob/585220b/projects/auth0-angular/src/lib/auth.config.ts#L107"
+                href="https://github.com/auth0/auth0-angular/blob/d11191f/projects/auth0-angular/src/lib/auth.config.ts#L107"
                 >projects/auth0-angular/src/lib/auth.config.ts:107</a
               >
             </li>
@@ -941,7 +941,7 @@
                 <li>
                   Defined in
                   <a
-                    href="https://github.com/auth0/auth0-angular/blob/585220b/projects/auth0-angular/src/lib/auth.config.ts#L136"
+                    href="https://github.com/auth0/auth0-angular/blob/d11191f/projects/auth0-angular/src/lib/auth.config.ts#L136"
                     >projects/auth0-angular/src/lib/auth.config.ts:136</a
                   >
                 </li>
@@ -993,7 +993,7 @@
                 <li>
                   Defined in
                   <a
-                    href="https://github.com/auth0/auth0-angular/blob/585220b/projects/auth0-angular/src/lib/auth.config.ts#L130"
+                    href="https://github.com/auth0/auth0-angular/blob/d11191f/projects/auth0-angular/src/lib/auth.config.ts#L130"
                     >projects/auth0-angular/src/lib/auth.config.ts:130</a
                   >
                 </li>
@@ -1387,7 +1387,7 @@
                 <li>
                   Defined in
                   <a
-                    href="https://github.com/auth0/auth0-angular/blob/585220b/projects/auth0-angular/src/lib/auth.config.ts#L124"
+                    href="https://github.com/auth0/auth0-angular/blob/d11191f/projects/auth0-angular/src/lib/auth.config.ts#L124"
                     >projects/auth0-angular/src/lib/auth.config.ts:124</a
                   >
                 </li>

--- a/docs/interfaces/HttpInterceptorConfig.html
+++ b/docs/interfaces/HttpInterceptorConfig.html
@@ -97,7 +97,7 @@
             <li>
               Defined in
               <a
-                href="https://github.com/auth0/auth0-angular/blob/585220b/projects/auth0-angular/src/lib/auth.config.ts#L44"
+                href="https://github.com/auth0/auth0-angular/blob/d11191f/projects/auth0-angular/src/lib/auth.config.ts#L44"
                 >projects/auth0-angular/src/lib/auth.config.ts:44</a
               >
             </li>
@@ -210,7 +210,7 @@
                 <li>
                   Defined in
                   <a
-                    href="https://github.com/auth0/auth0-angular/blob/585220b/projects/auth0-angular/src/lib/auth.config.ts#L45"
+                    href="https://github.com/auth0/auth0-angular/blob/d11191f/projects/auth0-angular/src/lib/auth.config.ts#L45"
                     >projects/auth0-angular/src/lib/auth.config.ts:45</a
                   >
                 </li>

--- a/docs/interfaces/HttpInterceptorRouteConfig.html
+++ b/docs/interfaces/HttpInterceptorRouteConfig.html
@@ -99,7 +99,7 @@
             <li>
               Defined in
               <a
-                href="https://github.com/auth0/auth0-angular/blob/585220b/projects/auth0-angular/src/lib/auth.config.ts#L51"
+                href="https://github.com/auth0/auth0-angular/blob/d11191f/projects/auth0-angular/src/lib/auth.config.ts#L51"
                 >projects/auth0-angular/src/lib/auth.config.ts:51</a
               >
             </li>
@@ -270,7 +270,7 @@
                 <li>
                   Defined in
                   <a
-                    href="https://github.com/auth0/auth0-angular/blob/585220b/projects/auth0-angular/src/lib/auth.config.ts#L101"
+                    href="https://github.com/auth0/auth0-angular/blob/d11191f/projects/auth0-angular/src/lib/auth.config.ts#L101"
                     >projects/auth0-angular/src/lib/auth.config.ts:101</a
                   >
                 </li>
@@ -319,7 +319,7 @@
                 <li>
                   Defined in
                   <a
-                    href="https://github.com/auth0/auth0-angular/blob/585220b/projects/auth0-angular/src/lib/auth.config.ts#L94"
+                    href="https://github.com/auth0/auth0-angular/blob/d11191f/projects/auth0-angular/src/lib/auth.config.ts#L94"
                     >projects/auth0-angular/src/lib/auth.config.ts:94</a
                   >
                 </li>
@@ -371,7 +371,7 @@
                 <li>
                   Defined in
                   <a
-                    href="https://github.com/auth0/auth0-angular/blob/585220b/projects/auth0-angular/src/lib/auth.config.ts#L85"
+                    href="https://github.com/auth0/auth0-angular/blob/d11191f/projects/auth0-angular/src/lib/auth.config.ts#L85"
                     >projects/auth0-angular/src/lib/auth.config.ts:85</a
                   >
                 </li>
@@ -435,7 +435,7 @@
                 <li>
                   Defined in
                   <a
-                    href="https://github.com/auth0/auth0-angular/blob/585220b/projects/auth0-angular/src/lib/auth.config.ts#L67"
+                    href="https://github.com/auth0/auth0-angular/blob/d11191f/projects/auth0-angular/src/lib/auth.config.ts#L67"
                     >projects/auth0-angular/src/lib/auth.config.ts:67</a
                   >
                 </li>
@@ -539,7 +539,7 @@
                 <li>
                   Defined in
                   <a
-                    href="https://github.com/auth0/auth0-angular/blob/585220b/projects/auth0-angular/src/lib/auth.config.ts#L79"
+                    href="https://github.com/auth0/auth0-angular/blob/d11191f/projects/auth0-angular/src/lib/auth.config.ts#L79"
                     >projects/auth0-angular/src/lib/auth.config.ts:79</a
                   >
                 </li>

--- a/docs/interfaces/LogoutOptions.html
+++ b/docs/interfaces/LogoutOptions.html
@@ -100,7 +100,7 @@
             <li>
               Defined in
               <a
-                href="https://github.com/auth0/auth0-angular/blob/585220b/projects/auth0-angular/src/lib/interfaces.ts#L7"
+                href="https://github.com/auth0/auth0-angular/blob/d11191f/projects/auth0-angular/src/lib/interfaces.ts#L7"
                 >projects/auth0-angular/src/lib/interfaces.ts:7</a
               >
             </li>

--- a/docs/interfaces/RedirectLoginOptions.html
+++ b/docs/interfaces/RedirectLoginOptions.html
@@ -114,7 +114,7 @@
             <li>
               Defined in
               <a
-                href="https://github.com/auth0/auth0-angular/blob/585220b/projects/auth0-angular/src/lib/interfaces.ts#L4"
+                href="https://github.com/auth0/auth0-angular/blob/d11191f/projects/auth0-angular/src/lib/interfaces.ts#L4"
                 >projects/auth0-angular/src/lib/interfaces.ts:4</a
               >
             </li>

--- a/docs/types/ApiRouteDefinition.html
+++ b/docs/types/ApiRouteDefinition.html
@@ -103,7 +103,7 @@
             <li>
               Defined in
               <a
-                href="https://github.com/auth0/auth0-angular/blob/585220b/projects/auth0-angular/src/lib/auth.config.ts#L28"
+                href="https://github.com/auth0/auth0-angular/blob/d11191f/projects/auth0-angular/src/lib/auth.config.ts#L28"
                 >projects/auth0-angular/src/lib/auth.config.ts:28</a
               >
             </li>

--- a/docs/variables/Auth0ClientService.html
+++ b/docs/variables/Auth0ClientService.html
@@ -98,7 +98,7 @@
             <li>
               Defined in
               <a
-                href="https://github.com/auth0/auth0-angular/blob/585220b/projects/auth0-angular/src/lib/auth.client.ts#L29"
+                href="https://github.com/auth0/auth0-angular/blob/d11191f/projects/auth0-angular/src/lib/auth.client.ts#L29"
                 >projects/auth0-angular/src/lib/auth.client.ts:29</a
               >
             </li>

--- a/docs/variables/AuthConfigService.html
+++ b/docs/variables/AuthConfigService.html
@@ -113,7 +113,7 @@
             <li>
               Defined in
               <a
-                href="https://github.com/auth0/auth0-angular/blob/585220b/projects/auth0-angular/src/lib/auth.config.ts#L166"
+                href="https://github.com/auth0/auth0-angular/blob/d11191f/projects/auth0-angular/src/lib/auth.config.ts#L166"
                 >projects/auth0-angular/src/lib/auth.config.ts:166</a
               >
             </li>

--- a/projects/auth0-angular/package.json
+++ b/projects/auth0-angular/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@auth0/auth0-angular",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "description": "Auth0 SDK for Angular Single Page Applications (SPA)",
   "keywords": [
     "auth0",

--- a/projects/auth0-angular/src/useragent.ts
+++ b/projects/auth0-angular/src/useragent.ts
@@ -1,1 +1,1 @@
-export default { name: '@auth0/auth0-angular', version: '2.2.0' };
+export default { name: '@auth0/auth0-angular', version: '2.2.1' };


### PR DESCRIPTION

**Fixed**
- Do not crash when getTokenSilently returns null [\#458](https://github.com/auth0/auth0-angular/pull/458) ([frederikprijck](https://github.com/frederikprijck))
