### PR TITLE
feat: enable trusted publishing for npm packages

### DIFF
--- a/.github/actions/npm-publish/action.yml
+++ b/.github/actions/npm-publish/action.yml
@@ -3,8 +3,6 @@ name: Publish release to npm
 inputs:
   node-version:
     required: true
-  npm-token:
-    required: true
   version:
     required: true
   require-build:
@@ -26,6 +24,10 @@ runs:
         cache: 'npm'
         registry-url: 'https://registry.npmjs.org'
 
+    - name: Update npm to version 11
+      shell: bash
+      run: npm install -g npm@11
+
     - name: Install dependencies
       shell: bash
       run: npm ci --include=dev
@@ -46,7 +48,6 @@ runs:
         else
           TAG="latest"
         fi
-        npm publish --provenance --tag $TAG
+        npm publish --tag $TAG
       env:
-        NODE_AUTH_TOKEN: ${{ inputs.npm-token }}
         VERSION: ${{ inputs.version }}

--- a/.github/workflows/npm-release.yml
+++ b/.github/workflows/npm-release.yml
@@ -15,8 +15,10 @@ on:
     secrets:
       github-token:
         required: true
-      npm-token:
-        required: true
+
+permissions:
+  contents: write
+  id-token: write
 
 jobs:
   release:
@@ -66,7 +68,6 @@ jobs:
           node-version: ${{ inputs.node-version }}
           require-build: ${{ inputs.require-build }}
           version: ${{ steps.get_version.outputs.version }}
-          npm-token: ${{ secrets.npm-token }}
           release-directory: ${{ inputs.release-directory }}
 
       # Create a release for the tag

--- a/.github/workflows/npm-release.yml
+++ b/.github/workflows/npm-release.yml
@@ -16,15 +16,14 @@ on:
       github-token:
         required: true
 
-permissions:
-  contents: write
-  id-token: write
-
 jobs:
   release:
     if: github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && github.event.pull_request.merged && startsWith(github.event.pull_request.head.ref, 'release/'))
     runs-on: ubuntu-latest
     environment: release
+    permissions:
+      contents: write
+      id-token: write
 
     steps:
       # Checkout the code

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,7 @@ on:
 
 permissions:
   contents: write
-  id-token: write # For publishing to npm using --provenance
+  id-token: write # For trusted publishing to npm
 
 ### TODO: Replace instances of './.github/workflows/' w/ `auth0/dx-sdk-actions/workflows/` and append `@latest` after the common `dx-sdk-actions` repo is made public.
 ### TODO: Also remove `get-prerelease`, `get-release-notes`, `get-version`, `npm-publish`, `release-create`, and `tag-exists` actions from this repo's .github/actions folder once the repo is public.
@@ -36,5 +36,4 @@ jobs:
       require-build: true
       release-directory: './dist/auth0-angular'
     secrets:
-      npm-token: ${{ secrets.NPM_TOKEN }}
       github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

Implements trusted publishing using OIDC authentication to eliminate long-lived npm tokens.

## Changes

- Add `id-token: write` permissions to workflows
- Update npm CLI to version 11 (includes trusted publishing support ≥11.5.1)
- Remove `--provenance` flag (auto-generated with trusted publishing) [Refer](https://docs.npmjs.com/generating-provenance-statements#prerequisites)
- Remove npm-token dependency

## Modified Files

- `.github/workflows/release.yml` - Updated permissions comment, removed npm-token secret
- `.github/workflows/npm-release.yml` - Added permissions, removed npm-token from secrets
- `.github/actions/npm-publish/action.yml` - Updated to npm@11, removed token dependencies

## Post-merge: Configure on npmjs.com

Package Settings → Trusted Publisher → GitHub Actions:
- **Organization**: `auth0`
- **Repository**: `auth0-angular`
- **Workflow**: `release.yml`
- **Environment**: `release`

## Benefits

- Enhanced security with short-lived tokens
- Automatic provenance attestations
- No token management needed

Follows [OpenSSF trusted publishers standard](https://repos.openssf.org/trusted-publishers)

## Testing

After merge, verify that the release workflow can publish successfully using trusted publishing.