### PR TITLE
fix: use TAppState generic in ConnectAccountRedirectResult type

### DIFF
--- a/projects/auth0-angular/src/lib/auth.service.ts
+++ b/projects/auth0-angular/src/lib/auth.service.ts
@@ -309,7 +309,7 @@ export class AuthService<TAppState extends AppState = AppState>
   handleRedirectCallback(
     url?: string
   ): Observable<
-    RedirectLoginResult<TAppState> | ConnectAccountRedirectResult<AppState>
+    RedirectLoginResult<TAppState> | ConnectAccountRedirectResult<TAppState>
   > {
     return defer(() =>
       this.auth0Client.handleRedirectCallback<TAppState>(url)


### PR DESCRIPTION
## Changes

Fixed type inconsistency in `handleRedirectCallback` return type (line 312-313):

```typescript
// Before
ConnectAccountRedirectResult<AppState>

// After
ConnectAccountRedirectResult<TAppState>
```

## Why

Both union types should use the same generic parameter for type safety and consistency with `RedirectLoginResult<TAppState>`.

## Impact

- Improves type inference when extending `AppState`
- No runtime changes
- No breaking changes