### PR TITLE
SEC-2149:updating github publish workflow to handle security vulnerab…

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -52,8 +52,9 @@ jobs:
       # Build the tag string from package.json version and release suffix. Produces something like `1.0.0-beta.1` for a beta, or `1.0.0` for a stable release.
       - name: Build tag
         id: vtag
-        run: |
+        env:
           PACKAGE_VERSION="${{ github.event.inputs.version }}"
+        run: |
           echo "vtag=${PACKAGE_VERSION}" >> $GITHUB_ENV
           echo "vtag=${PACKAGE_VERSION}" >> $GITHUB_OUTPUT
 


### PR DESCRIPTION
By submitting a PR to this repository, you agree to the terms within the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/auth0/.github/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo.

### Description
Updating the Publish Release GitHub Workflow in the auth0‐angular repository, as it was vulnerable to a script injection attack due to user input being passed through a shell.

### References
- SEC-2149

### Testing
- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not the default branch
