### PR TITLE
Use outputs for capturing release-notes

### DIFF
--- a/.github/actions/get-release-notes/action.yml
+++ b/.github/actions/get-release-notes/action.yml
@@ -15,6 +15,10 @@ inputs:
   token:
     required: true
 
+outputs:
+  release-notes:
+    value: ${{ steps.get_release_notes.outputs.RELEASE_NOTES }}
+
 runs:
   using: composite
 
@@ -30,7 +34,7 @@ runs:
             state: 'all',
             head: `${process.env.REPO_OWNER}:release/${process.env.VERSION}`,
           });
-          core.exportVariable('RELEASE_NOTES', pulls[0].body)
+          core.setOutput('RELEASE_NOTES', pulls[0].body);
       env:
         GITHUB_TOKEN: ${{ inputs.token }}
         REPO_OWNER: ${{ inputs.repo_owner }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -72,7 +72,7 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           name: ${{ steps.get_version.outputs.version }}
-          body: ${{ env.RELEASE_NOTES }}
+          body: ${{ steps.get_release_notes.outputs.release-notes }}
           tag: ${{ steps.get_version.outputs.version }}
           commit: ${{ github.sha }}
           prerelease: ${{ steps.get_prerelease.outputs.prerelease }}


### PR DESCRIPTION
### Changes

Ensuring we use outputs for capturing the release notes rather than relying on an environment variable.

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All code quality tools/guidelines have been run/followed
