### PR TITLE
fix: use virtual pypi index for rl-wrapper install

### DIFF
--- a/.github/actions/rl-scanner/action.yml
+++ b/.github/actions/rl-scanner/action.yml
@@ -31,7 +31,7 @@ runs:
     - name: Install RL Wrapper
       shell: bash
       run: |
-        pip install rl-wrapper>=1.0.0 --index-url "https://${{ env.PRODSEC_TOOLS_USER }}:${{ env.PRODSEC_TOOLS_TOKEN }}@a0us.jfrog.io/artifactory/api/pypi/python-local/simple"
+        pip install rl-wrapper --index-url "https://${{ env.PRODSEC_TOOLS_USER }}:${{ env.PRODSEC_TOOLS_TOKEN }}@a0us.jfrog.io/artifactory/api/pypi/python/simple"
 
     - name: Run RL Scanner
       shell: bash


### PR DESCRIPTION
## Summary
- Switches rl-wrapper install from `python-local` to the `python` virtual Artifactory repository so pip can resolve transitive dependencies
- Removes `>=1.0.0` version pin to ensure the latest published version is always installed