### PR TITLE
docs: add code formatting to migration guide

### DIFF
--- a/MIGRATION_GUIDE.md
+++ b/MIGRATION_GUIDE.md
@@ -308,9 +308,9 @@ With v2, we have flipped the default value for `useFormData` to **true**, meanin
 
 When using refresh tokens in v1, we fall back to using iframes whenever a refresh token exchange would fail. This has caused problems before in environments that do not support iframes, and we have specifically introduced `useRefreshTokensFallback` to be able to opt-out of falling back to iframes in the case a refresh_grant fails.
 
-With v2, we have flipped the default value for `useRefreshTokensFallback` to false so we do not fall back to using iframes by default when `useRefreshTokens` is `true`, and the refresh token exchange fails.
+With v2, we have flipped the default value for `useRefreshTokensFallback` to `false` so we do not fall back to using iframes by default when `useRefreshTokens` is `true`, and the refresh token exchange fails.
 
-If you want to restore the original behaviour, and still fall back to iframes when the refresh token exchange fails, you can set `useRefreshTokensFallback` to true.
+If you want to restore the original behaviour, and still fall back to iframes when the refresh token exchange fails, you can set `useRefreshTokensFallback` to `true`.
 
 ### `getUser` and `getIdTokenClaims` have been removed
 


### PR DESCRIPTION
## Description

Adds inline code formatting (backticks) around boolean values in the "No more iframe fallback by default when using refresh tokens" section for consistency.

## Changes

- Added backticks around `false` boolean value
- Added backticks around `true` boolean value

## Related

Closes #629

## Credit

Originally contributed by @AlexElin in #629. Applied with signed commits and proper co-author attribution.

Co-authored-by: Alexey Elin <alexey.elin@list.ru>