### PR TITLE
fix: add RxJS as peer dependency

### DIFF
--- a/projects/auth0-angular/package.json
+++ b/projects/auth0-angular/package.json
@@ -28,7 +28,8 @@
   "peerDependencies": {
     "@angular/common": ">=13",
     "@angular/core": ">=13",
-    "@angular/router": ">=13"
+    "@angular/router": ">=13",
+    "rxjs": "^6.5.3 || ^7.4.0"
   },
   "dependencies": {
     "tslib": "^2.0.0",


### PR DESCRIPTION
## Problem

`@auth0/auth0-angular` imports from `rxjs` and exposes RxJS types (`Observable`) in its public API, but does not declare RxJS as a peer dependency. In strict package managers (pnpm, Yarn PnP), this allows multiple RxJS versions to coexist, causing TypeScript type incompatibilities at API boundaries (interceptors, guards).

## Solution

Add `rxjs` as a peer dependency with the same version range that `@angular/core` uses (`^6.5.3 || ^7.4.0`). This ensures package managers dedupe to a single RxJS version shared with the app.

## Impact

- Zero breaking changes — every Angular app already has RxJS installed
- Zero behavior changes — metadata only
- Aligns with how `@angular/core`, `@angular/common`, `@angular/router`, `@ngrx/store`, etc. all declare RxJS

## Testing

All 131 tests pass.

Fixes #670