### PR TITLE
Group Angular dependencies for dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,12 @@ updates:
     directory: '/'
     schedule:
       interval: 'daily'
+    groups:
+      angular:
+        patterns:
+          - "@angular*"
+        update-types:
+          - "minor"
     ignore:
       - dependency-name: "*"
         update-types: ["version-update:semver-major"]


### PR DESCRIPTION
Given that `@angular` updates need to be performed together, create a group that instructs dependabot to do this, [docs here](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#groups)