### PR TITLE
chore: use setup-node-npm consistently across CI

### DIFF
--- a/.github/actions/setup-node-npm/action.yml
+++ b/.github/actions/setup-node-npm/action.yml
@@ -15,7 +15,6 @@ runs:
       uses: actions/setup-node@v6
       with:
         node-version: ${{ inputs.node-version }}
-        package-manager-cache: false
 
     - name: Update npm to version 11
       shell: bash

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,11 +46,10 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v6
 
-      - name: Setup Node
-        uses: actions/setup-node@v6
+      - name: Setup Node and npm
+        uses: ./.github/actions/setup-node-npm
         with:
           node-version: ${{ matrix.NODE_VERSION }}
-          package-manager-cache: false
 
       - name: Install dependencies
         run: npm i
@@ -69,11 +68,10 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v6
 
-      - name: Setup Node
-        uses: actions/setup-node@v6
+      - name: Setup Node and npm
+        uses: ./.github/actions/setup-node-npm
         with:
           node-version: ${{ env.NODE_VERSION }}
-          package-manager-cache: false
 
       - name: Install dependencies
         run: npm i


### PR DESCRIPTION
## Summary

- Remove no-op `package-manager-cache: false` from `setup-node` steps (not a real input, silently ignored)
- Replace direct `actions/setup-node` calls in `test.yml` with `setup-node-npm` so unit and lint jobs respect the npm 11.10.0 pin from `.npmrc`