### PR TITLE
Add Skip the Auth0 login page to FAQ

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -11,6 +11,7 @@
 7. [Using the SDK with Angular Universal](#7-using-the-sdk-with-angular-universal)
 8. [Retrieving and refreshing a token](#8-retrieving-and-refreshing-a-token)
 9. [When using localOnly logout, the user is getting logged in again](#9-when-using-localonly-logout-the-user-is-getting-logged-in-again)
+9. [Skip the Auth0 login page?](#10-skip-the-auth0-login-page)
 
 ## 1. User is not logged in after page refresh
 
@@ -289,7 +290,7 @@ providers: [
   ],
 ```
 
-## 10. How can I skip the Auth0 login page?
+## 10. Skip the Auth0 login page
 
 When integrating with third party providers such as Google or Microsoft, being redirected to Auth0 before being redirected to the corresponding provider can be sub-optimal in terms of user-experience.
 If you only have a single connection enabled, or you know up front how the user wants to authenticate, you can set the `connection` parameter when calling `loginWithRedirect()` or `loginWithPopup()`:
@@ -318,3 +319,5 @@ bootstrapApplication(AppComponent, {
   ]
 });
 ```
+
+ℹ️ You can find the connection's logical identifier as the **connection name** in the connection settings in the Auth0 dashboard for your tenant.

--- a/FAQ.md
+++ b/FAQ.md
@@ -292,7 +292,7 @@ providers: [
 ## 10. How can I skip the Auth0 login page?
 
 When integrating with third party providers such as Google or Microsoft, being redirected to Auth0 before being redirected to the corresponding provider can be sub-optimal in terms of user-experience.
-If you only have a single connection enabled, or you know up front how the user wants to authenticate, you can set the `connection` parameter when calling `loginWithRedirect()` or `loginWithPopup`:
+If you only have a single connection enabled, or you know up front how the user wants to authenticate, you can set the `connection` parameter when calling `loginWithRedirect()` or `loginWithPopup()`:
 
 ```
 this.auth.loginWithRedirect({

--- a/FAQ.md
+++ b/FAQ.md
@@ -288,3 +288,33 @@ providers: [
     }
   ],
 ```
+
+## 10. How can I skip the Auth0 login page?
+
+When integrating with third party providers such as Google or Microsoft, being redirected to Auth0 before being redirected to the corresponding provider, can be sub-optimal in terms of user-experience.
+If you only have a single connection enabled, or you know up front how the user wants to authenticate, you can set the `connection` parameter when calling `loginWithRedirect()` or `loginWithPopup`:
+
+```
+this.auth.loginWithRedirect({
+  // ...
+  authorizationParams: {
+    connection: 'connection_logical_identifier'
+  }
+})
+```
+
+Doing so for connections such as Google or Microsoft, would automatically redirect you to them instead of showing the Auth0 login page first.
+
+Additionally, if you are using our AuthGuard, you may want it to pick up the same connection when it would redirect for login. To do so, you should provide the `connection` property when configuring Auth0:
+
+```
+bootstrapApplication(AppComponent, {
+  providers: [
+    provideAuth0({ 
+      authorizationParams: { 
+        connection: 'connection_logical_identifier' 
+      }
+    }),
+  ]
+});
+```

--- a/FAQ.md
+++ b/FAQ.md
@@ -291,7 +291,7 @@ providers: [
 
 ## 10. How can I skip the Auth0 login page?
 
-When integrating with third party providers such as Google or Microsoft, being redirected to Auth0 before being redirected to the corresponding provider, can be sub-optimal in terms of user-experience.
+When integrating with third party providers such as Google or Microsoft, being redirected to Auth0 before being redirected to the corresponding provider can be sub-optimal in terms of user-experience.
 If you only have a single connection enabled, or you know up front how the user wants to authenticate, you can set the `connection` parameter when calling `loginWithRedirect()` or `loginWithPopup`:
 
 ```


### PR DESCRIPTION
### Description

Adds an additional entry to the FAQ about skipping the Auth0 login page, after having a conversation with someone that was confused about this.

### References

N/A

### Testing

N/A

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not the default branch
