### PR TITLE
chore(deps): bump @auth0/auth0-spa-js from 2.11.0 to 2.19.2

### DIFF
--- a/projects/auth0-angular/package.json
+++ b/projects/auth0-angular/package.json
@@ -32,7 +32,7 @@
   },
   "dependencies": {
     "tslib": "^2.0.0",
-    "@auth0/auth0-spa-js": "^2.11.0"
+    "@auth0/auth0-spa-js": "^2.19.2"
   },
   "schematics": "./schematics/collection.json"
 }


### PR DESCRIPTION
Bumps `@auth0/auth0-spa-js` from `2.11.0` to `2.19.2`.