### PR TITLE
fix: handle undefined token response in allowAnonymous interceptor

### DIFF
--- a/projects/auth0-angular/src/lib/auth.interceptor.spec.ts
+++ b/projects/auth0-angular/src/lib/auth.interceptor.spec.ts
@@ -403,10 +403,30 @@ describe('The Auth HTTP Interceptor', () => {
       await assertPassThruApiCallTo('https://my-api.com/api/orders', done);
     }));
 
+    it('does execute HTTP call when getTokenSilently returns undefined but allowAnonymous is set to true', fakeAsync(async (
+      done: () => void
+    ) => {
+      (
+        auth0Client.getTokenSilently as unknown as jest.SpyInstance
+      ).mockResolvedValue(undefined);
+
+      await assertPassThruApiCallTo('https://my-api.com/api/orders', done);
+    }));
+
     it('does not emit error when interaction_required but allowAnonymous is set to true', fakeAsync(async () => {
       (
         auth0Client.getTokenSilently as unknown as jest.SpyInstance
       ).mockRejectedValue({ error: 'interaction_required' });
+
+      await assertPassThruApiCallTo('https://my-api.com/api/orders', () => {
+        expect(authState.setError).not.toHaveBeenCalled();
+      });
+    }));
+
+    it('does not emit error when getTokenSilently returns undefined but allowAnonymous is set to true', fakeAsync(async () => {
+      (
+        auth0Client.getTokenSilently as unknown as jest.SpyInstance
+      ).mockResolvedValue(undefined);
 
       await assertPassThruApiCallTo('https://my-api.com/api/orders', () => {
         expect(authState.setError).not.toHaveBeenCalled();

--- a/projects/auth0-angular/src/lib/auth.interceptor.ts
+++ b/projects/auth0-angular/src/lib/auth.interceptor.ts
@@ -119,6 +119,11 @@ export class AuthHttpInterceptor implements HttpInterceptor {
     return of(this.auth0Client).pipe(
       concatMap((client) => client.getTokenSilently(options)),
       map((tokenOrResponse: string | GetTokenSilentlyVerboseResponse) => {
+        // spa-js returns undefined when cacheMode is 'cache-only' with no
+        // cached entry, or when an IPSIE session_expiry ceiling is reached.
+        if (!tokenOrResponse) {
+          throw { error: 'missing_token' };
+        }
         // Extract access_token from detailed response when detailedResponse: true
         if (typeof tokenOrResponse === 'string') return tokenOrResponse;
         return tokenOrResponse.access_token;
@@ -223,6 +228,7 @@ export class AuthHttpInterceptor implements HttpInterceptor {
         'consent_required',
         'missing_refresh_token',
         'interaction_required',
+        'missing_token',
       ].includes(err.error)
     );
   }


### PR DESCRIPTION
Fixes #926

`getTokenSilently` returns `undefined` (rather than throwing) in two cases:
- `cacheMode: 'cache-only'` with no matching cache entry
- IPSIE `session_expiry` ceiling reached

Without this guard, the interceptor crashes attempting to access `.access_token` on `undefined`. This change detects the `undefined` return, throws a `missing_token` error, and adds it to the `allowAnonymous` allowlist so routes configured with `allowAnonymous: true` pass through cleanly without a token.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved silent token retrieval to correctly treat missing/undefined tokens as a handled error case.
  * Expanded anonymous access behavior to cover additional missing-token scenarios.
  * Ensures requests proceed without attaching an authorization header when anonymous access is allowed, without triggering auth state errors.
* **Tests**
  * Added Jest coverage for pass-through request behavior and verifying auth error handling is not invoked when token retrieval returns `undefined` for anonymous routes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->