### PR TITLE
docs(changelog): call out Native to Web SSO support in v2.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 [Full Changelog](https://github.com/auth0/auth0-angular/compare/v2.7.0...v2.8.0)
 
+**Added**
+
+- Native to Web SSO support (via [auth0-spa-js v2.18.0](https://github.com/auth0/auth0-spa-js/releases/tag/v2.18.0))
+
 **Changed**
 
 - build(deps): bump @auth0/auth0-spa-js from 2.18.2 to 2.18.3 [\#878](https://github.com/auth0/auth0-angular/pull/878) ([dependabot[bot]](https://github.com/apps/dependabot))


### PR DESCRIPTION
## Summary

- Updates the v2.8.0 changelog entry to explicitly call out Native to Web SSO support introduced via `auth0-spa-js` v2.18.0, making the minor version bump self-explanatory to consumers.