### PR TITLE
fix: add dependabot config for library package

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,12 +7,19 @@ updates:
     groups:
       angular:
         patterns:
-          - "@angular*"
+          - '@angular*'
         update-types:
-          - "minor"
+          - 'minor'
     ignore:
-      - dependency-name: "*"
-        update-types: ["version-update:semver-major"]
+      - dependency-name: '*'
+        update-types: ['version-update:semver-major']
+  - package-ecosystem: 'npm'
+    directory: '/projects/auth0-angular'
+    schedule:
+      interval: 'daily'
+    ignore:
+      - dependency-name: '*'
+        update-types: ['version-update:semver-major']
   - package-ecosystem: 'github-actions'
     directory: '/'
     schedule:


### PR DESCRIPTION
Dependabot was only scanning the root `package.json`, so updates to dependencies in `projects/auth0-angular/package.json` (the published library) were never picked up.

Adds a second npm entry pointing to `/projects/auth0-angular` so Dependabot also tracks and updates the library's dependencies.