### PR TITLE
chore: group @typescript-eslint deps in dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,9 @@ updates:
         update-types:
           - 'minor'
           - 'patch'
+      typescript-eslint:
+        patterns:
+          - '@typescript-eslint/*'
     ignore:
       - dependency-name: '*'
         update-types: ['version-update:semver-major']


### PR DESCRIPTION
Group `@typescript-eslint/parser` and `@typescript-eslint/eslint-plugin` into a single Dependabot PR since they are always versioned together.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Grouped `@typescript-eslint` package updates into a single automated dependency update.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->