### PR TITLE
Ensure tag-exists action works as intended

### DIFF
--- a/.github/actions/tag-exists/action.yml
+++ b/.github/actions/tag-exists/action.yml
@@ -21,7 +21,7 @@ runs:
   using: composite
 
   steps:
-    - id: check
+    - id: tag-exists
       shell: bash
       run: |
         GET_API_URL="https://api.github.com/repos/${GITHUB_REPOSITORY}/git/ref/tags/${TAG_NAME}"


### PR DESCRIPTION
### Changes

The tag-exists action was not working due to the fact that it was trying to read from a step that did not exist.
Without these changes, it would always 404 and act as if the tag doesn't exist.

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All code quality tools/guidelines have been run/followed