### PR TITLE
fix: pin npm to 11.10.0

### DIFF
--- a/.github/actions/setup-node-npm/action.yml
+++ b/.github/actions/setup-node-npm/action.yml
@@ -27,4 +27,4 @@ runs:
 
     - name: Update npm to version 11
       shell: bash
-      run: npm install -g npm@11
+      run: npm install -g npm@11.10.0


### PR DESCRIPTION
Running `npm install -g npm@latest` on Node 22.22.2 fails with `MODULE_NOT_FOUND: promise-retry`. npm 11.12.0 removed `promise-retry` from its bundle, causing the still-running 10.x process to blow up mid-upgrade.

Pinning to `11.10.0` until this is resolved upstream in npm/cli#9152.