### PR TITLE
chore: enable conventionalCommits in .shiprc

### DIFF
--- a/.shiprc
+++ b/.shiprc
@@ -1,5 +1,6 @@
 {
     "packagePath": "projects/auth0-angular",
+    "conventionalCommits": true,
     "files": {
         ".version": []
     },


### PR DESCRIPTION
## Summary

- Adds `"conventionalCommits": true` to `.shiprc` to adopt the `chore(release): vX.Y.Z` PR title format introduced in `@a0/ship` 0.9.0
- Ensures release PRs pass commitlint CI checks, which enforce Conventional Commits on PR titles

**Reference:** https://github.com/auth0/auth0-spa-js/pull/1708

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enabled support for conventional commit messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->