### PR TITLE
fix: handle interaction_required in allowAnonymous interceptor

### DIFF
--- a/projects/auth0-angular/src/lib/auth.interceptor.spec.ts
+++ b/projects/auth0-angular/src/lib/auth.interceptor.spec.ts
@@ -393,6 +393,26 @@ describe('The Auth HTTP Interceptor', () => {
       });
     }));
 
+    it('does execute HTTP call when interaction_required but allowAnonymous is set to true', fakeAsync(async (
+      done: () => void
+    ) => {
+      (
+        auth0Client.getTokenSilently as unknown as jest.SpyInstance
+      ).mockReturnValue(throwError({ error: 'interaction_required' }));
+
+      await assertPassThruApiCallTo('https://my-api.com/api/orders', done);
+    }));
+
+    it('does not emit error when interaction_required but allowAnonymous is set to true', fakeAsync(async () => {
+      (
+        auth0Client.getTokenSilently as unknown as jest.SpyInstance
+      ).mockRejectedValue({ error: 'interaction_required' });
+
+      await assertPassThruApiCallTo('https://my-api.com/api/orders', () => {
+        expect(authState.setError).not.toHaveBeenCalled();
+      });
+    }));
+
     it('attach the access token when tokenOptions includes detailedResponse: true', fakeAsync(async (
       done: () => void
     ) => {

--- a/projects/auth0-angular/src/lib/auth.interceptor.ts
+++ b/projects/auth0-angular/src/lib/auth.interceptor.ts
@@ -218,9 +218,12 @@ export class AuthHttpInterceptor implements HttpInterceptor {
       !!route &&
       isHttpInterceptorRouteConfig(route) &&
       !!route.allowAnonymous &&
-      ['login_required', 'consent_required', 'missing_refresh_token'].includes(
-        err.error
-      )
+      [
+        'login_required',
+        'consent_required',
+        'missing_refresh_token',
+        'interaction_required',
+      ].includes(err.error)
     );
   }
 }


### PR DESCRIPTION
Fixes #926

`interaction_required` is a standard OIDC error returned when silent authentication cannot proceed without user interaction — the same family as `login_required` and `consent_required`. It was missing from the `allowAnonymous` error allowlist in `AuthHttpInterceptor`, causing the error to be emitted on `error$` and the HTTP request to fail even when `allowAnonymous: true` was configured.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of authentication errors so users are less likely to be interrupted by unnecessary sign-in prompts.
  * Expanded support for additional “anonymous allowed” error conditions during login flows, including the `interaction_required` case.
  * Added test coverage to ensure anonymous handling passes requests through without adding an authorization header and does not set an auth error.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->