### PR TITLE
fix: group angular patch updates in dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,7 @@ updates:
           - '@angular*'
         update-types:
           - 'minor'
+          - 'patch'
     ignore:
       - dependency-name: '*'
         update-types: ['version-update:semver-major']


### PR DESCRIPTION
## Summary

- The `angular` dependabot group was configured with only `minor` in `update-types`, causing patch-level Angular bumps (e.g. `19.2.18` → `19.2.19`) to be opened as separate PRs instead of being grouped
- Added `patch` to `update-types` so all Angular version updates are grouped into a single PR regardless of whether they are minor or patch bumps

## Test plan

- [ ] Verify next Angular patch release triggers a single grouped dependabot PR instead of separate ones