### PR TITLE
feat: use makeEnvironmentProviders to prevent provideAuth0 component-level usage at compile time

### DIFF
--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -724,7 +724,7 @@ bootstrapApplication(AppComponent, {
 });
 ```
 
-Note that `provideAuth0` should **never** be provided to components, but only at the root level of your application.
+**Important:** `provideAuth0` returns `EnvironmentProviders`, which ensures it can only be used at the application/environment level. Attempting to add it to a component's `providers` array will result in a compile-time error.
 
 ## Connect Accounts for using Token Vault
 

--- a/projects/auth0-angular/src/lib/provide.ts
+++ b/projects/auth0-angular/src/lib/provide.ts
@@ -1,4 +1,4 @@
-import { Provider } from '@angular/core';
+import { EnvironmentProviders, makeEnvironmentProviders } from '@angular/core';
 import { Auth0ClientService, Auth0ClientFactory } from './auth.client';
 import { AuthConfig, AuthConfigService, AuthClientConfig } from './auth.config';
 import { AuthGuard } from './auth.guard';
@@ -9,7 +9,9 @@ import { AuthService } from './auth.service';
  * Initialize the authentication system. Configuration can either be specified here,
  * or by calling AuthClientConfig.set (perhaps from an APP_INITIALIZER factory function).
  *
- * Note: Should only be used as of Angular 15, and should not be added to a component's providers.
+ * Note: Should only be used as of Angular 15. This function returns `EnvironmentProviders`
+ * which ensures it can only be used at the application/environment level and cannot be
+ * added to a component's providers array (this will result in a compile-time error).
  *
  * @param config The optional configuration for the SDK.
  *
@@ -20,8 +22,8 @@ import { AuthService } from './auth.service';
  *   ],
  * });
  */
-export function provideAuth0(config?: AuthConfig): Provider[] {
-  return [
+export function provideAuth0(config?: AuthConfig): EnvironmentProviders {
+  return makeEnvironmentProviders([
     AuthService,
     AuthHttpInterceptor,
     AuthGuard,
@@ -34,5 +36,5 @@ export function provideAuth0(config?: AuthConfig): Provider[] {
       useFactory: Auth0ClientFactory.createClient,
       deps: [AuthClientConfig],
     },
-  ];
+  ]);
 }


### PR DESCRIPTION
## Description                                                                                                                                                                                                                        
                                                                                                                                                                                                                                       
  This PR refactors the `provideAuth0` function to return `EnvironmentProviders` instead of `Provider[]`, enforcing type safety at compile-time and preventing incorrect usage in component providers.                                  
                                                                                                                                                                                                                                        
  Fixes #664                                                                                                                                                                                                                            
                                                                                                                                                                                                                                        
  ## Changes                                                                                                                                                                                                                            
                                                                                                                                                                                                                                        
  - Updated `provideAuth0()` to use `makeEnvironmentProviders()` and return `EnvironmentProviders`                                                                                                                                      
  - Updated return type from `Provider[]` to `EnvironmentProviders`                                                                                                                                                                     
  - Enhanced JSDoc documentation to explain the type safety benefit                                                                                                                                                                     
  - Updated `EXAMPLES.md` to reflect that this restriction is now enforced at compile-time                                                                                                                                              
                                                                                                                                                                                                                                        
  ## Motivation                                                                                                                                                                                                                         
                                                                                                                                                                                                                                        
  Previously, developers could mistakenly add `provideAuth0()` to a component's `providers` array, which could lead to unexpected behavior and runtime issues. While the documentation warned against this, there was no compile-time   
  enforcement.                                                                                                                                                                                                                          
                                                                                                                                                                                                                                        
  By using `makeEnvironmentProviders`, TypeScript now prevents this misuse:                                                                                                                                                             
                                                                                                                                                                                                                                        
  **Before (incorrect usage would compile):**                                                                                                                                                                                           
  ```ts                                                                                                                                                                                                                                 
  @Component({                                                                                                                                                                                                                          
    providers: [provideAuth0()] // ⚠️ Compiles but incorrect                                                                                                                                                                            
  })                                                                                                                                                                                                                                    
  export class MyComponent {}                                                                                                                                                                                                           
  ```                                                                                                                                                                                                                                      
  **After (incorrect usage produces a type error):**
   ```ts                                                                                                                                                                                   
  @Component({                                                                                                                                                                                                                          
    providers: [provideAuth0()] // ❌ Type error: EnvironmentProviders not assignable to Provider                                                                                                                                       
  })                                                                                                                                                                                                                                    
  export class MyComponent {}                                                                                                                                                                                                           
  ```                                                                                                                                                                                                                                      
  ## Benefits                                                                                                                                                                                                                              
                                                                                                                                                                                                                                        
  - ✅ **Type Safety**: Compile-time prevention of incorrect usage                                                                                                                                                                          
  - ✅ **Better DX**: Developers get immediate TypeScript feedback                                                                                                                                                                          
  - ✅ **Follows Angular Best Practices**: Uses makeEnvironmentProviders as intended                                                                                                                                                        
  - ✅ **No Breaking Changes**: Existing correct usage continues to work without modification                                                                                                                                               
                                                                                                                                                                                                                                        
  ## Testing                                                                                                                                                                                                                               
                                                                                                                                                                                                                                        
  - ✅ All existing unit tests pass (7 suites, 122 tests)                                                                                                                                                                               
  - ✅ Build succeeds without errors                                                                                                                                                                                                    
  - ✅ No changes to public API surface beyond return type                                                                                                                                                                              
                                                                                                                                                                                                                                        
  ## Related                                                                                                                                                                                                                               
                                                                                                                                                                                                                                        
  - Implements the solution proposed in #664 by @LcsGa  