### PR TITLE
feat: add AUTH_INTERCEPTOR_BYPASS token for per-request bypass

### DIFF
--- a/projects/auth0-angular/src/lib/auth.config.ts
+++ b/projects/auth0-angular/src/lib/auth.config.ts
@@ -6,6 +6,7 @@ import {
 } from '@auth0/auth0-spa-js';
 
 import { InjectionToken, Injectable, Optional, Inject } from '@angular/core';
+import { HttpContextToken } from '@angular/common/http';
 
 /**
  * Defines a common set of HTTP methods.
@@ -18,6 +19,28 @@ export const enum HttpMethod {
   Delete = 'DELETE',
   Head = 'HEAD',
 }
+
+/**
+ * HttpContextToken to bypass the AuthHttpInterceptor for a specific request.
+ *
+ * When set to true on an HttpRequest's context, the interceptor will not attach
+ * an access token to the request, even if the URL matches the allowedList configuration.
+ *
+ * @usageNotes
+ *
+ * ```typescript
+ * import { HttpClient, HttpContext } from '@angular/common/http';
+ * import { AUTH_INTERCEPTOR_BYPASS } from '@auth0/auth0-angular';
+ *
+ * // Bypass the interceptor for a specific request
+ * this.http.get('/api/public', {
+ *   context: new HttpContext().set(AUTH_INTERCEPTOR_BYPASS, true)
+ * });
+ * ```
+ */
+export const AUTH_INTERCEPTOR_BYPASS = new HttpContextToken<boolean>(
+  () => false
+);
 
 /**
  * Defines the type for a route config entry. Can either be:

--- a/projects/auth0-angular/src/lib/auth.interceptor.ts
+++ b/projects/auth0-angular/src/lib/auth.interceptor.ts
@@ -13,6 +13,7 @@ import {
   isHttpInterceptorRouteConfig,
   AuthClientConfig,
   HttpInterceptorConfig,
+  AUTH_INTERCEPTOR_BYPASS,
 } from './auth.config';
 
 import {
@@ -56,6 +57,11 @@ export class AuthHttpInterceptor implements HttpInterceptor {
   ): Observable<HttpEvent<any>> {
     const config = this.configFactory.get();
     if (!config.httpInterceptor?.allowedList) {
+      return next.handle(req);
+    }
+
+    // Early return if interceptor bypass is requested via HttpContext
+    if (req.context.get(AUTH_INTERCEPTOR_BYPASS)) {
       return next.handle(req);
     }
 


### PR DESCRIPTION
### Description                                                                                                                                                                                                                        
                                                                                                                                                                                                                                        
 Adds support for bypassing the `AuthHttpInterceptor` on a per-request basis using Angular's `HttpContextToken` pattern. This provides developers with dynamic, runtime control over token attachment without relying solely on         
 URL-based configuration.                                                                                                                                                                                                               
                                                                                                                                                                                                                                        
 ### Changes                                                                                                                                                                                                                            
                                                                                                                                                                                                                                        
 - **New export**: `AUTH_INTERCEPTOR_BYPASS` - An `HttpContextToken<boolean>` for controlling interceptor behavior per-request                                                                                                          
 - **Interceptor enhancement**: Early bypass check in `intercept()` method that takes precedence over `allowedList` configuration                                                                                                       
 - **Comprehensive tests**: 9 new test cases covering all bypass scenarios and HTTP methods                                                                                                                                             
 - **Documentation**: Added new section in `EXAMPLES.md` with usage examples and common scenarios                                                                                                                                       
                                                                                                                                                                                                                                        
 ### Usage                                                                                                                                                                                                                              
                                                                                                                                                                                                                                        
 ```typescript                                                                                                                                                                                                                          
 import { HttpClient, HttpContext } from '@angular/common/http';                                                                                                                                                                        
 import { AUTH_INTERCEPTOR_BYPASS } from '@auth0/auth0-angular';                                                                                                                                                                        
                                                                                                                                                                                                                                        
 // Make a request without attaching an access token                                                                                                                                                                                    
 this.http.get('/api/public', {                                                                                                                                                                                                         
   context: new HttpContext().set(AUTH_INTERCEPTOR_BYPASS, true)                                                                                                                                                                        
 }).subscribe(data => {                                                                                                                                                                                                                 
   // Handle response                                                                                                                                                                                                                   
 });                                                                                                                                                                                                                                    
 ```                                                                                                                                                                                                                                       
 ### Use Cases                                                                                                                                                                                                                              
                                                                                                                                                                                                                                        
 - **Public endpoints**: Skip authentication for public APIs even when URL matches `allowedList`                                                                                                                                              
 - **Dynamic control**: Conditionally bypass based on runtime logic or application state                                                                                                                                                    
 - **Per-request override**: Override global `allowedList` configuration for specific requests                                                                                                                                                
                                                                                                                                                                                                                                        
 ### Testing                                                                                                                                                                                                                                
                                                                                                                                                                                                                                        
 - ✅ All existing tests pass (131 total)                                                                                                                                                                                               
 - ✅ 9 new test cases covering bypass functionality                                                                                                                                                                                    
 - ✅ Tested with GET, POST, PUT, DELETE, PATCH methods                                                                                                                                                                                 
 - ✅ Verified interaction with `allowAnonymous` configuration                                                                                                                                                                            
 - ✅ Build verification confirms token is exported in public API                                                                                                                                                                       
                                                                                                                                                                                                                                        
 ### Breaking Changes                                                                                                                                                                                                                       
                                                                                                                                                                                                                                        
 None. This is a completely additive feature that maintains full backward compatibility.                                                                                                                                                
                                                                                                                                                                                                                                        
 ### Checklist                                                                                                                                                                                                                              
                                                                                                                                                                                                                                        
 - Code follows the project's coding standards                                                                                                                                                                                          
 - Tests have been added/updated                                                                                                                                                                                                        
 - Documentation has been updated                                                                                                                                                                                                       
 - All tests pass locally                                                                                                                                                                                                               
 - No breaking changes                                                                                                                                                                                                                  
                                                                                                                                                                                                                                        
 Fixes #658                                                                                                                                                                                                                             