### PR TITLE
feat: add loginWithCustomTokenExchange method

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "@angular/platform-browser": "^19.2.18",
         "@angular/platform-browser-dynamic": "^19.2.18",
         "@angular/router": "^19.2.18",
-        "@auth0/auth0-spa-js": "^2.13.1",
+        "@auth0/auth0-spa-js": "^2.14.0",
         "rxjs": "^6.6.7",
         "tslib": "^2.8.1",
         "zone.js": "~0.15.1"
@@ -806,9 +806,9 @@
       }
     },
     "node_modules/@auth0/auth0-spa-js": {
-      "version": "2.13.1",
-      "resolved": "https://registry.npmjs.org/@auth0/auth0-spa-js/-/auth0-spa-js-2.13.1.tgz",
-      "integrity": "sha512-H9N4QjBO8Dxr9hWT9NsAn60pPDGJy4gW5GKdYLpn4M33GocmrxoZ5wfYh99mMObZj3Ww4HiTyauNT2HGr9mx/A==",
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/@auth0/auth0-spa-js/-/auth0-spa-js-2.14.0.tgz",
+      "integrity": "sha512-2XGd3j7SCTMWBTCAU6Xk9ZtQxcgz9mjMs28t0BMv3y1GfoO7qA9VAgElYb52CyCeiTGlOYAVZFsioojFdRwxcA==",
       "license": "MIT",
       "dependencies": {
         "@auth0/auth0-auth-js": "^1.4.0",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "@angular/platform-browser": "^19.2.18",
     "@angular/platform-browser-dynamic": "^19.2.18",
     "@angular/router": "^19.2.18",
-    "@auth0/auth0-spa-js": "^2.13.1",
+    "@auth0/auth0-spa-js": "^2.14.0",
     "rxjs": "^6.6.7",
     "tslib": "^2.8.1",
     "zone.js": "~0.15.1"

--- a/projects/auth0-angular/src/public-api.ts
+++ b/projects/auth0-angular/src/public-api.ts
@@ -38,4 +38,6 @@ export {
   FetcherConfig,
   CustomFetchMinimalOutput,
   UseDpopNonceError,
+  CustomTokenExchangeOptions,
+  TokenEndpointResponse,
 } from '@auth0/auth0-spa-js';


### PR DESCRIPTION
## 📝 Summary

This PR adds support for the `loginWithCustomTokenExchange()` method from **auth0-spa-js 2.14.0** to **auth0-angular**, enabling token exchange flows based on [RFC 8693](https://www.rfc-editor.org/rfc/rfc8693.html). This allows apps to exchange external or legacy tokens for Auth0 tokens directly in Angular.

This implementation aligns with the auth0-spa-js changes in https://github.com/auth0/auth0-spa-js/pull/1526.

### 🔧 Changes

* Added `loginWithCustomTokenExchange()` method to the `AuthService` with full TypeScript and JSDoc support
* Implemented using RxJS operators with proper error handling
* Updates the auth state after successful token exchange
* Exported `CustomTokenExchangeOptions` and `TokenEndpointResponse` types
* Bumped `@auth0/auth0-spa-js` from 2.13.1 to 2.14.0
* Added examples and best practices to `EXAMPLES.md`

### 🧪 Testing

* Added 5 new tests for method behavior, error handling, auth state updates, and error propagation
* All 127 tests passing with full TypeScript coverage
* Build verified successfully

### 💥 Impact

* Enables secure token exchange following [RFC 8693](https://www.rfc-editor.org/rfc/rfc8693.html)
* Helps migration from legacy auth systems
* Fully documented, type-safe, and consistent with existing SDK patterns
* Maintains consistency across Auth0 SPA SDKs

## Test plan

- [x] Unit tests added and passing (127 tests)
- [x] Build succeeds
- [x] Documentation added to EXAMPLES.md
- [x] Types exported correctly
- [x] Dependency updated to @auth0/auth0-spa-js@2.14.0