### PR TITLE
chore: change CI to not rely on uploaded build artifacts for lint step

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,12 +35,6 @@ jobs:
         with:
           node: ${{ env.NODE_VERSION }}
 
-      - name: Save build artifacts
-        uses: actions/cache/save@v5
-        with:
-          path: .
-          key: ${{ env.CACHE_KEY }}
-
   unit:
     name: Unit Tests
     runs-on: ubuntu-latest
@@ -59,10 +53,8 @@ jobs:
           node-version: ${{ matrix.NODE_VERSION }}
           cache: npm
 
-      - name: Build package
-        uses: ./.github/actions/build
-        with:
-          node: ${{ matrix.NODE_VERSION }}
+      - name: Install dependencies
+        run: npm ci
 
       - name: Run tests
         run: npm run test:ci
@@ -71,8 +63,6 @@ jobs:
         uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de # pin@5.5.2
 
   lint:
-    needs: build # Require build to complete before running tests
-
     name: Lint Tests
     runs-on: ubuntu-latest
 
@@ -86,11 +76,8 @@ jobs:
           node-version: ${{ env.NODE_VERSION }}
           cache: npm
 
-      - name: Restore build artifacts
-        uses: actions/cache/restore@v5
-        with:
-          path: .
-          key: ${{ env.CACHE_KEY }}
+      - name: Install dependencies
+        run: npm ci
 
       - name: Run tests
         run: npm run lint


### PR DESCRIPTION
### Description

The linter step was restoring the build arfifacts, and not running npm ci. This seemed to be flakey, but also unnecessary.

### References

N/A

### Testing

N/A

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not the default branch
