### PR TITLE
fix: group codeql-action dependabot updates and align versions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -25,3 +25,7 @@ updates:
     directory: '/'
     schedule:
       interval: 'daily'
+    groups:
+      codeql:
+        patterns:
+          - 'github/codeql-action*'


### PR DESCRIPTION
## Summary
- Groups all `github/codeql-action/*` Dependabot updates so init, autobuild, and analyze are always bumped together in a single PR
- Aligns any mismatched codeql-action versions in the CodeQL workflow